### PR TITLE
Add esc option to muse::strings join and split utils

### DIFF
--- a/framework/global/stringutils.cpp
+++ b/framework/global/stringutils.cpp
@@ -34,8 +34,14 @@ bool muse::strings::replace(std::string& str, const std::string& from, const std
     return true;
 }
 
-void muse::strings::split(const std::string& str, std::vector<std::string>& out, const std::string& delim)
+namespace {
+void split_simple(const std::string& str, std::vector<std::string>& out, const std::string& delim)
 {
+    if (delim.empty()) {
+        out.push_back(str);
+        return;
+    }
+
     std::size_t current, previous = 0;
     current = str.find(delim);
     std::size_t delimLen = delim.length();
@@ -48,7 +54,54 @@ void muse::strings::split(const std::string& str, std::vector<std::string>& out,
     out.push_back(str.substr(previous, current - previous));
 }
 
-std::string muse::strings::join(const std::vector<std::string>& strs, const std::string& sep)
+//! Split that handles an escape character, which causes the following escape or separator to be emitted verbatim.
+void split_handle_escape(const std::string& str, std::vector<std::string>& out, const std::string& delim, const std::string& esc)
+{
+    const size_t delimLen = delim.size();
+    const size_t escLen = esc.size();
+    std::string current;
+
+    for (size_t i = 0; i < str.size();) {
+        if (escLen > 0 && str.compare(i, escLen, esc) == 0) {
+            // Escaped sequence: drop the escape, then emit the following escape
+            // or separator token literally (mirrors what join() produced). Any
+            // other (or dangling) escape consumes a single following character.
+            i += escLen;
+            if (str.compare(i, escLen, esc) == 0) {
+                current += esc;
+                i += escLen;
+            } else if (str.compare(i, delimLen, delim) == 0) {
+                current += delim;
+                i += delimLen;
+            } else if (i < str.size()) {
+                current += str[i];
+                ++i;
+            }
+        } else if (delimLen > 0 && str.compare(i, delimLen, delim) == 0) {
+            out.push_back(current);
+            current.clear();
+            i += delimLen;
+        } else {
+            current += str[i];
+            ++i;
+        }
+    }
+    out.push_back(current);
+}
+}
+
+void muse::strings::split(const std::string& str, std::vector<std::string>& out, const std::string& delim,
+                          const std::string& esc)
+{
+    if (esc.empty()) {
+        split_simple(str, out, delim);
+    } else {
+        split_handle_escape(str, out, delim, esc);
+    }
+}
+
+namespace {
+std::string join_simple(const std::vector<std::string>& strs, const std::string& sep)
 {
     std::string str;
     bool first = true;
@@ -60,6 +113,43 @@ std::string muse::strings::join(const std::vector<std::string>& strs, const std:
         str += s;
     }
     return str;
+}
+
+//! Join that prefixes any separator or escape characters in the input with the escape string.
+std::string join_handle_escape(const std::vector<std::string>& strs, const std::string& sep, const std::string& esc)
+{
+    std::string str;
+    bool first = true;
+    for (const std::string& s : strs) {
+        if (!first) {
+            str += sep;
+        }
+        first = false;
+        for (size_t i = 0; i < s.size(); ++i) {
+            if (esc.size() > 0 && s.compare(i, esc.size(), esc) == 0) {
+                str += esc;
+                str += esc;
+                i += esc.size() - 1;
+            } else if (!sep.empty() && s.compare(i, sep.size(), sep) == 0) {
+                str += esc;
+                str += sep;
+                i += sep.size() - 1;
+            } else {
+                str += s[i];
+            }
+        }
+    }
+    return str;
+}
+}
+
+std::string muse::strings::join(const std::vector<std::string>& strs, const std::string& sep, const std::string& esc)
+{
+    if (esc.empty()) {
+        return join_simple(strs, sep);
+    } else {
+        return join_handle_escape(strs, sep, esc);
+    }
 }
 
 void muse::strings::ltrim(std::string& s)

--- a/framework/global/stringutils.h
+++ b/framework/global/stringutils.h
@@ -31,8 +31,8 @@
 
 namespace muse::strings {
 bool replace(std::string& source, const std::string& what, const std::string& to);
-void split(const std::string& str, std::vector<std::string>& out, const std::string& delim);
-std::string join(const std::vector<std::string>& strs, const std::string& sep = ",");
+void split(const std::string& str, std::vector<std::string>& out, const std::string& delim, const std::string& esc = "");
+std::string join(const std::vector<std::string>& strs, const std::string& sep = ",", const std::string& esc = "");
 
 void ltrim(std::string& s);
 void rtrim(std::string& s);

--- a/framework/global/tests/CMakeLists.txt
+++ b/framework/global/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/iodevice_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fileinfo_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/string_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringutils_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/json_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/datetime_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/flags_tests.cpp

--- a/framework/global/tests/stringutils_tests.cpp
+++ b/framework/global/tests/stringutils_tests.cpp
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "global/stringutils.h"
+
+using namespace muse;
+
+class Global_StringUtilsTests : public ::testing::Test
+{
+public:
+};
+
+TEST_F(Global_StringUtilsTests, Join_NoEscape)
+{
+    EXPECT_EQ(strings::join({ "a", "b", "c" }, "_"), "a_b_c");
+    EXPECT_EQ(strings::join({ "a" }, "_"), "a");
+    EXPECT_EQ(strings::join({}, "_"), "");
+    EXPECT_EQ(strings::join({ "", "" }, "_"), "_");
+}
+
+TEST_F(Global_StringUtilsTests, Join_DefaultSeparator)
+{
+    EXPECT_EQ(strings::join({ "a", "b", "c" }), "a,b,c");
+}
+
+TEST_F(Global_StringUtilsTests, Join_NoEscape_SeparatorInElementIsAmbiguous)
+{
+    //! GIVEN an element that contains the separator, and no escape character
+    //! THEN the separator is emitted verbatim (the result cannot be split back)
+    EXPECT_EQ(strings::join({ "a_b", "c" }, "_"), "a_b_c");
+}
+
+TEST_F(Global_StringUtilsTests, Join_EscapesSeparatorInElement)
+{
+    //! GIVEN an element containing the separator, with an escape character
+    //! THEN the embedded separator is prefixed with the escape character
+    EXPECT_EQ(strings::join({ "a_b", "c" }, "_", "\\"), "a\\_b_c");
+}
+
+TEST_F(Global_StringUtilsTests, Join_EscapesEscapeCharacterItself)
+{
+    //! GIVEN an element containing the escape character
+    //! THEN the escape character is itself escaped
+    EXPECT_EQ(strings::join({ "a\\b", "c" }, "_", "\\"), "a\\\\b_c");
+}
+
+TEST_F(Global_StringUtilsTests, Join_EscapesBothEscapeAndSeparator)
+{
+    EXPECT_EQ(strings::join({ "a\\_b" }, "_", "\\"), "a\\\\\\_b");
+}
+
+TEST_F(Global_StringUtilsTests, Split_NoEscape)
+{
+    std::vector<std::string> out;
+    strings::split("a_b_c", out, "_");
+    EXPECT_EQ(out, (std::vector<std::string> { "a", "b", "c" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_NoEscape_EmptyFields)
+{
+    std::vector<std::string> out;
+    strings::split("a__c", out, "_");
+    EXPECT_EQ(out, (std::vector<std::string> { "a", "", "c" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_NoEscape_TrailingAndLeadingDelim)
+{
+    std::vector<std::string> out;
+    strings::split("_a_", out, "_");
+    EXPECT_EQ(out, (std::vector<std::string> { "", "a", "" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_EmptyString)
+{
+    std::vector<std::string> out;
+    strings::split("", out, "_");
+    EXPECT_EQ(out, (std::vector<std::string> { "" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_HonoursEscapedSeparator)
+{
+    std::vector<std::string> out;
+    strings::split("a\\_b_c", out, "_", "\\");
+    EXPECT_EQ(out, (std::vector<std::string> { "a_b", "c" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_HonoursEscapedEscapeCharacter)
+{
+    std::vector<std::string> out;
+    strings::split("a\\\\b_c", out, "_", "\\");
+    EXPECT_EQ(out, (std::vector<std::string> { "a\\b", "c" }));
+}
+
+TEST_F(Global_StringUtilsTests, Split_TrailingEscapeIsDropped)
+{
+    //! GIVEN a string ending with a lone (dangling) escape character
+    //! THEN the escape consumes nothing and is dropped
+    std::vector<std::string> out;
+    strings::split("ab\\", out, "_", "\\");
+    EXPECT_EQ(out, (std::vector<std::string> { "ab" }));
+}
+
+TEST_F(Global_StringUtilsTests, RoundTrip_PlainComponents)
+{
+    const std::vector<std::string> parts { "Effect", "VST3", "Acme", "Reverb", "/usr/lib/reverb.vst3" };
+    const std::string joined = strings::join(parts, "_", "\\");
+
+    std::vector<std::string> out;
+    strings::split(joined, out, "_", "\\");
+    EXPECT_EQ(out, parts);
+}
+
+TEST_F(Global_StringUtilsTests, RoundTrip_ComponentsContainingSeparator)
+{
+    //! GIVEN components that themselves contain the separator
+    //! THEN join + split round-trips them back to the original count and values
+    const std::vector<std::string> parts { "Effect", "VST_3", "Ac_me", "Re_verb", "/usr/lib/re_verb.vst3" };
+    const std::string joined = strings::join(parts, "_", "\\");
+
+    std::vector<std::string> out;
+    strings::split(joined, out, "_", "\\");
+    EXPECT_EQ(out.size(), 5u);
+    EXPECT_EQ(out, parts);
+}
+
+TEST_F(Global_StringUtilsTests, RoundTrip_ComponentsContainingEscapeAndSeparator)
+{
+    const std::vector<std::string> parts { "a\\b", "c_d", "e\\_f", "\\", "_" };
+    const std::string joined = strings::join(parts, "_", "\\");
+
+    std::vector<std::string> out;
+    strings::split(joined, out, "_", "\\");
+    EXPECT_EQ(out, parts);
+}
+
+TEST_F(Global_StringUtilsTests, RoundTrip_MultiCharSeparatorAndEscape)
+{
+    const std::vector<std::string> parts { "a::b", "c", "d##::e" };
+    const std::string joined = strings::join(parts, "::", "##");
+
+    std::vector<std::string> out;
+    strings::split(joined, out, "::", "##");
+    EXPECT_EQ(out, parts);
+}
+
+TEST_F(Global_StringUtilsTests, Join_EmptySeparatorWithEscape)
+{
+    const std::string result = strings::join({ "a", "b", "c" }, "", "\\");
+    EXPECT_EQ(result, "abc");
+}
+
+TEST_F(Global_StringUtilsTests, Split_EmptyDelimiter)
+{
+    std::vector<std::string> out;
+    strings::split("abc", out, "");
+    EXPECT_EQ(out, (std::vector<std::string> { "abc" }));
+}


### PR DESCRIPTION
The split and join utils from `muse::strings` can't be used by Audacity's effect-ID resolve logic as it stands, because it does not handle the presence of the escape characters in one of the constituents.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
