### PR TITLE
Add opt-out setting to skip audio plugin scan on startup

### DIFF
--- a/framework/audioplugins/audiopluginsmodule.cpp
+++ b/framework/audioplugins/audiopluginsmodule.cpp
@@ -48,6 +48,8 @@ void AudioPluginsModule::registerExports()
     globalIoc()->registerExport<IKnownAudioPluginsRegister>(moduleName(), std::make_shared<KnownAudioPluginsRegister>());
     globalIoc()->registerExport<IAudioPluginsScannerRegister>(moduleName(), std::make_shared<AudioPluginsScannerRegister>());
     globalIoc()->registerExport<IAudioPluginMetaReaderRegister>(moduleName(), std::make_shared<AudioPluginMetaReaderRegister>());
+
+    m_configuration->init();
 }
 
 void AudioPluginsModule::resolveImports()

--- a/framework/audioplugins/iaudiopluginsconfiguration.h
+++ b/framework/audioplugins/iaudiopluginsconfiguration.h
@@ -24,6 +24,7 @@
 #include "modularity/imoduleinterface.h"
 
 #include "global/io/path.h"
+#include "global/async/channel.h"
 
 namespace muse::audioplugins {
 class IAudioPluginsConfiguration : MODULE_GLOBAL_INTERFACE
@@ -34,5 +35,9 @@ public:
     virtual ~IAudioPluginsConfiguration() = default;
 
     virtual io::path_t knownAudioPluginsFilePath() const = 0;
+
+    virtual bool needScanForPluginsOnStart() const = 0;
+    virtual void setNeedScanForPluginsOnStart(bool need) = 0;
+    virtual async::Channel<bool> needScanForPluginsOnStartChanged() const = 0;
 };
 }

--- a/framework/audioplugins/internal/audiopluginsconfiguration.cpp
+++ b/framework/audioplugins/internal/audiopluginsconfiguration.cpp
@@ -32,7 +32,7 @@ static const Settings::Key NEED_SCAN_FOR_PLUGINS_ON_START(module_name, "applicat
 void AudioPluginsConfiguration::init()
 {
     settings()->setDefaultValue(NEED_SCAN_FOR_PLUGINS_ON_START, Val(true));
-    settings()->valueChanged(NEED_SCAN_FOR_PLUGINS_ON_START).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(NEED_SCAN_FOR_PLUGINS_ON_START).onReceive(this, [this](const Val& val) {
         m_needScanForPluginsOnStartChanged.send(val.toBool());
     });
 }

--- a/framework/audioplugins/internal/audiopluginsconfiguration.cpp
+++ b/framework/audioplugins/internal/audiopluginsconfiguration.cpp
@@ -21,10 +21,39 @@
  */
 #include "audiopluginsconfiguration.h"
 
+#include "settings.h"
+
 using namespace muse;
 using namespace muse::audioplugins;
+
+static const std::string module_name("audioplugins");
+static const Settings::Key NEED_SCAN_FOR_PLUGINS_ON_START(module_name, "application/audioplugins/scanOnStart");
+
+void AudioPluginsConfiguration::init()
+{
+    settings()->setDefaultValue(NEED_SCAN_FOR_PLUGINS_ON_START, Val(true));
+    settings()->valueChanged(NEED_SCAN_FOR_PLUGINS_ON_START).onReceive(nullptr, [this](const Val& val) {
+        m_needScanForPluginsOnStartChanged.send(val.toBool());
+    });
+}
 
 io::path_t AudioPluginsConfiguration::knownAudioPluginsFilePath() const
 {
     return globalConfiguration()->userAppDataPath() + "/known_audio_plugins.json";
+}
+
+bool AudioPluginsConfiguration::needScanForPluginsOnStart() const
+{
+    const Val val = settings()->value(NEED_SCAN_FOR_PLUGINS_ON_START);
+    return val.isNull() ? true : val.toBool();
+}
+
+void AudioPluginsConfiguration::setNeedScanForPluginsOnStart(bool need)
+{
+    settings()->setSharedValue(NEED_SCAN_FOR_PLUGINS_ON_START, Val(need));
+}
+
+async::Channel<bool> AudioPluginsConfiguration::needScanForPluginsOnStartChanged() const
+{
+    return m_needScanForPluginsOnStartChanged;
 }

--- a/framework/audioplugins/internal/audiopluginsconfiguration.h
+++ b/framework/audioplugins/internal/audiopluginsconfiguration.h
@@ -36,6 +36,15 @@ public:
     AudioPluginsConfiguration(const muse::modularity::ContextPtr& iocCtx)
         : Contextable(iocCtx) {}
 
+    void init();
+
     io::path_t knownAudioPluginsFilePath() const override;
+
+    bool needScanForPluginsOnStart() const override;
+    void setNeedScanForPluginsOnStart(bool need) override;
+    async::Channel<bool> needScanForPluginsOnStartChanged() const override;
+
+private:
+    async::Channel<bool> m_needScanForPluginsOnStartChanged;
 };
 }

