### PR TITLE
[uicomponents] omit table separators that double the container border

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledTableView.qml
@@ -117,6 +117,11 @@ Item {
             leftMargin: showVerticalHeader ? 8 : index === 0 ? 16 : 8
             rightMargin: showVerticalHeader ? 8 : index === tableView.model.columnCount() - 1 ? 16 : 8
 
+            // The container border already delimits the right edge; a trailing
+            // separator on the last column would double up with it — but only
+            // once the columns fill the viewport width.
+            showTrailingSeparator: index !== tableView.model.columnCount() - 1 || tableView.contentWidth < tableView.width
+
             title: display.title
             preferredWidth: display.preferredWidth
             availableFormats: display.availableFormats

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewCell.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewCell.qml
@@ -567,10 +567,18 @@ TableViewDelegate {
         SeparatorLine {
             anchors.bottom: parent.bottom
             orientation: Qt.Horizontal
+            // Drop the underline on the last row only when the rows fill the
+            // viewport, so its bottom edge coincides with the container border.
+            // With empty space below, the last row still needs its separator.
+            visible: root.row !== tableView.rows - 1 || tableView.contentHeight < tableView.height
         }
         SeparatorLine {
             anchors.right: parent.right
             orientation: Qt.Vertical
+            // Likewise, drop the trailing edge on the last column only when the
+            // columns fill the viewport width (otherwise it delimits the column
+            // from the empty space to its right).
+            visible: root.column !== tableView.model.columnCount() - 1 || tableView.contentWidth < tableView.width
         }
 
         Component.onCompleted: {

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewColumn.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/StyledTableViewColumn.qml
@@ -31,6 +31,10 @@ Item {
     property string title: ""
     property int preferredWidth: 0
 
+    // Hidden for the last column, whose right edge coincides with the
+    // table's container border (avoids a doubled border line).
+    property bool showTrailingSeparator: true
+
     property var availableFormats: null
 
     property real leftMargin: 0
@@ -137,6 +141,7 @@ Item {
     SeparatorLine {
         anchors.right: parent.right
         orientation: Qt.Vertical
+        visible: root.showTrailingSeparator
     }
 
     NavigationFocusBorder {


### PR DESCRIPTION
The last column's right separator and the last row's bottom separator sat on top of the table's 1px container border, giving those edges a doubled, thicker look. Hide them when the content fills that dimension (so the edge coincides with the border); keep them otherwise, so a table with empty space below/right still delimits its last row/column.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
