### PR TITLE
33319 - Make PlatformInteractive.RevealInFileBrowser properly invoke Windows Explorer to select the file

### DIFF
--- a/framework/interactive/internal/platforminteractive.cpp
+++ b/framework/interactive/internal/platforminteractive.cpp
@@ -87,8 +87,12 @@ Ret PlatformInteractive::revealInFileBrowser(const io::path_t& filePath) const
         return true;
     }
 #elif defined(Q_OS_WIN)
-    QString command = QLatin1String("explorer /select,%1").arg(QDir::toNativeSeparators(filePath.toQString()));
-    if (QProcess::startDetached(command, QStringList())) {
+    QString program = "explorer.exe";
+    QString arg = QLatin1String("/select,\"%1\"").arg(QDir::toNativeSeparators(filePath.toQString()));
+    QProcess process;
+    process.setProgram(program);
+    process.setNativeArguments(arg);
+    if (process.startDetached()) {
         return true;
     }
 #endif


### PR DESCRIPTION
First PR to resolve [MuseScore/33319](https://github.com/musescore/MuseScore/issues/33319). Then a second PR will be created to update the submodule.

The problem here is that `PlatformInteractive::RevealInFileBrowser` is passing **explorer /select,filename** as the program to start specifying no command line arguments. `QProcess` performs some proccessing of the program string: namely, on Windows it replaces any forward slashes "`/`" with backslashes "`\`". So the program to start ends up being **explorer \select,filename**. Note: the forward slash before `select` becomes a backslash and as a result Windows explorer does not recognize it and does not select the file (but properly opens the containing folder).

Therefore the solution at first glance is to pass only **explorer** as the program to start and pass **/select,filename** as a command line argument (the second parameter to `QProcess::startDetached`).

There is another hidden problem - that `filename` must be enclosed in double quotes so that paths and file names with spaces (and possibly other special characters) be processed correctly (as part of the filename and not as other command line prameters). This leads to another problem: `QProcess` also processes the command-line parameters and if a parameter contains a double quote, it add a backslash ("`\`") before the quote and encloses the entire parameter in double quotes. So the argument **/select,"filename"** is turned into **"/select,\\"filename\\""** which again is not what Windows Explorer expects.

The solution is to pass **/select,"filename"** in `nativeArguments`. `nativeArguments` is a `QProcess` property containing command-line arguments that `QProcess` just appends _unprocessed_ to the other arguments (that it pre-processes). The use of `nativeArguments` requires that we create a `QProcess` instance - the native arguments cannot be set in any static method of `QProcess`.

Summary of changes:
1. The program to start becomes "explorer". I've changed it to "explorer.exe".
2. The only argument is **/select,"filename"** (filename enclosed in double quotes).
3. The static method `QProcess::startDetached` can no longer be used because the argument must be passed via the `nativeArguments` property (so the argument is not altered in any way).

[QProcess class documentation](https://doc.qt.io/qt-6/qprocess.html)

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

