### PR TITLE
Add DockWindow::openPage

### DIFF
--- a/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -275,6 +275,11 @@ void DockWindow::loadPage(const QString& uri, const QVariantMap& params)
     }
 }
 
+void DockWindow::openPage(const QString& uri)
+{
+    interactive()->open(uri.toStdString());
+}
+
 bool DockWindow::isDockOpen(const QString& dockName) const
 {
     return m_currentPage && m_currentPage->isDockOpen(dockName);

--- a/framework/dockwindow/qml/Muse/Dock/dockwindow.h
+++ b/framework/dockwindow/qml/Muse/Dock/dockwindow.h
@@ -79,7 +79,12 @@ public:
     QQuickWindow* windowProperty() const;
 
     Q_INVOKABLE void init();
+    /* loadPage() is used internally by the InteractiveProvider. Regular code should call
+     * openPage(), to ensure the Interactive's m_openingObject query will be properly set
+     * by the time Interactive::onOpen() is called (from DockWindow>onPageLoaded).
+     */
     Q_INVOKABLE void loadPage(const QString& uri, const QVariantMap& params);
+    Q_INVOKABLE void openPage(const QString& uri);
 
     //! IDockWindow
     bool isDockOpen(const QString& dockName) const override;


### PR DESCRIPTION
This PR exposes a new `DockWindow::openPage` function, to allow the `DockWindow` to make the appropriate calls when navigating its pages, to ensure that the `UiContext` is always properly set. See: [Fix editable Publish tab](https://github.com/musescore/MuseScore/pull/33406)