### PR TITLE
Fix `LocaleShortFormat` to show date/time as per current locale

### DIFF
--- a/framework/languages/internal/languagesservice.cpp
+++ b/framework/languages/internal/languagesservice.cpp
@@ -30,6 +30,7 @@
 #include <QJsonParseError>
 #include <QQmlEngine>
 #include <QTranslator>
+#include <clocale>
 
 #include "languageserrors.h"
 
@@ -211,6 +212,9 @@ void LanguagesService::setCurrentLanguage(const QString& languageCode)
     QLocale locale(lang.code);
     QLocale::setDefault(locale);
     qGuiApp->setLayoutDirection(locale.textDirection());
+    if (!std::setlocale(LC_TIME, locale.name().toStdString().c_str())) {
+        LOGW() << "Failed to set LC_TIME locale for language code:" << locale.name();
+    }
 
     lang.direction = locale.textDirection();
 

--- a/framework/rcontrol/mcp/mcpcontroller.cpp
+++ b/framework/rcontrol/mcp/mcpcontroller.cpp
@@ -45,7 +45,7 @@ void McpController::init()
     });
 
     m_mcpServer->onToolsCallRequest([this](const std::string& name,
-                                           const JsonObject& args,
+                                           const JsonObject& /*args*/,
                                            const McpServer::ToolsCallResultHandler& onResult)
     {
         LOGDA() << "Tools call: " << name;


### PR DESCRIPTION
Prerequisite to resolve https://github.com/musescore/MuseScore/issues/15437

Without this using `muse::DateFormat::LocaleShortFormat` results in the "C" locale (AKA "en_US") to be used, with the very confusing MM/DD/YYYY format, that in turn prevents MuseScore to use anything sensible but the `muse::DateFormat::ISODate` format YYYY-MM-DD in headerfooterlayout.cpp