### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/framework/audio/common/audiotaskscheduler.h
+++ b/framework/audio/common/audiotaskscheduler.h
@@ -72,12 +72,12 @@ private:
 
     int getIdealThreadCount(AudioWorkGroup workGroup) const
     {
-        int bestThreadHint = std::thread::hardware_concurrency();
+        unsigned int bestThreadHint = std::thread::hardware_concurrency();
         if (workGroup.getProvider() != nullptr) {
-            bestThreadHint = workGroup.getMaxParallelThreadCount();
+            bestThreadHint = static_cast<unsigned int>(workGroup.getMaxParallelThreadCount());
         }
-        constexpr int hardwareToRealtimeRatio = 2; // This is a heuristic value. The optimal value may vary depending on the workload and system.
-        return bestThreadHint > 0 ? static_cast<int>(bestThreadHint / hardwareToRealtimeRatio) : 1;
+        constexpr unsigned int hardwareToRealtimeRatio = 2; // This is a heuristic value. The optimal value may vary depending on the workload and system.
+        return bestThreadHint > 0 ? bestThreadHint / hardwareToRealtimeRatio : 1;
     }
 
     void ensureThreadPoolSize(const AudioWorkGroup& currentWorkGroup)

--- a/framework/shortcuts/internal/commandshortcutsregister.cpp
+++ b/framework/shortcuts/internal/commandshortcutsregister.cpp
@@ -190,10 +190,10 @@ bool CommandShortcutsRegister::readFromFile(ShortcutList& shortcuts, const io::p
         return false;
     }
 
-    JsonObject obj = doc.rootObject();
+    JsonObject rootObj = doc.rootObject();
 
-    for (const std::string& key : obj.keys()) {
-        JsonValue scope = obj.value(key);
+    for (const std::string& key : rootObj.keys()) {
+        JsonValue scope = rootObj.value(key);
         if (!scope.isArray()) {
             LOGE() << "failed parse json: " << path << ", key: " << key;
             continue;


### PR DESCRIPTION
* reg.: '=': conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg.: declaration of 'obj' hides previous local declaration (C4456)