### PR TITLE
Add tooltips to StyledTabButton

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/StyledTabButton.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledTabButton.qml
@@ -86,6 +86,7 @@ TabButton {
         text: root.text
         font: root.font
         opacity: 0.75
+        displayTruncatedTextOnHover: true
     }
 
     background: Item {

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledTextLabel.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledTextLabel.qml
@@ -52,6 +52,11 @@ Text {
             cursorShape: root.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
             hoverEnabled: true
 
+            onPressed: function(mouse) {
+                ui.tooltip.hide(root, true)
+                mouse.accepted = false
+            }
+
             onClicked: {
                 ui.tooltip.hide(root, true)
 


### PR DESCRIPTION
Partially resolves: https://github.com/musescore/MuseScore/issues/32604

Adds tooltips over truncated text on StyledTabButtons, without interfering with button interaction.

Related to: https://github.com/musescore/MuseScore/pull/33765