### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/framework/audio/main/internal/playback.cpp
+++ b/framework/audio/main/internal/playback.cpp
@@ -97,7 +97,7 @@ async::Promise<Ret> Playback::init()
                 ONLY_AUDIO_MAIN_THREAD;
                 Ret ret;
                 IF_ASSERT_FAILED(RpcPacker::unpack(res.data, ret)) {
-                    Ret ret = audio::make_ret(Err::InvalidRpcData);
+                    ret = audio::make_ret(Err::InvalidRpcData);
                     (void)resolve(ret);
                     return;
                 }

--- a/framework/global/thirdparty/kors_modularity/modularity/context.h
+++ b/framework/global/thirdparty/kors_modularity/modularity/context.h
@@ -31,9 +31,9 @@ namespace kors::modularity {
 using IoCID = uint16_t;
 struct Context
 {
-    IoCID id = -1;
+    IoCID id = static_cast<IoCID>(-1);
 
-    Context(IoCID id = -1)
+    Context(IoCID id = static_cast<IoCID>(-1))
         : id(id) {}
 };
 


### PR DESCRIPTION
* reg.: 'initializing': conversion from 'int' to 'kors::modularity::IoCID', signed/unsigned mismatch (C4245)
* reg.: declaration of 'ret' hides previous local declaration (C4456)

These got lost in transit...