### PR TITLE
Update default MSS branch in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@ Available platforms (space-separated):
 -->
 audacity: audacity/audacity/master
 audacity platforms: linux_x64
-musescore: musescore/MuseScore/master
+musescore: musescore/MuseScore/main
 musescore platforms: linux_x64


### PR DESCRIPTION
The default MSS branch was changed from `master` to `main`.

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
