### PR TITLE
Fix non-unity build

### DIFF
--- a/framework/audio/engine/internal/enginecontroller.cpp
+++ b/framework/audio/engine/internal/enginecontroller.cpp
@@ -29,6 +29,7 @@
 
 #include "audio/common/audioutils.h"
 #include "audio/common/rpc/rpcpacker.h"
+#include "audio/common/audioerrors.h"
 
 #include "enginerpccontroller.h"
 #include "audioengine.h"

--- a/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -38,7 +38,6 @@
 
 using namespace muse;
 using namespace muse::audio;
-using namespace muse::audio::engine;
 using namespace muse::audio::soundtrack;
 
 static encode::AbstractAudioEncoderPtr createEncoder(const SoundTrackFormat& format, io::IODevice& dstDevice)


### PR DESCRIPTION
## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/master
musescore platforms: linux_x64
