### PR TITLE
[audio] fix SIGBUS crash in rpcpacker tests from packed async::Channel

### DIFF
--- a/framework/audio/tests/rpcpacker_tests.cpp
+++ b/framework/audio/tests/rpcpacker_tests.cpp
@@ -21,6 +21,16 @@
  */
 #include <gtest/gtest.h>
 
+// audiotypes.h is included inside a `#pragma pack(push, 1)` region below so that
+// the KNOWN_FIELDS() size checks (which assert sizeof(T) equals the sum of its
+// field sizes) are not thrown off by alignment padding. Packing must NOT reach
+// the async infrastructure though: async::Channel ultimately stores a std::mutex
+// (and atomics) by value, and packing those to alignment 1 makes the atomic
+// operations in their destructors crash with SIGBUS on architectures that
+// require aligned atomics (e.g. arm64). Pre-include it here, unpacked, so the
+// pack region only affects the plain data structs declared in audiotypes.h.
+#include "global/async/channel.h"
+
 #pragma pack(push, 1)
 #include "audio/common/audiotypes.h"
 #pragma pack(pop)


### PR DESCRIPTION
rpcpacker_tests.cpp includes audiotypes.h inside a #pragma pack(push, 1) region so the KNOWN_FIELDS() size assertions are not defeated by padding. However, the pack also reached everything audiotypes.h transitively includes, including async/channel.h. That forced alignof(ChannelImpl) (which holds a std::mutex by value) to 1, so InputProcessingProgress's make_shared'd Channel placed the mutex at a misaligned offset. The atomic compare-and-swap in pthread_mutex_destroy then crashed with SIGBUS on arm64.

Pre-include async/channel.h unpacked before the pack region so only the plain data structs in audiotypes.h are packed; the async infrastructure keeps its natural alignment.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>