--- a/framework/audioplugins/internal/audiopluginsconfiguration.h
+++ b/framework/audioplugins/internal/audiopluginsconfiguration.h
@@ -26,9 +26,10 @@
 
 #include "modularity/ioc.h"
 #include "global/iglobalconfiguration.h"
+#include "global/async/asyncable.h"
 
 namespace muse::audioplugins {
-class AudioPluginsConfiguration : public IAudioPluginsConfiguration, public muse::Contextable
+class AudioPluginsConfiguration : public IAudioPluginsConfiguration, public muse::Contextable, public async::Asyncable
 {
     muse::GlobalInject<IGlobalConfiguration> globalConfiguration;
 

--- a/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
+++ b/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
@@ -80,6 +80,11 @@ void RegisterAudioPluginsScenario::updatePluginsRegistry()
 {
     TRACEFUNC;
 
+    if (!configuration()->needScanForPluginsOnStart()) {
+        LOGI() << "Skipping audio plugins scan on start (disabled in preferences)";
+        return;
+    }
+
     const PluginScanResult result = scanPlugins();
 
     Ret ret = unregisterRemovedPlugins(result.missingPluginIds);

--- a/framework/audioplugins/internal/registeraudiopluginsscenario.h
+++ b/framework/audioplugins/internal/registeraudiopluginsscenario.h
@@ -29,6 +29,7 @@
 #include "global/async/asyncable.h"
 
 #include "../iregisteraudiopluginsscenario.h"
+#include "../iaudiopluginsconfiguration.h"
 #include "../iknownaudiopluginsregister.h"
 #include "../iaudiopluginsscannerregister.h"
 #include "../iaudiopluginmetareaderregister.h"
@@ -38,6 +39,7 @@ class RegisterAudioPluginsScenario : public IRegisterAudioPluginsScenario, publi
 {
 public:
     GlobalInject<IGlobalConfiguration> globalConfiguration;
+    GlobalInject<IAudioPluginsConfiguration> configuration;
     GlobalInject<IProcess> process;
     GlobalInject<IKnownAudioPluginsRegister> knownPluginsRegister;
     GlobalInject<IAudioPluginsScannerRegister> scannerRegister;

--- a/framework/audioplugins/tests/mocks/audiopluginsconfigurationmock.h
+++ b/framework/audioplugins/tests/mocks/audiopluginsconfigurationmock.h
@@ -31,5 +31,8 @@ class AudioPluginsConfigurationMock : public IAudioPluginsConfiguration
 public:
 
     MOCK_METHOD(io::path_t, knownAudioPluginsFilePath, (), (const, override));
+    MOCK_METHOD(bool, needScanForPluginsOnStart, (), (const, override));
+    MOCK_METHOD(void, setNeedScanForPluginsOnStart, (bool), (override));
+    MOCK_METHOD(async::Channel<bool>, needScanForPluginsOnStartChanged, (), (const, override));
 };
 }

--- a/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
+++ b/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
@@ -27,6 +27,7 @@
 #include "global/tests/mocks/processmock.h"
 #include "interactive/tests/mocks/interactivemock.h"
 
+#include "mocks/audiopluginsconfigurationmock.h"
 #include "mocks/knownaudiopluginsregistermock.h"
 #include "mocks/audiopluginsscannerregistermock.h"
 #include "mocks/audiopluginsscannermock.h"
@@ -53,6 +54,7 @@ protected:
     {
         m_scenario = std::make_shared<RegisterAudioPluginsScenario>(modularity::globalCtx());
         m_globalConfiguration = std::make_shared<NiceMock<GlobalConfigurationMock> >();
+        m_configuration = std::make_shared<NiceMock<AudioPluginsConfigurationMock> >();
         m_interactive = std::make_shared<InteractiveMock>();
         m_process = std::make_shared<ProcessMock>();
         m_scannerRegister = std::make_shared<NiceMock<AudioPluginsScannerRegisterMock> >();
@@ -64,6 +66,7 @@ protected:
         m_metaReaders = { metaReaderMock };
 
         m_scenario->globalConfiguration.set(m_globalConfiguration);
+        m_scenario->configuration.set(m_configuration);
         m_scenario->interactive.set(m_interactive);
         m_scenario->process.set(m_process);
         m_scenario->knownPluginsRegister.set(m_knownPlugins);
@@ -84,10 +87,15 @@ protected:
 
         ON_CALL(*metaReaderMock, canReadMeta(_))
         .WillByDefault(Return(true));
+
+        // By default, scanning on start is enabled, so the existing tests behave as before
+        ON_CALL(*m_configuration, needScanForPluginsOnStart())
+        .WillByDefault(Return(true));
     }
 
     std::shared_ptr<RegisterAudioPluginsScenario> m_scenario;
     std::shared_ptr<GlobalConfigurationMock> m_globalConfiguration;
+    std::shared_ptr<AudioPluginsConfigurationMock> m_configuration;
     std::shared_ptr<InteractiveMock> m_interactive;
     std::shared_ptr<ProcessMock> m_process;
     std::shared_ptr<KnownAudioPluginsRegisterMock> m_knownPlugins;
@@ -190,6 +198,39 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, UpdatePluginsRegistry)
     .WillOnce(Return(muse::make_ok()));
 
     // [WHEN] Register new plugins
+    m_scenario->updatePluginsRegistry();
+}
+
+//! When scanning on start is disabled in preferences, updatePluginsRegistry() is a no-op:
+//! nothing is scanned, (un)registered, reloaded, or shown to the user.
+TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, UpdatePluginsRegistry_ScanningDisabled)
+{
+    // [GIVEN] Scanning for plugins on start is disabled
+    ON_CALL(*m_configuration, needScanForPluginsOnStart())
+    .WillByDefault(Return(false));
+
+    // [THEN] No scan is performed
+    EXPECT_CALL(*m_scannerRegister, scanners())
+    .Times(0);
+
+    EXPECT_CALL(*m_knownPlugins, pluginInfoList(_))
+    .Times(0);
+
+    // [THEN] Nothing is registered or unregistered, and the register is not reloaded
+    EXPECT_CALL(*m_process, execute(_, _))
+    .Times(0);
+
+    EXPECT_CALL(*m_knownPlugins, unregisterPlugins(_))
+    .Times(0);
+
+    EXPECT_CALL(*m_knownPlugins, load())
+    .Times(0);
+
+    // [THEN] No progress dialog is shown
+    EXPECT_CALL(*m_interactive, showProgress(_, _))
+    .Times(0);
+
+    // [WHEN] Update the registry
     m_scenario->updatePluginsRegistry();
 }
 


### PR DESCRIPTION
Refs: #33680

The audio plugin (VST) registry is refreshed on every startup and there is
currently no in-app way to disable it. This adds an opt-out setting
(`application/audioplugins/scanOnStart`, default **on**, so behavior is
unchanged) and makes `RegisterAudioPluginsScenario::updatePluginsRegistry()`
skip the scan when it is turned off.

This is the framework half. The Preferences UI that exposes the toggle is in
musescore/MuseScore (linked once opened). Motivation: #17519, #11412. This is
an opt-out mitigation, not a root-cause fix for #17519; I'm not aware of a
prior toggle attempt.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [Alex Andro](https://musescore.org/en/user/168391)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
musescore: amail80/MuseScore/feature/optional-vst-scan-on-start-ui
musescore platforms: windows_x64 linux_x64