### PR TITLE
Fuzzy text search, part 0: Allow subclassing filters and sorters of SortFilterProxyModel

### DIFF
--- a/framework/extensions/internal/extensionsession.cpp
+++ b/framework/extensions/internal/extensionsession.cpp
@@ -18,6 +18,8 @@
  */
 #include "extensionsession.h"
 
+#include "extensions/extensionstypes.h"
+
 using namespace muse;
 using namespace muse::extensions;
 

--- a/framework/extensions/internal/extensionsession.h
+++ b/framework/extensions/internal/extensionsession.h
@@ -22,6 +22,8 @@
 #include "scriptengine.h"
 
 namespace muse::extensions {
+struct Manifest;
+
 class ExtensionSession final : public IExtensionSession
 {
 public:

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -78,6 +78,8 @@ qt_add_qml_module(muse_uicomponents_qml
         selectableitemlistmodel.h
         selectmultipledirectoriesmodel.cpp
         selectmultipledirectoriesmodel.h
+        sorter.cpp
+        sorter.h
         sortervalue.cpp
         sortervalue.h
         sortfilterproxymodel.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -40,6 +40,8 @@ qt_add_qml_module(muse_uicomponents_qml
         dropdownview.h
         filepickermodel.cpp
         filepickermodel.h
+        filter.cpp
+        filter.h
         filteredflyoutmodel.cpp
         filteredflyoutmodel.h
         filtervalue.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
@@ -82,20 +82,17 @@ Item {
         property real spacing: 4
         property real sideMargin: 30
 
-        function toggleSorter(sorter) {
+        function toggleSorter(sorter: Sorter) {
             if (!sorter.enabled) {
-                setSorterEnabled(sorter, true)
+                sorter.sortOrder = Qt.AscendingOrder
+                sorter.enabled = true
             } else if (sorter.sortOrder === Qt.AscendingOrder) {
                 sorter.sortOrder = Qt.DescendingOrder
             } else {
-                setSorterEnabled(sorter, false)
+                sorter.enabled = false
             }
 
             selectionModel.clear()
-        }
-
-        function setSorterEnabled(sorter, enable) {
-            sorter.enabled = enable
         }
     }
 
@@ -188,7 +185,7 @@ Item {
                 }
 
                 prv.toggleSorter(keySorter)
-                prv.setSorterEnabled(valueSorter, false)
+                valueSorter.enabled = false
             }
         }
 
@@ -219,7 +216,7 @@ Item {
                 }
 
                 prv.toggleSorter(valueSorter)
-                prv.setSorterEnabled(keySorter, false)
+                keySorter.enabled = false
             }
         }
     }

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "filter.h"
+
+namespace muse::uicomponents {
+Filter::Filter(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool Filter::enabled() const
+{
+    return m_enabled;
+}
+
+void Filter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit dataChanged();
+}
+
+bool Filter::async() const
+{
+    return m_async;
+}
+
+void Filter::setAsync(const bool async)
+{
+    if (m_async == async) {
+        return;
+    }
+
+    m_async = async;
+    emit dataChanged();
+}
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include <QObject>
+
+class QModelIndex;
+
+namespace muse::uicomponents {
+class SortFilterProxyModel;
+
+class Filter : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
+    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+
+public:
+    explicit Filter(QObject* parent = nullptr);
+
+    virtual bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) = 0;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    bool async() const;
+    void setAsync(bool async);
+
+signals:
+    void dataChanged();
+
+private:
+    bool m_enabled = true;
+    bool m_async = false;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
@@ -19,33 +19,50 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "filtervalue.h"
+
+#include "global/log.h"
+
+#include "sortfilterproxymodel.h"
 
 using namespace muse::uicomponents;
 
 FilterValue::FilterValue(QObject* parent)
-    : QObject(parent)
+    : Filter(parent)
 {
+}
+
+bool FilterValue::acceptsRow(const int sourceRow, const QModelIndex& sourceParent,
+                             const SortFilterProxyModel& proxyModel)
+{
+    const int roleId = proxyModel.roleIdFromName(m_roleName);
+    if (roleId < 0) {
+        return true;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    IF_ASSERT_FAILED(sourceModel) {
+        return true;
+    }
+
+    const QModelIndex index = sourceModel->index(sourceRow, 0, sourceParent);
+    const QVariant data = sourceModel->data(index, roleId);
+    switch (m_compareType) {
+    case CompareType::Equal:
+        return data == m_roleValue;
+    case CompareType::NotEqual:
+        return data != m_roleValue;
+    case CompareType::Contains:
+        return data.toString().contains(m_roleValue.toString(), Qt::CaseInsensitive);
+    }
+
+    return false;
 }
 
 QString FilterValue::roleName() const
 {
     return m_roleName;
-}
-
-QVariant FilterValue::roleValue() const
-{
-    return m_roleValue;
-}
-
-CompareType::Type FilterValue::compareType() const
-{
-    return m_compareType;
-}
-
-bool FilterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void FilterValue::setRoleName(QString roleName)
@@ -58,6 +75,11 @@ void FilterValue::setRoleName(QString roleName)
     emit dataChanged();
 }
 
+QVariant FilterValue::roleValue() const
+{
+    return m_roleValue;
+}
+
 void FilterValue::setRoleValue(QVariant value)
 {
     if (m_roleValue == value) {
@@ -68,6 +90,11 @@ void FilterValue::setRoleValue(QVariant value)
     emit dataChanged();
 }
 
+CompareType::Type FilterValue::compareType() const
+{
+    return m_compareType;
+}
+
 void FilterValue::setCompareType(CompareType::Type type)
 {
     if (m_compareType == type) {
@@ -75,30 +102,5 @@ void FilterValue::setCompareType(CompareType::Type type)
     }
 
     m_compareType = type;
-    emit dataChanged();
-}
-
-void FilterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-    emit dataChanged();
-}
-
-bool FilterValue::async() const
-{
-    return m_async;
-}
-
-void FilterValue::setAsync(bool async)
-{
-    if (m_async == async) {
-        return;
-    }
-
-    m_async = async;
     emit dataChanged();
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
@@ -24,8 +24,10 @@
 
 #include <qqmlintegration.h>
 
-#include <QObject>
+#include <QString>
 #include <QVariant>
+
+#include "filter.h"
 
 namespace muse::uicomponents {
 namespace CompareType {
@@ -41,7 +43,7 @@ enum Type
 Q_ENUM_NS(Type)
 }
 
-class FilterValue : public QObject
+class FilterValue : public Filter
 {
     Q_OBJECT
     QML_ELEMENT
@@ -49,36 +51,24 @@ class FilterValue : public QObject
     Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
     Q_PROPERTY(QVariant roleValue READ roleValue WRITE setRoleValue NOTIFY dataChanged)
     Q_PROPERTY(muse::uicomponents::CompareType::Type compareType READ compareType WRITE setCompareType NOTIFY dataChanged)
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
-
-    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
-    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
 
 public:
     explicit FilterValue(QObject* parent = nullptr);
 
+    bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) override;
+
     QString roleName() const;
-    QVariant roleValue() const;
-    CompareType::Type compareType() const;
-    bool enabled() const;
-
-    bool async() const;
-    void setAsync(bool async);
-
-public slots:
     void setRoleName(QString roleName);
-    void setRoleValue(QVariant roleValue);
-    void setCompareType(muse::uicomponents::CompareType::Type compareType);
-    void setEnabled(bool enabled);
 
-signals:
-    void dataChanged();
+    QVariant roleValue() const;
+    void setRoleValue(QVariant roleValue);
+
+    CompareType::Type compareType() const;
+    void setCompareType(muse::uicomponents::CompareType::Type compareType);
 
 private:
     QString m_roleName;
     QVariant m_roleValue;
     CompareType::Type m_compareType = CompareType::Equal;
-    bool m_enabled = true;
-    bool m_async = false;
 };
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
@@ -2,10 +2,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
- * MuseScore Studio
+ * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,31 +20,41 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include <qqmlintegration.h>
-
-#include <QString>
-
 #include "sorter.h"
 
 namespace muse::uicomponents {
-class SorterValue : public Sorter
+Sorter::Sorter(QObject* parent)
+    : QObject(parent)
 {
-    Q_OBJECT
-    QML_ELEMENT
+}
 
-    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+Qt::SortOrder Sorter::sortOrder() const
+{
+    return m_sortOrder;
+}
 
-public:
-    explicit SorterValue(QObject* parent = nullptr);
+void Sorter::setSortOrder(const Qt::SortOrder sortOrder)
+{
+    if (m_sortOrder == sortOrder) {
+        return;
+    }
 
-    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
+    m_sortOrder = sortOrder;
+    emit dataChanged();
+}
 
-    QString roleName() const;
-    void setRoleName(QString roleName);
+bool Sorter::enabled() const
+{
+    return m_enabled;
+}
 
-private:
-    QString m_roleName;
-};
+void Sorter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit dataChanged();
+}
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include <QObject>
+#include <QtCore/qnamespace.h>
+
+class QModelIndex;
+
+namespace muse::uicomponents {
+class SortFilterProxyModel;
+
+class Sorter : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY dataChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+
+public:
+    explicit Sorter(QObject* parent = nullptr);
+
+    virtual bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) = 0;
+
+    Qt::SortOrder sortOrder() const;
+    void setSortOrder(Qt::SortOrder sortOrder);
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+signals:
+    void dataChanged();
+
+private:
+    Qt::SortOrder m_sortOrder = Qt::AscendingOrder;
+    bool m_enabled = false;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
@@ -19,28 +19,46 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortervalue.h"
+
+#include "global/log.h"
+
+#include "sortfilterproxymodel.h"
 
 using namespace muse::uicomponents;
 
 SorterValue::SorterValue(QObject* parent)
-    : QObject(parent)
+    : Sorter(parent)
 {
+}
+
+bool SorterValue::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
+                           const SortFilterProxyModel& proxyModel)
+{
+    const int roleId = proxyModel.roleIdFromName(m_roleName);
+    if (roleId < 0) {
+        return sourceLeft < sourceRight;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    IF_ASSERT_FAILED(sourceModel) {
+        return sourceLeft < sourceRight;
+    }
+
+    const QVariant leftData = sourceModel->data(sourceLeft, roleId);
+    const QVariant rightData = sourceModel->data(sourceRight, roleId);
+    const QPartialOrdering ordering = QVariant::compare(leftData, rightData);
+    if (ordering == QPartialOrdering::Unordered || ordering == QPartialOrdering::Equivalent) {
+        return sourceLeft < sourceRight;
+    }
+
+    return ordering == QPartialOrdering::Less;
 }
 
 QString SorterValue::roleName() const
 {
     return m_roleName;
-}
-
-Qt::SortOrder SorterValue::sortOrder() const
-{
-    return m_sortOrder;
-}
-
-bool SorterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void SorterValue::setRoleName(QString roleName)
@@ -50,30 +68,5 @@ void SorterValue::setRoleName(QString roleName)
     }
 
     m_roleName = roleName;
