### PR TITLE
Fix #33536: shorten checkCloudIsAvailable timeout

### DIFF
--- a/framework/cloud/internal/abstractcloudservice.cpp
+++ b/framework/cloud/internal/abstractcloudservice.cpp
@@ -342,13 +342,22 @@ Ret AbstractCloudService::checkCloudIsAvailable() const
     }
 
     Ret ret = make_ok();
-
     QEventLoop loop;
+
     progress.val.finished().onReceive(this, [&ret, &loop](const ProgressResult& res) {
         ret = res.ret;
         loop.quit();
     });
+
+    QTimer timer;
+    timer.setSingleShot(true);
+    QObject::connect(&timer, &QTimer::timeout, [&progress]() {
+        progress.val.cancel();
+    });
+    timer.start(5000);
+
     loop.exec();
+    timer.stop();
 
     return ret;
 }


### PR DESCRIPTION
Ports (changes in the framework): https://github.com/musescore/MuseScore/pull/33543
Resolves: https://github.com/musescore/MuseScore/issues/33536