### PR TITLE
Buildscripts. Separated dependencies cmake for reusing in musescore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(MUSE_FRAMEWORK_PATH ${CMAKE_CURRENT_LIST_DIR})
 set(MUSE_FRAMEWORK_SRC_PATH ${MUSE_FRAMEWORK_PATH}/framework)
 
+set(FETCHCONTENT_BASE_DIR ${PROJECT_BINARY_DIR}/_deps)
+
 set(CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}
     ${MUSE_FRAMEWORK_PATH}/buildscripts
@@ -73,6 +75,8 @@ endif(MUSE_COMPILE_USE_COMPILER_CACHE)
 ###########################################
 
 include(SetupQt6)
+
+include(SetupDependencies)
 
 ###########################################
 # Add source tree

--- a/buildscripts/cmake/MuseDeps.cmake
+++ b/buildscripts/cmake/MuseDeps.cmake
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
+#
+# MuseScore Studio
+# Music Composition & Notation
+#
+# Copyright (C) 2026 MuseScore Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Config
+include(GetPlatformInfo)
+include(GetBuildType)
+
+set(LIB_OS )
+if (OS_IS_WIN)
+    set(LIB_OS "windows")
+elseif(OS_IS_LIN)
+    set(LIB_OS "linux")
+elseif(OS_IS_FBSD)
+    set(LIB_OS "linux")
+elseif(OS_IS_MAC)
+    set(LIB_OS "macos")
+    list(LENGTH CMAKE_OSX_ARCHITECTURES arch_count)
+    if(arch_count GREATER 1)
+        set(ARCH "universal")
+    endif()
+endif()
+
+set(LIB_ARCH ${ARCH})
+
+if (BUILD_IS_RELEASE)
+    set(LIB_BUILD_TYPE "release")
+else()
+    set(LIB_BUILD_TYPE "debug")
+endif()
+
+set(REMOTE_ROOT_URL https://raw.githubusercontent.com/musescore/muse_deps/main)
+set(LOCAL_ROOT_PATH ${FETCHCONTENT_BASE_DIR})
+
+function(populate name remote_suffix)
+    set(remote_url ${REMOTE_ROOT_URL}/${remote_suffix})
+    set(local_path ${LOCAL_ROOT_PATH}/${name})
+
+    if (NOT EXISTS ${local_path}/${name}.cmake)
+        file(MAKE_DIRECTORY ${local_path})
+        file(DOWNLOAD ${remote_url}/${name}.cmake ${local_path}/${name}.cmake
+            HTTPHEADER "Cache-Control: no-cache"
+        )
+    endif()
+
+    include(${local_path}/${name}.cmake)
+
+    # func from ${name}.cmake
+    cmake_language(CALL ${name}_Populate ${remote_url} ${local_path} ${LIB_OS} ${LIB_ARCH} ${LIB_BUILD_TYPE})
+
+    get_property(include_dirs GLOBAL PROPERTY ${name}_INCLUDE_DIRS)
+    get_property(libraries GLOBAL PROPERTY ${name}_LIBRARIES)
+    get_property(install_libraries GLOBAL PROPERTY ${name}_INSTALL_LIBRARIES)
+
+    set(${name}_INCLUDE_DIRS ${include_dirs} PARENT_SCOPE)
+    set(${name}_LIBRARIES ${libraries} PARENT_SCOPE)
+    set(${name}_INSTALL_LIBRARIES ${install_libraries} PARENT_SCOPE)
+
+endfunction()

--- a/buildscripts/cmake/SetupDependencies.cmake
+++ b/buildscripts/cmake/SetupDependencies.cmake
@@ -20,61 +20,7 @@
 
 message(STATUS "Setup dependencies")
 
-# Config
-include(GetPlatformInfo)
-include(GetBuildType)
-
-set(LIB_OS )
-if (OS_IS_WIN)
-    set(LIB_OS "windows")
-elseif(OS_IS_LIN)
-    set(LIB_OS "linux")
-elseif(OS_IS_FBSD)
-    set(LIB_OS "linux")
-elseif(OS_IS_MAC)
-    set(LIB_OS "macos")
-    list(LENGTH CMAKE_OSX_ARCHITECTURES arch_count)
-    if(arch_count GREATER 1)
-        set(ARCH "universal")
-    endif()
-endif()
-
-set(LIB_ARCH ${ARCH})
-
-if (BUILD_IS_RELEASE)
-    set(LIB_BUILD_TYPE "release")
-else()
-    set(LIB_BUILD_TYPE "debug")
-endif()
-
-set(REMOTE_ROOT_URL https://raw.githubusercontent.com/musescore/muse_deps/main)
-set(LOCAL_ROOT_PATH ${FETCHCONTENT_BASE_DIR})
-
-function(populate name remote_suffix)
-    set(remote_url ${REMOTE_ROOT_URL}/${remote_suffix})
-    set(local_path ${LOCAL_ROOT_PATH}/${name})
-
-    if (NOT EXISTS ${local_path}/${name}.cmake)
-        file(MAKE_DIRECTORY ${local_path})
-        file(DOWNLOAD ${remote_url}/${name}.cmake ${local_path}/${name}.cmake
-            HTTPHEADER "Cache-Control: no-cache"
-        )
-    endif()
-
-    include(${local_path}/${name}.cmake)
-
-    # func from ${name}.cmake
-    cmake_language(CALL ${name}_Populate ${remote_url} ${local_path} ${LIB_OS} ${LIB_ARCH} ${LIB_BUILD_TYPE})
-
-    get_property(include_dirs GLOBAL PROPERTY ${name}_INCLUDE_DIRS)
-    get_property(libraries GLOBAL PROPERTY ${name}_LIBRARIES)
-    get_property(install_libraries GLOBAL PROPERTY ${name}_INSTALL_LIBRARIES)
-
-    set(${name}_INCLUDE_DIRS ${include_dirs} PARENT_SCOPE)
-    set(${name}_LIBRARIES ${libraries} PARENT_SCOPE)
-    set(${name}_INSTALL_LIBRARIES ${install_libraries} PARENT_SCOPE)
-
-endfunction()
+include(MuseDeps)
 
 if (MUSE_MODULE_DOCKWINDOW_KDDOCKWIDGETS_V2)
     populate(kddockwidgets "kddockwidgets/2.4")


### PR DESCRIPTION
```
include(${MUSE_FRAMEWORK_PATH}/buildscripts/cmake/DependenciesFunctions.cmake)

# add a list of dependencies here
# populate(...)
```