### PR TITLE
Fix setupV1: use m_engineV1->rootContext() instead of m_engine->rootContext()

### DIFF
--- a/framework/extensions/internal/extensionsuiengine.cpp
+++ b/framework/extensions/internal/extensionsuiengine.cpp
@@ -103,7 +103,7 @@ void ExtensionsUiEngine::setupV1()
     QmlIoCContext* qmlIoc = new QmlIoCContext(this);
     qmlIoc->ctx = iocContext();
 
-    QQmlContext* rootContext = m_engine->rootContext();
+    QQmlContext* rootContext = m_engineV1->rootContext();
     rootContext->setObjectName(QString("Root QQmlContext: %1").arg(qmlIoc->ctx->id));
     rootContext->setContextProperty("ioc_context", QVariant::fromValue(qmlIoc));
     m_engineV1->setProperty("ioc_context", QVariant::fromValue(qmlIoc));


### PR DESCRIPTION
Resolves: musescore/MuseScore#33364

`setupV1()` incorrectly calls `m_engine->rootContext()` (the v2 engine) instead of `m_engineV1->rootContext()`. Since `m_engine` is lazily initialized only when a v2 plugin is first opened, it is null when a v1 plugin is opened first, causing an immediate SIGSEGV.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)