### PR TITLE
32612-Do not make the main window transparent on startup anymore

### DIFF
--- a/framework/ui/internal/guiapplication.cpp
+++ b/framework/ui/internal/guiapplication.cpp
@@ -177,13 +177,7 @@ bool GuiApplication::loadMainWindow(const muse::modularity::ContextPtr& ctxId)
 
     // The main window must be shown at this point so KDDockWidgets can read its size correctly
     // and scale all sizes properly. https://github.com/musescore/MuseScore/issues/21148
-    // but before that, let's make the window transparent,
-    // otherwise the empty window frame will be visible
-    // https://github.com/musescore/MuseScore/issues/29630
-    // Transparency will be removed after the page loads.
-
     QQuickWindow* window = dynamic_cast<QQuickWindow*>(obj);
-    window->setOpacity(0.01);
     window->setVisible(true);
 
     m_windows[ctxId->id] = window;


### PR DESCRIPTION
Framework PR to resolve [#32612](https://github.com/musescore/MuseScore/issues/32612) and [#31620](https://github.com/musescore/MuseScore/issues/31620).
Will be followed by [MuseScore/PR32940](https://github.com/musescore/MuseScore/pull/32940) and a similar one for Audacity.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/master
musescore platforms: linux_x64
