### PR TITLE
Check for intermediate values on int validator

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/tests/intinputvalidator_tests.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/intinputvalidator_tests.cpp
@@ -112,8 +112,26 @@ TEST_F(IntInputValidatorTests, ValidateCommaLocale) {
 
     runInputTests({
             { "0", QValidator::Invalid },
-            { "", QValidator::Invalid },
+            { "", QValidator::Intermediate, "1" },
             { "1", QValidator::Acceptable }
+        });
+
+    m_validator->setTop(10);
+    m_validator->setBottom(5);
+
+    runInputTests({
+            { "1", QValidator::Intermediate, "5" },
+            { "2", QValidator::Intermediate, "5" }
+        });
+
+    m_validator->setTop(-50);
+    m_validator->setBottom(-100);
+
+    runInputTests({
+            { "-5", QValidator::Intermediate, "-50" },
+            { "-2", QValidator::Intermediate, "-50" },
+            { "-75", QValidator::Acceptable },
+            { "0", QValidator::Invalid }
         });
 
     QLocale::setDefault(prev);

--- a/framework/uicomponents/qml/Muse/UiComponents/validators/intinputvalidator.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/validators/intinputvalidator.cpp
@@ -21,6 +21,7 @@
  */
 #include "intinputvalidator.h"
 #include "global/realfn.h"
+#include <qvalidator.h>
 
 using namespace muse::uicomponents;
 
@@ -89,16 +90,26 @@ QValidator::State IntInputValidator::validate(QString& inputStr, int& cursorPos)
         } else {
             state = Acceptable;
         }
-    } else if (digits.contains(QRegularExpression("^\\-?$"))) {
-        state = Intermediate;
-    } else {
+    } else if (digits.isEmpty()) {
+        return Intermediate;
+    } else if ((digits == "-")) {
+        if (m_bottom < 0) {
+            return Intermediate;
+        }
+
         cursorPos = 0;
         return Invalid;
     }
 
     int val = digits.toInt();
-    if (val > m_top || val < m_bottom) {
-        return Invalid;
+    if (val > m_top) {
+        // A negative value above the maximum may still be an in-progress prefix
+        return val < 0 ? Intermediate : Invalid;
+    }
+
+    if (val < m_bottom) {
+        // Symmetrically, a positive not 0 value below the minimum may still be an in-progress
+        return val > 0 ? Intermediate : Invalid;
     }
 
     return state;


### PR DESCRIPTION
Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

The input validator should not invalidate values that are merely intermediate ones.
For example, if the input should be [5, 50], the value 2 should not be considered invalid because it can be the first digit of 20.
Also empty string should be considered intermediate values. So we can remove all digits from a field in order to insert new digits. 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