-    emit dataChanged();
-}
-
-void SorterValue::setSortOrder(Qt::SortOrder sortOrder)
-{
-    if (m_sortOrder == sortOrder) {
-        return;
-    }
-
-    m_sortOrder = sortOrder;
-    emit dataChanged();
-}
-
-void SorterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-
-    if (!enabled) {
-        m_sortOrder = Qt::AscendingOrder;
-    }
-
     emit dataChanged();
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -22,6 +22,8 @@
 
 #include "sortfilterproxymodel.h"
 
+#include <algorithm>
+
 #include <QTimer>
 #include <QtVersionChecks>
 
@@ -49,8 +51,8 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 #endif
     };
 
-    auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
-        if (changedFilterValue->async()) {
+    auto onFilterChanged = [this, invalidateRows](Filter* changedFilter) {
+        if (changedFilter->async()) {
             QTimer::singleShot(0, this, invalidateRows);
         } else {
             invalidateRows();
@@ -58,13 +60,12 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     };
 
     connect(m_filters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onFilterChanged](int index) {
-        FilterValue* filter = m_filters.at(index);
-
+        Filter* filter = m_filters.at(index);
         if (filter->enabled()) {
             onFilterChanged(filter);
         }
 
-        connect(filter, &FilterValue::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
+        connect(filter, &Filter::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
     });
 
     auto onSortersChanged = [this] {
@@ -91,7 +92,7 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 }
 
-QQmlListProperty<FilterValue> SortFilterProxyModel::filters()
+QQmlListProperty<Filter> SortFilterProxyModel::filters()
 {
     return m_filters.property();
 }
@@ -185,39 +186,10 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
         return false;
     }
 
-    const QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-    const QList<FilterValue*> filters = m_filters.list();
-    for (auto* filter : filters) {
-        if (!filter->enabled()) {
-            continue;
-        }
-
-        const int roleId = roleIdFromName(filter->roleName());
-        if (roleId < 0) {
-            continue;
-        }
-
-        const QVariant data = sourceModel()->data(index, roleId);
-        switch (filter->compareType()) {
-        case CompareType::Equal:
-            if (data != filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::NotEqual:
-            if (data == filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::Contains:
-            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
-                return false;
-            }
-            break;
-        }
-    }
-
-    return true;
+    const QList<Filter*> filters = m_filters.list();
+    return std::all_of(filters.begin(), filters.end(), [&] (Filter* filter) {
+        return !filter->enabled() || filter->acceptsRow(sourceRow, sourceParent, *this);
+    });
 }
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -25,27 +25,35 @@
 #include <QTimer>
 #include <QtVersionChecks>
 
-#include "global/defer.h"
+#include "global/log.h"
 #include "global/types/val.h"
 
 #include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
 
-static const int INVALID_KEY = -1;
+static constexpr int INVALID_ROLE_ID = -1;
 
 SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     : QSortFilterProxyModel(parent), m_filters(this), m_sorters(this)
 {
     ModelUtils::connectRowCountChangedSignal(this, &SortFilterProxyModel::rowCountChanged);
+    connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, &SortFilterProxyModel::updateRoleIds);
 
-    auto onFilterChanged = [this](FilterValue* changedFilterValue) {
+    const auto invalidateRows = [this] {
+        beginFilterChange();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+    };
+
+    auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
         if (changedFilterValue->async()) {
-            QTimer::singleShot(0, this, [this](){
-                fillRoleIds();
-            });
+            QTimer::singleShot(0, this, invalidateRows);
         } else {
-            fillRoleIds();
+            invalidateRows();
         }
     };
 
@@ -80,7 +88,6 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
         invalidate();
-        fillRoleIds();
     });
 }
 
