### PR TITLE
TextStream operator<<: add size_t overload

### DIFF
--- a/framework/global/serialization/textstream.cpp
+++ b/framework/global/serialization/textstream.cpp
@@ -64,30 +64,6 @@ TextStream& TextStream::operator<<(char ch)
     return *this;
 }
 
-TextStream& TextStream::write_int32_t(int32_t val)
-{
-    // ceil(log_10(2^31)) = 10 (+ sign)
-    return writeInt<11>(val);
-}
-
-TextStream& TextStream::write_uint32_t(uint32_t val)
-{
-    // ceil(log_10(2^32)) = 10
-    return writeInt<10>(val);
-}
-
-TextStream& TextStream::write_int64_t(int64_t val)
-{
-    // ceil(log_10(2^63)) = 20 (+ sign)
-    return writeInt<21>(val);
-}
-
-TextStream& TextStream::write_uint64_t(uint64_t val)
-{
-    // ceil(log_10(2^64)) = 20
-    return writeInt<20>(val);
-}
-
 template<size_t MaxDigits, typename T>
 TextStream& TextStream::writeInt(T val)
 {
@@ -101,6 +77,11 @@ TextStream& TextStream::writeInt(T val)
 
     return *this;
 }
+
+template TextStream& TextStream::writeInt<11, int32_t>(int32_t val);
+template TextStream& TextStream::writeInt<10, uint32_t>(uint32_t val);
+template TextStream& TextStream::writeInt<21, int64_t>(int64_t val);
+template TextStream& TextStream::writeInt<20, uint64_t>(uint64_t val);
 
 TextStream& TextStream::operator<<(double val)
 {

--- a/framework/global/serialization/textstream.cpp
+++ b/framework/global/serialization/textstream.cpp
@@ -88,8 +88,8 @@ TextStream& TextStream::write_uint64_t(uint64_t val)
     return writeInt<20>(val);
 }
 
-template<size_t MaxDigits>
-TextStream& TextStream::writeInt(NonCharInteger auto val)
+template<size_t MaxDigits, typename T>
+TextStream& TextStream::writeInt(T val)
 {
     std::array<char, MaxDigits> buf{};
     const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);

--- a/framework/global/serialization/textstream.cpp
+++ b/framework/global/serialization/textstream.cpp
@@ -64,30 +64,41 @@ TextStream& TextStream::operator<<(char ch)
     return *this;
 }
 
-TextStream& TextStream::operator<<(const int32_t val)
+TextStream& TextStream::write_int32_t(int32_t val)
 {
     // ceil(log_10(2^31)) = 10 (+ sign)
-    std::array<char, 11> buf{};
-    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
-    IF_ASSERT_FAILED(ec == std::errc {}) {
-        return *this;
-    }
-
-    write(buf.data(), static_cast<size_t>(last - buf.data()));
-
-    return *this;
+    return writeInt<11>(val);
 }
 
-TextStream& TextStream::operator<<(const uint32_t val)
+TextStream& TextStream::write_uint32_t(uint32_t val)
 {
     // ceil(log_10(2^32)) = 10
-    std::array<char, 10> buf{};
+    return writeInt<10>(val);
+}
+
+TextStream& TextStream::write_int64_t(int64_t val)
+{
+    // ceil(log_10(2^63)) = 20 (+ sign)
+    return writeInt<21>(val);
+}
+
+TextStream& TextStream::write_uint64_t(uint64_t val)
+{
+    // ceil(log_10(2^64)) = 20
+    return writeInt<20>(val);
+}
+
+template<size_t MaxDigits>
+TextStream& TextStream::writeInt(NonCharInteger auto val)
+{
+    std::array<char, MaxDigits> buf{};
     const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
     IF_ASSERT_FAILED(ec == std::errc {}) {
         return *this;
     }
 
     write(buf.data(), static_cast<size_t>(last - buf.data()));
+
     return *this;
 }
 
@@ -116,34 +127,6 @@ TextStream& TextStream::operator<<(double val)
     std::string buf = ss.str();
     write(buf.data(), buf.size());
 #endif
