### PR TITLE
Fix `BasicTableView` compatibility issue with Qt 6.10.3

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/LegacyTreeView/BasicTableView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/LegacyTreeView/BasicTableView.qml
@@ -356,7 +356,7 @@ FocusScope {
     function resizeColumnsToContents () {
         for (var i = 0; i < __columns.length; ++i) {
             var col = getColumn(i)
-            var header = __listView.headerItem.headerRepeater.itemAt(i)
+            var header = listView.headerItem.headerRepeater.itemAt(i)
             if (col) {
                 col.resizeToContents()
                 if (col.width < header.implicitWidth)
@@ -394,17 +394,6 @@ FocusScope {
 
     /*! \internal */
     default property alias __columns: root.data
-
-    /*! \internal */
-    property alias __currentRowItem: listView.currentItem
-
-    /*! \internal
-        This property is forwarded to TableView::currentRow, but not to any TreeView property.
-    */
-    property alias __currentRow: listView.currentIndex
-
-    /*! \internal */
-    readonly property alias __listView: listView
 
     /*! \internal */
     property Component __itemDelegateLoader: null
@@ -528,7 +517,7 @@ FocusScope {
                     height: rowfiller.rowHeight
                     sourceComponent: root.rowDelegate
                     property QtObject styleData: QtObject {
-                        readonly property bool alternate: (index + __listView.count) % 2 === 1
+                        readonly property bool alternate: (index + listView.count) % 2 === 1
                         readonly property bool selected: false
                         readonly property bool hasActiveFocus: false
                         readonly property bool pressed: false

--- a/framework/uicomponents/qml/Muse/UiComponents/LegacyTreeView/LegacyTreeView.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/LegacyTreeView/LegacyTreeView.qml
@@ -131,7 +131,6 @@ BasicTableView {
         property var pressedIndex: undefined
         property bool selectOnRelease: false
         property int pressedColumn: -1
-        readonly property alias currentRow: root.__currentRow
         readonly property alias currentIndex: root.currentIndex
 
         // Handle vertical scrolling whem dragging mouse outside boundaries
@@ -223,7 +222,7 @@ BasicTableView {
                 }
             }
 
-            return row === currentRow
+            return row === root.listView.currentIndex
                    && (selectionMode === L.SelectionMode.SingleSelection
                        || (selectionMode > L.SelectionMode.SingleSelection && !selection))
         }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11211

This might also resolve https://github.com/musescore/muse_framework/issues/59 since it mentions crashing around accessibility, but I only tested Audacity and not MuseScore.

Remove aliases to read-only `StyledListView` properties in `BasicTableView`, replace them with direct access to `StyledListView`'s properties.

Aliases to read-only properties caused the error: `Invalid property assignment: "__currentRowItem" is a read-only property` when adding any Qt object to a `LegacyTreeView` object (e.g.: Audacity preferences and accessibility diagnostic panel).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [camporcr](https://musescore.com/user/122142653): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
