### PR TITLE
fixed audio realtime thread name

### DIFF
--- a/framework/audio/common/audiotaskscheduler.h
+++ b/framework/audio/common/audiotaskscheduler.h
@@ -34,7 +34,7 @@
 namespace muse::audio {
 class AudioTaskScheduler : public IAudioTaskScheduler, public muse::async::Asyncable
 {
-    constexpr static const char* threadpoolName = "audio_realtime_thread";
+    constexpr static const char* threadpoolName = "audio_rt"; // The name must be no more than 12 characters.
 public:
     void submitRealtimeTasksAndWait(const std::vector<Task>& tasks) override
     {


### PR DESCRIPTION
On Linux thread names are limited to 16 bytes, including the terminating null = 15 characters.

Audio realtime thread name 
```
muse::runtime::setThreadName(name + "_" + std::to_string(workerIndex));
```

fixed name prefix length 