@@ -140,7 +147,7 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
 
 int SortFilterProxyModel::roleIdFromName(const QString& roleName) const
 {
-    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+    return m_roleIds.value(roleName.toUtf8(), INVALID_ROLE_ID);
 }
 
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
@@ -178,32 +185,32 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
         return false;
     }
 
-    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-
-    QHashIterator<int, FilterValue*> it(m_roleIdToFilterValueHash);
-    while (it.hasNext()) {
-        it.next();
-
-        QVariant data = sourceModel()->data(index, it.key());
-        FilterValue* value = it.value();
-
-        if (!value->enabled()) {
+    const QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+    const QList<FilterValue*> filters = m_filters.list();
+    for (auto* filter : filters) {
+        if (!filter->enabled()) {
             continue;
         }
 
-        switch (value->compareType()) {
+        const int roleId = roleIdFromName(filter->roleName());
+        if (roleId < 0) {
+            continue;
+        }
+
+        const QVariant data = sourceModel()->data(index, roleId);
+        switch (filter->compareType()) {
         case CompareType::Equal:
-            if (data != value->roleValue()) {
+            if (data != filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::NotEqual:
-            if (data == value->roleValue()) {
+            if (data == filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::Contains:
-            if (!data.toString().contains(value->roleValue().toString(), Qt::CaseInsensitive)) {
+            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
                 return false;
             }
             break;
@@ -228,40 +235,6 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
     return leftData < rightData;
 }
 
-void SortFilterProxyModel::fillRoleIds()
-{
-    beginFilterChange();
-
-    DEFER {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        endFilterChange(QSortFilterProxyModel::Direction::Rows);
-#else
-        invalidateFilter();
-#endif
-    };
-
-    m_roleIdToFilterValueHash.clear();
-
-    if (!sourceModel()) {
-        return;
-    }
-
-    QHash<QString, FilterValue*> roleNameToValueHash;
-    QList<FilterValue*> filterList = m_filters.list();
-    for (FilterValue* filter : std::as_const(filterList)) {
-        roleNameToValueHash.insert(filter->roleName(), filter);
-    }
-
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    QHash<int, QByteArray>::const_iterator it = roles.constBegin();
-    while (it != roles.constEnd()) {
-        if (roleNameToValueHash.contains(it.value())) {
-            m_roleIdToFilterValueHash.insert(it.key(), roleNameToValueHash[it.value()]);
-        }
-        ++it;
-    }
-}
-
 SorterValue* SortFilterProxyModel::currentSorterValue() const
 {
     QList<SorterValue*> sorterList = m_sorters.list();
@@ -272,4 +245,15 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
     }
 
     return nullptr;
+}
+
+void SortFilterProxyModel::updateRoleIds()
+{
+    m_roleIds.clear();
+
+    const QHash<int, QByteArray> roleNames = this->roleNames();
+    for (const auto& [roleId, roleName] : roleNames.asKeyValueRange()) {
+        const auto [it, didInsert] = m_roleIds.try_emplace(roleName, roleId);
+        DO_ASSERT_X(didInsert, "duplicate role name");
+    }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -28,7 +28,6 @@
 #include <QtVersionChecks>
 
 #include "global/log.h"
-#include "global/types/val.h"
 
 #include "uicomponents/view/modelutils.h"
 
@@ -69,22 +68,24 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 
     auto onSortersChanged = [this] {
-        SorterValue* sorter = currentSorterValue();
+        Sorter* sorter = currentSorter();
         invalidate();
 
         if (!sorter) {
+            sort(-1, Qt::AscendingOrder);
             return;
         }
 
-        if (sourceModel()) {
-            sort(0, sorter->sortOrder());
-        }
+        sort(0, sorter->sortOrder());
     };
 
     connect(m_sorters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onSortersChanged](int index) {
-        onSortersChanged();
+        Sorter* sorter = m_sorters.at(index);
+        if (sorter->enabled()) {
+            onSortersChanged();
+        }
 
-        connect(m_sorters.at(index), &SorterValue::dataChanged, this, onSortersChanged);
+        connect(sorter, &Sorter::dataChanged, this, onSortersChanged);
     });
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
@@ -97,7 +98,7 @@ QQmlListProperty<Filter> SortFilterProxyModel::filters()
     return m_filters.property();
 }
 
-QQmlListProperty<SorterValue> SortFilterProxyModel::sorters()
+QQmlListProperty<Sorter> SortFilterProxyModel::sorters()
 {
     return m_sorters.property();
 }
@@ -194,23 +195,18 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
-    SorterValue* sorter = currentSorterValue();
+    Sorter* sorter = currentSorter();
     if (!sorter) {
-        return false;
+        return left < right;
     }
 
-    int sorterRoleKey = roleIdFromName(sorter->roleName());
-
-    Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
-    Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
-
-    return leftData < rightData;
+    return sorter->lessThan(left, right, *this);
 }
 
-SorterValue* SortFilterProxyModel::currentSorterValue() const
+Sorter* SortFilterProxyModel::currentSorter() const
 {
-    QList<SorterValue*> sorterList = m_sorters.list();
-    for (SorterValue* sorter : std::as_const(sorterList)) {
+    const QList<Sorter*> sorterList = m_sorters.list();
+    for (Sorter* sorter : sorterList) {
         if (sorter->enabled()) {
             return sorter;
         }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -19,14 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortfilterproxymodel.h"
 
 #include <QTimer>
+#include <QtVersionChecks>
 
-#include "defer.h"
-#include "types/val.h"
+#include "global/defer.h"
+#include "global/types/val.h"
 
-#include "view/modelutils.h"
+#include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
 
@@ -136,6 +138,11 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
     emit alwaysExcludeIndicesChanged();
 }
 
+int SortFilterProxyModel::roleIdFromName(const QString& roleName) const
+{
+    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+}
+
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
 {
     if (!sourceModel()) {
@@ -159,12 +166,6 @@ void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
         m_subSourceModelConnection = connect(sourceSortFilterModel, &SortFilterProxyModel::sourceModelRoleNamesChanged,
                                              this, &SortFilterProxyModel::sourceModelRoleNamesChanged);
     }
-}
-
-void SortFilterProxyModel::refresh()
-{
-    setFilterFixedString(filterRegularExpression().pattern());
-    setSortCaseSensitivity(sortCaseSensitivity());
 }
 
 bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
@@ -219,19 +220,12 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
         return false;
     }
 
-    int sorterRoleKey = roleKey(sorter->roleName());
+    int sorterRoleKey = roleIdFromName(sorter->roleName());
 
     Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
     Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
 
     return leftData < rightData;
-}
-
-void SortFilterProxyModel::reset()
-{
-    beginResetModel();
-    resetInternalData();
-    endResetModel();
 }
 
 void SortFilterProxyModel::fillRoleIds()
@@ -278,16 +272,4 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
     }
 
     return nullptr;
-}
-
-int SortFilterProxyModel::roleKey(const QString& roleName) const
-{
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    for (auto it = roles.begin(); it != roles.end(); ++it) {
-        if (roleName == QString(it.value())) {
-            return it.key();
-        }
-    }
-
-    return INVALID_KEY;
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -24,6 +24,7 @@
 
 #include <qqmlintegration.h>
 
+#include <QByteArray>
 #include <QHash>
 #include <QList>
 #include <QSortFilterProxyModel>
@@ -74,13 +75,12 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void fillRoleIds();
-
+    void updateRoleIds();
     SorterValue* currentSorterValue() const;
 
-    QmlListProperty<FilterValue> m_filters;
-    QHash<int, FilterValue*> m_roleIdToFilterValueHash;
+    QHash<QByteArray, int> m_roleIds;
 
+    QmlListProperty<FilterValue> m_filters;
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -29,7 +29,7 @@
 #include <QList>
 #include <QSortFilterProxyModel>
 
-#include "filtervalue.h"
+#include "filter.h"
 #include "sortervalue.h"
 #include "qmllistproperty.h"
 
@@ -40,7 +40,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
     QML_ELEMENT
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
@@ -48,7 +48,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
-    QQmlListProperty<FilterValue> filters();
+    QQmlListProperty<Filter> filters();
     QQmlListProperty<SorterValue> sorters();
 
     QList<int> alwaysIncludeIndices() const;
@@ -80,7 +80,7 @@ private:
 
     QHash<QByteArray, int> m_roleIds;
 
-    QmlListProperty<FilterValue> m_filters;
+    QmlListProperty<Filter> m_filters;
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -30,8 +30,8 @@
 #include <QSortFilterProxyModel>
 
 #include "filter.h"
-#include "sortervalue.h"
 #include "qmllistproperty.h"
+#include "sorter.h"
 
 namespace muse::uicomponents {
 class SortFilterProxyModel : public QSortFilterProxyModel
@@ -41,7 +41,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Sorter> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
 
@@ -49,7 +49,7 @@ public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
     QQmlListProperty<Filter> filters();
-    QQmlListProperty<SorterValue> sorters();
+    QQmlListProperty<Sorter> sorters();
 
     QList<int> alwaysIncludeIndices() const;
     void setAlwaysIncludeIndices(const QList<int>& indices);
@@ -76,12 +76,12 @@ protected:
 
 private:
     void updateRoleIds();
-    SorterValue* currentSorterValue() const;
+    Sorter* currentSorter() const;
 
     QHash<QByteArray, int> m_roleIds;
 
     QmlListProperty<Filter> m_filters;
-    QmlListProperty<SorterValue> m_sorters;
+    QmlListProperty<Sorter> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;
     QList<int> m_alwaysExcludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -19,10 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include <qqmlintegration.h>
 
+#include <QHash>
+#include <QList>
 #include <QSortFilterProxyModel>
 
 #include "filtervalue.h"
@@ -36,7 +39,6 @@ class SortFilterProxyModel : public QSortFilterProxyModel
     QML_ELEMENT
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
@@ -54,16 +56,13 @@ public:
     QList<int> alwaysExcludeIndices() const;
     void setAlwaysExcludeIndices(const QList<int>& indices);
 
+    int roleIdFromName(const QString&) const;
     QHash<int, QByteArray> roleNames() const override;
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
 
-    Q_INVOKABLE void refresh();
-
 signals:
     void rowCountChanged();
-
-    void filtersChanged(QQmlListProperty<muse::uicomponents::FilterValue> filters);
 
     void alwaysIncludeIndicesChanged();
     void alwaysExcludeIndicesChanged();
@@ -75,11 +74,9 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void reset();
     void fillRoleIds();
 
     SorterValue* currentSorterValue() const;
-    int roleKey(const QString& roleName) const;
 
     QmlListProperty<FilterValue> m_filters;
     QHash<int, FilterValue*> m_roleIdToFilterValueHash;

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_TEST muse_uicomponents_qml_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/doubleinputvalidator_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/intinputvalidator_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sortfilterproxymodel_tests.cpp
     )
 
 set(MODULE_TEST_LINK

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <QString>
+#include <QStringList>
+#include <QStringListModel>
+
+#include "uicomponents/qml/Muse/UiComponents/filtervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h"
+
+using namespace Qt::StringLiterals;
+
+namespace muse::uicomponents {
+class UiComponents_SortFilterProxyModelTests : public ::testing::Test
+{
+public:
+    UiComponents_SortFilterProxyModelTests()
+    {
+        QStringList modelData;
+        modelData << u"hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay needle hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay hay"_s;
+        m_model->setStringList(modelData);
+    }
+
+    QAbstractListModel* listModel() const
+    {
+        return m_model.get();
+    }
+
+private:
+    std::unique_ptr<QStringListModel> m_model = std::make_unique<QStringListModel>();
+};
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* filter = new FilterValue(proxyModel.get());
+    filter->setCompareType(CompareType::Equal);
+    filter->setRoleName(u"display"_s);
+    filter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, filter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 2);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(3));
+
+    filter->setCompareType(CompareType::NotEqual);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(0));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(4));
+
+    filter->setCompareType(CompareType::Contains);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(3));
+
+    filter->setEnabled(false);
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValueMultiple)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* hayFilter = new FilterValue(proxyModel.get());
+    hayFilter->setCompareType(CompareType::Contains);
+    hayFilter->setRoleName(u"display"_s);
+    hayFilter->setRoleValue(u"hay"_s);
+
+    FilterValue* needleFilter = new FilterValue(proxyModel.get());
+    needleFilter->setCompareType(CompareType::Contains);
+    needleFilter->setRoleName(u"display"_s);
+    needleFilter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, hayFilter);
+    filters.append(&filters, needleFilter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 1);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(2));
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testSorterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    SorterValue* sorter = new SorterValue(proxyModel.get());
+    sorter->setRoleName(u"display"_s);
+
+    QQmlListProperty<Sorter> sorters = proxyModel->sorters();
+    ASSERT_TRUE(sorters.append);
+    sorters.append(&sorters, sorter);
+
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+    for (int row = 0; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+        EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(row, 0)), model->index(row));
+    }
+
+    sorter->setEnabled(true);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Less || ordering == QPartialOrdering::Equivalent);
+    }
+
+    sorter->setSortOrder(Qt::DescendingOrder);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Greater || ordering == QPartialOrdering::Equivalent);
+    }
+}
+}


### PR DESCRIPTION
This is a prerequisite part for my effort to implement fuzzy search in MSS. (musescore/musescore#15983)
This aligns our `SortFilterProxyModel` a bit closer to Qt's new-ish [Qml SortFilterProxyModel](https://doc.qt.io/qt-6/qml-qtqml-models-sortfilterproxymodel.html), while allowing custom filters and sorters.
MuseScore Studio builds over at the previous home of these changes: musescore/musescore#33052.

Also used GitHub code search in the Audacity repo to check for uses of the removed methods. The changes shouldn't be breaking.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/master
musescore platforms: linux_x64 windows_x64 macos 
