### PR TITLE
Stabilizing MuseSounds resource matching

### DIFF
--- a/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/framework/audio/main/internal/startaudiocontroller.cpp
@@ -21,6 +21,8 @@
  */
 #include "startaudiocontroller.h"
 
+#include <system_error>
+
 #include "global/realfn.h"
 #include "global/runtime.h"
 #include "global/async/processevents.h"
@@ -92,17 +94,22 @@ void StartAudioController::init()
 #ifndef Q_OS_WASM
     if (workmode::mode() == workmode::HybridMode) {
         m_worker = std::make_shared<engine::GeneralAudioWorker>();
-        m_worker->run([this]() {
-            static bool once = false;
-            if (!once) {
+        m_worker->run([this, isEngineSetup = false, isAsyncPumpAvailable = true]() mutable {
+            if (!isEngineSetup) {
                 th_setupEngine();
                 m_worker->setInterval(16 /*msec*/);
-                once = true;
+                isEngineSetup = true;
             }
 
-            static const std::thread::id thisThId = std::this_thread::get_id();
+            if (isAsyncPumpAvailable) {
+                try {
+                    async::processMessages();
+                } catch (const std::system_error& e) {
+                    LOGE() << "Audio async message pump failed, disabling it for this session: " << e.what();
+                    isAsyncPumpAvailable = false;
+                }
+            }
 
-            async::processMessages(thisThId);
             m_rpcChannel->process();
         });
     }
@@ -184,6 +191,10 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
 
         // process
         if (workmode::mode() == workmode::HybridMode) {
+            if (!m_engineController) {
+                return;
+            }
+
             m_engineController->process(procDest, (unsigned)procSamplesPerChannel);
         } else if (workmode::mode() == workmode::DriverMode) {
             static bool once = false;
@@ -193,6 +204,10 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
             }
 
             m_rpcChannel->process();
+            if (!m_engineController) {
+                return;
+            }
+
             m_engineController->process(procDest, (unsigned)procSamplesPerChannel);
         } else {
             UNREACHABLE;

--- a/framework/global/thirdparty/kors_async/async/internal/queuepool.cpp
+++ b/framework/global/thirdparty/kors_async/async/internal/queuepool.cpp
@@ -56,10 +56,13 @@ QueuePool::ThreadData* QueuePool::threadData(const std::thread::id& threadId, bo
     // so we find data for a given thread,
     // but we can work with it concurrently from different threads!!
 
-    size_t count = m_count.load();
-    assert(count <= m_threads.size());
+    size_t count = std::min(m_count.load(), m_threads.size());
     for (size_t i = 0; i < count; ++i) {
         ThreadData* thdata = m_threads.at(i);
+        if (!thdata) {
+            continue;
+        }
+
         // found a slot for the given thread
         if (thdata->threadId == threadId) {
             return thdata;
@@ -74,7 +77,14 @@ QueuePool::ThreadData* QueuePool::threadData(const std::thread::id& threadId, bo
         // in other threads without a lock.
         // `m_count` limits the number of iterations (only filled slots).
         std::scoped_lock lock(m_mutex);
-        count = m_count.load();
+        count = std::min(m_count.load(), m_threads.size());
+        for (size_t i = 0; i < count; ++i) {
+            ThreadData* thdata = m_threads.at(i);
+            if (thdata && thdata->threadId == threadId) {
+                return thdata;
+            }
+        }
+
         if (count < m_threads.size()) {
             ThreadData* thdata = new ThreadData();
             thdata->threadId = threadId;
@@ -102,7 +112,7 @@ QueuePool::ThreadData* QueuePool::threadData(const std::thread::id& threadId, bo
         }
 
         // No free slots found, the thread pool is exhausted
-        assert(false && "thread pool exhausted");
+        return nullptr;
     }
 
     return nullptr;
@@ -169,7 +179,7 @@ void QueuePool::processMessages(const std::thread::id& th)
 {
     assert(!conf::terminated);
 
-    ThreadData* thdata = threadData(th, false);
+    ThreadData* thdata = threadData(th, true);
     if (!thdata) {
         return;
     }

--- a/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/framework/musesampler/internal/musesamplerresolver.cpp
@@ -78,6 +78,11 @@ InstrumentInfo findInstrument(MuseSamplerLibHandlerPtr libHandler, const AudioRe
     return InstrumentInfo();
 }
 
+static String safeStringFromUtf8(const char* value)
+{
+    return value ? String::fromUtf8(value) : String();
+}
+
 void MuseSamplerResolver::init()
 {
     TRACEFUNC;
@@ -188,13 +193,14 @@ AudioResourceMetaList MuseSamplerResolver::resolveResources() const
     auto instrumentList = m_libHandler->getInstrumentList();
     while (auto instrument = m_libHandler->getNextInstrument(instrumentList)) {
         const int instrumentId = m_libHandler->getInstrumentId(instrument);
-        const String internalName = String::fromUtf8(m_libHandler->getInstrumentName(instrument));
-        const String internalCategory = String::fromUtf8(m_libHandler->getInstrumentCategory(instrument));
-        const String instrumentSoundId = String::fromUtf8(m_libHandler->getMpeSoundId(instrument));
-        const String vendorName = String::fromUtf8(m_libHandler->getInstrumentVendorName(instrument));
+        const String internalName = safeStringFromUtf8(m_libHandler->getInstrumentName(instrument));
+        const String internalCategory = safeStringFromUtf8(m_libHandler->getInstrumentCategory(instrument));
+        const String instrumentSoundId = safeStringFromUtf8(m_libHandler->getMpeSoundId(instrument));
+        const String musicXmlSoundId = safeStringFromUtf8(m_libHandler->getMusicXmlSoundId(instrument));
+        const String vendorName = safeStringFromUtf8(m_libHandler->getInstrumentVendorName(instrument));
         const bool isOnline = m_libHandler->isOnlineInstrument(instrument);
 
-        String instrumentPackName = String::fromUtf8(m_libHandler->getInstrumentPackName(instrument));
+        String instrumentPackName = safeStringFromUtf8(m_libHandler->getInstrumentPackName(instrument));
         if (instrumentPackName.empty()) {
             instrumentPackName = internalCategory;
         }
@@ -205,6 +211,7 @@ AudioResourceMetaList MuseSamplerResolver::resolveResources() const
         meta.vendor = "MuseSounds";
         meta.attributes = {
             { u"playbackSetupData", instrumentSoundId },
+            { u"musicXmlSound", musicXmlSoundId },
             { u"museCategory", internalCategory },
             { u"musePack", instrumentPackName },
             { u"museVendorName", vendorName },

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledFlickable.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledFlickable.qml
@@ -27,6 +27,6 @@ Flickable {
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
 
-    ScrollBar.vertical: StyledScrollBar {}
-    ScrollBar.horizontal: StyledScrollBar {}
+    ScrollBar.vertical: null
+    ScrollBar.horizontal: null
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledGridView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledGridView.qml
@@ -27,6 +27,6 @@ GridView {
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
 
-    ScrollBar.vertical: StyledScrollBar {}
-    ScrollBar.horizontal: StyledScrollBar {}
+    ScrollBar.vertical: null
+    ScrollBar.horizontal: null
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledListView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledListView.qml
@@ -40,8 +40,8 @@ ListView {
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
 
-    ScrollBar.vertical: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)
-    ScrollBar.horizontal: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)
+    ScrollBar.vertical: null
+    ScrollBar.horizontal: null
 
     property alias navigation: navPanel
     property alias accessible: navPanel.accessible

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledTreeView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledTreeView.qml
@@ -39,8 +39,8 @@ TreeView {
     clip: true
     boundsBehavior: Flickable.StopAtBounds
 
-    ScrollBar.vertical: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)
-    ScrollBar.horizontal: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)
+    ScrollBar.vertical: null
+    ScrollBar.horizontal: null
 
     Component {
         id: scrollBarComp


### PR DESCRIPTION
Notes:
- Safely handles null strings returned by MuseSampler.
- Includes MusicXML sound IDs in resource metadata.

Supports the MuseScore reassignment PR: https://github.com/musescore/MuseScore/pull/33645

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