-
-    return *this;
-}
-
-TextStream& TextStream::operator<<(const int64_t val)
-{
-    // ceil(log_10(2^63)) = 20 (+ sign)
-    std::array<char, 21> buf{};
-    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
-    IF_ASSERT_FAILED(ec == std::errc {}) {
-        return *this;
-    }
-
-    write(buf.data(), static_cast<size_t>(last - buf.data()));
-
-    return *this;
-}
-
-TextStream& TextStream::operator<<(const uint64_t val)
-{
-    // ceil(log_10(2^64)) = 20
-    std::array<char, 20> buf{};
-    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
-    IF_ASSERT_FAILED(ec == std::errc {}) {
-        return *this;
-    }
-
-    write(buf.data(), static_cast<size_t>(last - buf.data()));
 
     return *this;
 }

--- a/framework/global/serialization/textstream.h
+++ b/framework/global/serialization/textstream.h
@@ -71,15 +71,15 @@ public:
     {
         if constexpr (sizeof(T) <= 4) {
             if constexpr (std::is_signed_v<T>) {
-                return write_int32_t(static_cast<int32_t>(val));
+                return writeInt<11>(static_cast<int32_t>(val)); // ceil(log_10(2^31)) = 10 (+ sign)
             } else {
-                return write_uint32_t(static_cast<uint32_t>(val));
+                return writeInt<10>(static_cast<uint32_t>(val)); // ceil(log_10(2^32)) = 10
             }
         } else {
             if constexpr (std::is_signed_v<T>) {
-                return write_int64_t(static_cast<int64_t>(val));
+                return writeInt<21>(static_cast<int64_t>(val)); // ceil(log_10(2^63)) = 20 (+ sign)
             } else {
-                return write_uint64_t(static_cast<uint64_t>(val));
+                return writeInt<20>(static_cast<uint64_t>(val)); // ceil(log_10(2^64)) = 20
             }
         }
     }
@@ -97,11 +97,6 @@ public:
 
 private:
     void write(const char* ch, size_t len);
-
-    TextStream& write_int32_t(int32_t val);
-    TextStream& write_uint32_t(uint32_t val);
-    TextStream& write_int64_t(int64_t val);
-    TextStream& write_uint64_t(uint64_t val);
 
     template<size_t MaxDigits, typename T>
     TextStream& writeInt(T val);

--- a/framework/global/serialization/textstream.h
+++ b/framework/global/serialization/textstream.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include <vector>
@@ -37,6 +38,17 @@ namespace io {
 class IODevice;
 }
 
+template<typename T>
+concept NonCharInteger
+    =std::integral<T>
+      && !std::same_as<std::remove_cv_t<T>, char>
+      && !std::same_as<std::remove_cv_t<T>, signed char>
+      && !std::same_as<std::remove_cv_t<T>, unsigned char>
+      && !std::same_as<std::remove_cv_t<T>, wchar_t>
+      && !std::same_as<std::remove_cv_t<T>, char8_t>
+      && !std::same_as<std::remove_cv_t<T>, char16_t>
+      && !std::same_as<std::remove_cv_t<T>, char32_t>;
+
 class TextStream
 {
 public:
@@ -49,11 +61,28 @@ public:
     void flush();
 
     TextStream& operator<<(char ch);
-    TextStream& operator<<(int32_t);
-    TextStream& operator<<(uint32_t);
+    TextStream& operator<<(signed char ch) { return *this << static_cast<char>(ch); }
+    TextStream& operator<<(unsigned char ch) { return *this << static_cast<char>(ch); }
+
+    TextStream& operator<<(NonCharInteger auto val)
+    {
+        if constexpr (sizeof(val) <= 4) {
+            if constexpr (std::is_signed_v<decltype(val)>) {
+                return write_int32_t(static_cast<int32_t>(val));
+            } else {
+                return write_uint32_t(static_cast<uint32_t>(val));
+            }
+        } else {
+            if constexpr (std::is_signed_v<decltype(val)>) {
+                return write_int64_t(static_cast<int64_t>(val));
+            } else {
+                return write_uint64_t(static_cast<uint64_t>(val));
+            }
+        }
+    }
+
     TextStream& operator<<(double);
-    TextStream& operator<<(int64_t);
-    TextStream& operator<<(uint64_t);
+
     TextStream& operator<<(const char* s);
     TextStream& operator<<(std::string_view);
     TextStream& operator<<(const ByteArray& b);
@@ -65,6 +94,15 @@ public:
 
 private:
     void write(const char* ch, size_t len);
+
+    TextStream& write_int32_t(int32_t val);
+    TextStream& write_uint32_t(uint32_t val);
+    TextStream& write_int64_t(int64_t val);
+    TextStream& write_uint64_t(uint64_t val);
+
+    template<size_t MaxDigits>
+    TextStream& writeInt(NonCharInteger auto val);
+
     io::IODevice* m_device = nullptr;
     std::vector<uint8_t> m_buf;
 };

