### PR TITLE
fixed crashpad build on Windows with C++20

### DIFF
--- a/framework/diagnostics/thirdparty/google_crashpad_client/client/crash_report_database_win.cc
+++ b/framework/diagnostics/thirdparty/google_crashpad_client/client/crash_report_database_win.cc
@@ -537,7 +537,7 @@ void Metadata::Write() {
   for (const auto& report : reports_) {
     const base::FilePath& path = report.file_path;
     if (path.DirName() != report_dir_) {
-      LOG(ERROR) << path.value().c_str() << " expected to start with "
+      LOG(ERROR) << base::WideToUTF8(path.value()) << " expected to start with "
                  << base::WideToUTF8(report_dir_.value());
       return;
     }
@@ -693,7 +693,7 @@ FileWriter* CrashReportDatabase::NewReport::AddAttachment(
   auto writer = std::make_unique<FileWriter>();
   if (!writer->Open(
           path, FileWriteMode::kCreateOrFail, FilePermissions::kOwnerOnly)) {
-    LOG(ERROR) << "could not open " << path.value().c_str();
+    LOG(ERROR) << "could not open " << base::WideToUTF8(path.value());
     return nullptr;
   }
   attachment_writers_.emplace_back(std::move(writer));
@@ -719,7 +719,7 @@ void CrashReportDatabase::UploadReport::InitializeAttachments() {
     const base::FilePath filepath(attachments_dir.Append(filename));
     std::unique_ptr<FileReader> file_reader(std::make_unique<FileReader>());
     if (!file_reader->Open(filepath)) {
-      LOG(ERROR) << "attachment " << filepath.value().c_str()
+      LOG(ERROR) << "attachment " << base::WideToUTF8(filepath.value())
                  << " couldn't be opened, skipping";
       continue;
     }
@@ -1086,7 +1086,7 @@ void CrashReportDatabaseWin::CleanOrphanedAttachments() {
       UUID uuid;
       if (!uuid.InitializeFromString(filename.value())) {
         LOG(ERROR) << "unexpected attachment dir name "
-                   << filename.value().c_str();
+                   << base::WideToUTF8(filename.value());
         continue;
       }
 

--- a/framework/diagnostics/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/files/file_path.cc
+++ b/framework/diagnostics/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/files/file_path.cc
@@ -287,6 +287,6 @@ void FilePath::StripTrailingSeparatorsInternal() {
 
 }  // namespace base
 
-void PrintTo(const base::FilePath& path, std::ostream* out) {
-  *out << path.value().c_str();
-}
+// void PrintTo(const base::FilePath& path, std::ostream* out) {
+//   *out << path.value().c_str();
+// }

--- a/framework/diagnostics/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/files/file_path.h
+++ b/framework/diagnostics/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/files/file_path.h
@@ -227,7 +227,7 @@ class FilePath {
 }  // namespace base
 
 // This is required by googletest to print a readable output on test failures.
-extern void PrintTo(const base::FilePath& path, std::ostream* out);
+// extern void PrintTo(const base::FilePath& path, std::ostream* out);
 
 // Macros for string literal initialization of FilePath::CharType[], and for
 // using a FilePath::CharType[] in a printf-style format string.

--- a/framework/diagnostics/thirdparty/google_crashpad_client/util/stdlib/aligned_allocator.h
+++ b/framework/diagnostics/thirdparty/google_crashpad_client/util/stdlib/aligned_allocator.h
@@ -69,7 +69,7 @@ struct AlignedAllocator {
   pointer address(reference x) const noexcept { return &x; }
   const_pointer address(const_reference x) const noexcept { return &x; }
 
-  pointer allocate(size_type n, std::allocator<void>::const_pointer hint = 0) {
+  pointer allocate(size_type n, const void* hint = nullptr) {
     return reinterpret_cast<pointer>(
         AlignedAllocate(Alignment, sizeof(value_type) * n));
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message logging consistency for Windows file paths in crash report handling and diagnostics.

* **Refactor**
  * Removed unused testing utilities and updated internal allocation method signatures for API consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/musescore/muse_framework/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->