### PR TITLE
Fix docks becoming "pencil thin" on close and reopen [Port to main]

### DIFF
--- a/framework/dockwindow/qml/Muse/Dock/DockPanel.qml
+++ b/framework/dockwindow/qml/Muse/Dock/DockPanel.qml
@@ -34,6 +34,6 @@ DockPanelView {
     Loader {
         id: contentLoader
 
-        active: root.visible
+        active: root.visible && root.inited
     }
 }

--- a/framework/dockwindow/qml/Muse/Dock/dockpageview.cpp
+++ b/framework/dockwindow/qml/Muse/Dock/dockpageview.cpp
@@ -74,6 +74,7 @@ void DockPageView::deinit()
     TRACEFUNC;
 
     for (DockBase* dock : allDocks()) {
+        dock->deinit();
         dock->disconnect(this);
     }
 }

--- a/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/QWidgetAdapter_quick.cpp
@@ -627,22 +627,21 @@ void QWidgetAdapter::move(int x, int y)
 
 void QWidgetAdapter::setSize(QSize size)
 {
+    QSize newSize = size;
 #ifdef Q_OS_MACOS
     FloatingWindow *floatingWindow = this->floatingWindow();
-    if (!floatingWindow) {
-        return;
-    }
+    if (floatingWindow) {
+        newSize = size.expandedTo(minimumSize());
 
-    const auto newSize = size.expandedTo(minimumSize());
-
-    QWindow* window = floatingWindow->windowHandle();
-    if (window && window->size() != newSize) {
-        QRect windowGeo = window->geometry();
-        windowGeo.setSize(newSize);
-        window->setGeometry(windowGeo);
+        QWindow* window = floatingWindow->windowHandle();
+        if (window && window->size() != newSize) {
+            QRect windowGeo = window->geometry();
+            windowGeo.setSize(newSize);
+            window->setGeometry(windowGeo);
+        }
     }
 #endif
-    QQuickItem::setSize(QSizeF(size));
+    QQuickItem::setSize(QSizeF(newSize));
 }
 
 void QWidgetAdapter::setParent(QQuickItem *p)


### PR DESCRIPTION
Ports the framework part of https://github.com/musescore/MuseScore/pull/33402

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
musescore: musescore/MuseScore/main
musescore platforms: linux_x64 linux_arm64 macos windows_x64 windows_portable
