### PR TITLE
MenuView: fix x/y properties

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -146,10 +146,14 @@ Loader {
 
         if (x !== -1) {
             menu.x = x
+        } else {
+            menu.x = 0
         }
 
         if (y !== -1) {
             menu.y = y
+        } else {
+            menu.y = Qt.binding(() => menu.parent?.height ?? 0)
         }
     }
 

--- a/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
@@ -23,7 +23,6 @@
 #include "menuview.h"
 
 #include "log.h"
-#include "defer.h"
 
 using namespace muse::uicomponents;
 
@@ -110,9 +109,6 @@ void MenuView::updateGeometry()
     IF_ASSERT_FAILED(parent) {
         return;
     }
-
-    setLocalX(0);
-    setLocalY(parent->height());
 
     const QPointF parentTopLeft = parent->mapToGlobal(QPoint(0, 0));
 
@@ -317,7 +313,6 @@ void MenuView::setDesiredHeight(int desiredHeight)
     emit desiredHeightChanged();
 
     QMetaObject::invokeMethod(this, [this] {
-        updateGeometry();
         repositionWindowIfNeed();
     }, Qt::QueuedConnection);
 }
@@ -337,7 +332,6 @@ void MenuView::setDesiredWidth(int desiredWidth)
     emit desiredWidthChanged();
 
     QMetaObject::invokeMethod(this, [this] {
-        updateGeometry();
         repositionWindowIfNeed();
     }, Qt::QueuedConnection);
 }


### PR DESCRIPTION
Don’t override them immediately after setting them, in `updateGeometry`. Instead, set them in QML, and only when no explicit value for them is requested, hoping that this preserve the intention of the removed code (I must admit I’m not 100% sure what the intention was).

Also remove seemingly redundant calls to `updateGeometry` (but removing just those calls does not solve the problem).