### PR TITLE
fix: reset hovered state on ESC

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -150,6 +150,10 @@ void PolylinePlot::init()
     dispatcher()->reg(this, "action://cancel", [this](){
         // emit signal and let decide model what to do
         emit dragCancelled();
+        // Qt suppresses hover events while a mouse button is held, so the
+        // ghost-point preview would otherwise stay painted at the press
+        // position until the user releases and moves the mouse.
+        m_hoveredOnLine = false;
         resetGestureState();
     });
 }
@@ -1074,6 +1078,7 @@ void PolylinePlot::resetGestureState()
     m_pressedOnPoint = false;
     m_pressedPointIndex = INVALID_POINT_IDX;
     m_hasDraggedPointDomain = false;
+    m_hoveredOnLine = false;
     m_draggedPointDomain = {};
     m_movedSincePress = false;
     m_pressPx = QPointF(0.0, 0.0);


### PR DESCRIPTION
Needed for https://github.com/audacity/audacity/issues/10223

Without this, ESC doesn't clear the point after click-to-create-point and dragging. The point would then only disappear after the mouse is released and moved:

[Screencast from 2026-05-15 14-25-09.webm](https://github.com/user-attachments/assets/df294b58-f01f-4b8f-82b1-f00f41e1a580)

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/master
musescore platforms: linux_x64