--- a/framework/global/serialization/textstream.h
+++ b/framework/global/serialization/textstream.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #ifndef NO_QT_SUPPORT
@@ -39,15 +40,16 @@ class IODevice;
 }
 
 template<typename T>
-concept NonCharInteger
-    =std::integral<T>
-      && !std::same_as<std::remove_cv_t<T>, char>
-      && !std::same_as<std::remove_cv_t<T>, signed char>
-      && !std::same_as<std::remove_cv_t<T>, unsigned char>
-      && !std::same_as<std::remove_cv_t<T>, wchar_t>
-      && !std::same_as<std::remove_cv_t<T>, char8_t>
-      && !std::same_as<std::remove_cv_t<T>, char16_t>
-      && !std::same_as<std::remove_cv_t<T>, char32_t>;
+struct IsNonCharInteger : std::bool_constant<
+        std::is_integral_v<T>
+        && !std::is_same_v<std::remove_cv_t<T>, char>
+        && !std::is_same_v<std::remove_cv_t<T>, signed char>
+        && !std::is_same_v<std::remove_cv_t<T>, unsigned char>
+        && !std::is_same_v<std::remove_cv_t<T>, wchar_t>
+        && !std::is_same_v<std::remove_cv_t<T>, char8_t>
+        && !std::is_same_v<std::remove_cv_t<T>, char16_t>
+        && !std::is_same_v<std::remove_cv_t<T>, char32_t>
+        > {};
 
 class TextStream
 {
@@ -64,16 +66,17 @@ public:
     TextStream& operator<<(signed char ch) { return *this << static_cast<char>(ch); }
     TextStream& operator<<(unsigned char ch) { return *this << static_cast<char>(ch); }
 
-    TextStream& operator<<(NonCharInteger auto val)
+    template<typename T, std::enable_if_t<IsNonCharInteger<T>::value, int> = 0>
+    TextStream& operator<<(T val)
     {
-        if constexpr (sizeof(val) <= 4) {
-            if constexpr (std::is_signed_v<decltype(val)>) {
+        if constexpr (sizeof(T) <= 4) {
+            if constexpr (std::is_signed_v<T>) {
                 return write_int32_t(static_cast<int32_t>(val));
             } else {
                 return write_uint32_t(static_cast<uint32_t>(val));
             }
         } else {
-            if constexpr (std::is_signed_v<decltype(val)>) {
+            if constexpr (std::is_signed_v<T>) {
                 return write_int64_t(static_cast<int64_t>(val));
             } else {
                 return write_uint64_t(static_cast<uint64_t>(val));
@@ -100,8 +103,8 @@ private:
     TextStream& write_int64_t(int64_t val);
     TextStream& write_uint64_t(uint64_t val);
 
-    template<size_t MaxDigits>
-    TextStream& writeInt(NonCharInteger auto val);
+    template<size_t MaxDigits, typename T>
+    TextStream& writeInt(T val);
 
     io::IODevice* m_device = nullptr;
     std::vector<uint8_t> m_buf;


### PR DESCRIPTION
Necessary to solve a compilation issue in MuseScore’s tests on some platforms (including macOS)