### PR TITLE
Fix #33451: fix ringbuffer overflow caused by duplicate pedal CC events

### DIFF
--- a/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -237,12 +237,23 @@ void FluidSequencer::addControlChangeEvent(EventSequenceMap& destination, const 
 void FluidSequencer::addControlChange(EventSequenceMap& destination, const mpe::timestamp_t timestamp,
                                       const int midiControlIdx, const channel_t channelIdx, const uint32_t value)
 {
+    EventSequence& events = destination[timestamp];
+    for (const EventType& e : events) {
+        const midi::Event& midiEvent = std::get<midi::Event>(e);
+        if (midiEvent.opcode() == Event::Opcode::ControlChange
+            && midiEvent.channel() == channelIdx
+            && midiEvent.index() == static_cast<uint8_t>(midiControlIdx)
+            && midiEvent.data() == value) {
+            return;
+        }
+    }
+
     midi::Event cc(Event::Opcode::ControlChange, Event::MessageType::ChannelVoice10);
     cc.setIndex(midiControlIdx);
     cc.setChannel(channelIdx);
     cc.setData(value);
 
-    destination[timestamp].emplace_back(std::move(cc));
+    events.emplace_back(cc);
 }
 
 void FluidSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteEvent& noteEvent,

--- a/framework/vst/internal/synth/vstsequencer.cpp
+++ b/framework/vst/internal/synth/vstsequencer.cpp
@@ -201,7 +201,21 @@ void VstSequencer::addParamChange(EventSequenceMap& destination, const mpe::time
         return;
     }
 
-    destination[timestamp].emplace_back(ParamChangeEvent { controlIt->second, value });
+    const PluginParamId paramId = controlIt->second;
+    EventSequence& events = destination[timestamp];
+
+    for (const EventType& e : events) {
+        if (!std::holds_alternative<ParamChangeEvent>(e)) {
+            continue;
+        }
+
+        const ParamChangeEvent& pce = std::get<ParamChangeEvent>(e);
+        if (pce.paramId == paramId && RealIsEqual(pce.value, value)) {
+            return;
+        }
+    }
+
+    events.emplace_back(ParamChangeEvent { paramId, value });
 }
 
 void VstSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteEvent& noteEvent,


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/33572
Resolves: https://github.com/musescore/MuseScore/issues/33451