### PR TITLE
Fixed crash on close app

### DIFF
--- a/framework/global/internal/baseapplication.cpp
+++ b/framework/global/internal/baseapplication.cpp
@@ -386,6 +386,10 @@ void BaseApplication::doDestroyContext(const ContextData& data)
         s->onDeinit();
     }
 
+    for (modularity::IContextSetup* s : data.setups) {
+        s->onDestroy();
+    }
+
     qDeleteAll(data.setups);
 
     modularity::removeIoC(data.ctxId);

--- a/framework/global/modularity/imodulesetup.h
+++ b/framework/global/modularity/imodulesetup.h
@@ -47,6 +47,7 @@ public:
     virtual void onInit(const IApplication::RunMode& mode) { (void)mode; }
     virtual void onAllInited(const IApplication::RunMode& mode) { (void)mode; }
     virtual void onDeinit() {}
+    virtual void onDestroy() {}
 
 private:
     ContextPtr m_ctx;


### PR DESCRIPTION
We register the EngravingModule before the PaletteModule, but also delete it in the same order. The EngravingContext deletes the paletteScore, but later, the PaletteContext deletes cells, which in turn access the deleted paletteScore. 

<details><summary>Assan output</summary>

=================================================================
==21479==ERROR: AddressSanitizer: heap-use-after-free on address 0x00014be24b58 at pc 0x000108ade014 bp 0x00016eec5960 sp 0x00016eec5958
READ of size 8 at 0x00014be24b58 thread T0
    #0 0x000108ade010 in std::__1::shared_ptr<mu::engraving::IPaletteScoreProvider>::get[abi:nqe210106]() const shared_ptr.h:631
    #1 0x000108addc1c in std::__1::shared_ptr<mu::engraving::IPaletteScoreProvider>::operator bool[abi:nqe210106]() const shared_ptr.h:646
    #2 0x000108addb28 in kors::modularity::InjectBase<mu::engraving::IPaletteScoreProvider>::get() const ioc.h:71
    #3 0x000108a176ac in kors::modularity::InjectBase<mu::engraving::IPaletteScoreProvider>::operator()() const ioc.h:96
    #4 0x00010cdbd06c in mu::engraving::Score::paletteScore() const score.cpp:344
    #5 0x00010cdbd134 in mu::engraving::Score::isPaletteScore() const score.cpp:349
    #6 0x00010c823dbc in mu::engraving::EngravingObject::~EngravingObject() engravingobject.cpp:110
    #7 0x00010c825d8c in mu::engraving::EngravingItem::~EngravingItem() engravingitem.cpp:132
    #8 0x00010ca58518 in mu::engraving::Arpeggio::~Arpeggio() arpeggio.cpp:72
    #9 0x00010c8aaecc in mu::engraving::ChordBracket::~ChordBracket() chordbracket.h:29
    #10 0x00010c8aaea0 in mu::engraving::ChordBracket::~ChordBracket() chordbracket.h:29
    #11 0x00010c8e04cc in std::__1::default_delete<mu::engraving::ChordBracket>::operator()[abi:nqe210106](mu::engraving::ChordBracket*) const unique_ptr.h:77
    #12 0x00010c8e0234 in std::__1::__shared_ptr_pointer<mu::engraving::ChordBracket*, std::__1::shared_ptr<mu::engraving::ChordBracket>::__shared_ptr_default_delete<mu::engraving::ChordBracket, mu::engraving::ChordBracket>, std::__1::allocator<mu::engraving::ChordBracket>>::__on_zero_shared() shared_ptr.h:123
    #13 0x000100f29d98 in std::__1::__shared_count::__release_shared[abi:nqe210106]() shared_count.h:92
    #14 0x000100f29cd0 in std::__1::__shared_weak_count::__release_shared[abi:nqe210106]() shared_count.h:121
    #15 0x000108244a70 in std::__1::shared_ptr<mu::engraving::EngravingItem>::~shared_ptr[abi:nqe210106]() shared_ptr.h:561
    #16 0x0001081ca928 in std::__1::shared_ptr<mu::engraving::EngravingItem>::~shared_ptr[abi:nqe210106]() shared_ptr.h:559
    #17 0x000109974bf0 in mu::palette::PaletteCell::~PaletteCell() palettecell.h:67
    #18 0x0001098cc44c in mu::palette::PaletteCell::~PaletteCell() palettecell.h:67
    #19 0x000109a1653c in void std::__1::__destroy_at[abi:nqe210106]<mu::palette::PaletteCell, 0>(mu::palette::PaletteCell*) construct_at.h:61
    #20 0x000109a164a4 in void std::__1::allocator_traits<std::__1::allocator<mu::palette::PaletteCell>>::destroy[abi:nqe210106]<mu::palette::PaletteCell, 0>(std::__1::allocator<mu::palette::PaletteCell>&, mu::palette::PaletteCell*) allocator_traits.h:313
    #21 0x000109a163b4 in void std::__1::__shared_ptr_emplace<mu::palette::PaletteCell, std::__1::allocator<mu::palette::PaletteCell>>::__on_zero_shared_impl[abi:nqe210106]<std::__1::allocator<mu::palette::PaletteCell>, 0>() shared_ptr.h:181
    #22 0x000109a15ee0 in std::__1::__shared_ptr_emplace<mu::palette::PaletteCell, std::__1::allocator<mu::palette::PaletteCell>>::__on_zero_shared() shared_ptr.h:184
    #23 0x000100f29d98 in std::__1::__shared_count::__release_shared[abi:nqe210106]() shared_count.h:92
    #24 0x000100f29cd0 in std::__1::__shared_weak_count::__release_shared[abi:nqe210106]() shared_count.h:121
    #25 0x0001097b6b1c in std::__1::shared_ptr<mu::palette::PaletteCell>::~shared_ptr[abi:nqe210106]() shared_ptr.h:561
    #26 0x000109729988 in std::__1::shared_ptr<mu::palette::PaletteCell>::~shared_ptr[abi:nqe210106]() shared_ptr.h:559
    #27 0x00010979d968 in void std::__1::__destroy_at[abi:nqe210106]<std::__1::shared_ptr<mu::palette::PaletteCell>, 0>(std::__1::shared_ptr<mu::palette::PaletteCell>*) construct_at.h:61
    #28 0x00010979d944 in void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::destroy[abi:nqe210106]<std::__1::shared_ptr<mu::palette::PaletteCell>, 0>(std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>&, std::__1::shared_ptr<mu::palette::PaletteCell>*) allocator_traits.h:313
    #29 0x0001097a0904 in std::__1::vector<std::__1::shared_ptr<mu::palette::PaletteCell>, std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::__base_destruct_at_end[abi:nqe210106](std::__1::shared_ptr<mu::palette::PaletteCell>*) vector.h:763
    #30 0x0001097300c0 in std::__1::vector<std::__1::shared_ptr<mu::palette::PaletteCell>, std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::clear[abi:nqe210106]() vector.h:543
    #31 0x0001097a0280 in std::__1::vector<std::__1::shared_ptr<mu::palette::PaletteCell>, std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::__destroy_vector::operator()[abi:nqe210106]() vector.h:251
    #32 0x0001097a04d8 in std::__1::vector<std::__1::shared_ptr<mu::palette::PaletteCell>, std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::~vector[abi:nqe210106]() vector.h:262
    #33 0x00010972ada4 in std::__1::vector<std::__1::shared_ptr<mu::palette::PaletteCell>, std::__1::allocator<std::__1::shared_ptr<mu::palette::PaletteCell>>>::~vector[abi:nqe210106]() vector.h:262
    #34 0x0001098be814 in mu::palette::Palette::~Palette() palette.cpp:71
    #35 0x0001098beb54 in mu::palette::Palette::~Palette() palette.cpp:62
    #36 0x0001097c71f0 in void std::__1::__destroy_at[abi:nqe210106]<mu::palette::Palette, 0>(mu::palette::Palette*) construct_at.h:61
    #37 0x0001097c7158 in void std::__1::allocator_traits<std::__1::allocator<mu::palette::Palette>>::destroy[abi:nqe210106]<mu::palette::Palette, 0>(std::__1::allocator<mu::palette::Palette>&, mu::palette::Palette*) allocator_traits.h:313
    #38 0x0001097c7068 in void std::__1::__shared_ptr_emplace<mu::palette::Palette, std::__1::allocator<mu::palette::Palette>>::__on_zero_shared_impl[abi:nqe210106]<std::__1::allocator<mu::palette::Palette>, 0>() shared_ptr.h:181
    #39 0x0001097c6be0 in std::__1::__shared_ptr_emplace<mu::palette::Palette, std::__1::allocator<mu::palette::Palette>>::__on_zero_shared() shared_ptr.h:184
    #40 0x000100f29d98 in std::__1::__shared_count::__release_shared[abi:nqe210106]() shared_count.h:92
    #41 0x000100f29cd0 in std::__1::__shared_weak_count::__release_shared[abi:nqe210106]() shared_count.h:121
    #42 0x0001097c5d60 in std::__1::shared_ptr<mu::palette::Palette>::~shared_ptr[abi:nqe210106]() shared_ptr.h:561
    #43 0x00010972beec in std::__1::shared_ptr<mu::palette::Palette>::~shared_ptr[abi:nqe210106]() shared_ptr.h:559
    #44 0x000109920290 in void std::__1::__destroy_at[abi:nqe210106]<std::__1::shared_ptr<mu::palette::Palette>, 0>(std::__1::shared_ptr<mu::palette::Palette>*) construct_at.h:61
    #45 0x00010992026c in void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::destroy[abi:nqe210106]<std::__1::shared_ptr<mu::palette::Palette>, 0>(std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>&, std::__1::shared_ptr<mu::palette::Palette>*) allocator_traits.h:313
    #46 0x0001099242c8 in std::__1::vector<std::__1::shared_ptr<mu::palette::Palette>, std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::__base_destruct_at_end[abi:nqe210106](std::__1::shared_ptr<mu::palette::Palette>*) vector.h:763
    #47 0x000109924818 in std::__1::vector<std::__1::shared_ptr<mu::palette::Palette>, std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::clear[abi:nqe210106]() vector.h:543
    #48 0x00010992462c in std::__1::vector<std::__1::shared_ptr<mu::palette::Palette>, std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::__destroy_vector::operator()[abi:nqe210106]() vector.h:251
    #49 0x000109924464 in std::__1::vector<std::__1::shared_ptr<mu::palette::Palette>, std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::~vector[abi:nqe210106]() vector.h:262
    #50 0x00010987c960 in std::__1::vector<std::__1::shared_ptr<mu::palette::Palette>, std::__1::allocator<std::__1::shared_ptr<mu::palette::Palette>>>::~vector[abi:nqe210106]() vector.h:262
    #51 0x0001099a5000 in mu::palette::PaletteTree::~PaletteTree() palettetree.h:34
    #52 0x0001099a4fd4 in mu::palette::PaletteTree::~PaletteTree() palettetree.h:34
    #53 0x0001099a4fac in void std::__1::__destroy_at[abi:nqe210106]<mu::palette::PaletteTree, 0>(mu::palette::PaletteTree*) construct_at.h:61
    #54 0x0001099a4f88 in void std::__1::allocator_traits<std::__1::allocator<mu::palette::PaletteTree>>::destroy[abi:nqe210106]<mu::palette::PaletteTree, 0>(std::__1::allocator<mu::palette::PaletteTree>&, mu::palette::PaletteTree*) allocator_traits.h:313
    #55 0x0001099a4e98 in void std::__1::__shared_ptr_emplace<mu::palette::PaletteTree, std::__1::allocator<mu::palette::PaletteTree>>::__on_zero_shared_impl[abi:nqe210106]<std::__1::allocator<mu::palette::PaletteTree>, 0>() shared_ptr.h:181
    #56 0x0001099a49c0 in std::__1::__shared_ptr_emplace<mu::palette::PaletteTree, std::__1::allocator<mu::palette::PaletteTree>>::__on_zero_shared() shared_ptr.h:184
    #57 0x000100f29d98 in std::__1::__shared_count::__release_shared[abi:nqe210106]() shared_count.h:92
    #58 0x000100f29cd0 in std::__1::__shared_weak_count::__release_shared[abi:nqe210106]() shared_count.h:121
    #59 0x000109976ee8 in std::__1::shared_ptr<mu::palette::PaletteTree>::~shared_ptr[abi:nqe210106]() shared_ptr.h:561
    #60 0x00010984fb78 in std::__1::shared_ptr<mu::palette::PaletteTree>::~shared_ptr[abi:nqe210106]() shared_ptr.h:559
    #61 0x000109974d08 in mu::palette::PaletteTreeModel::~PaletteTreeModel() palettemodel.h:101
    #62 0x0001098cc514 in mu::palette::PaletteTreeModel::~PaletteTreeModel() palettemodel.h:101
    #63 0x0001098cc540 in mu::palette::PaletteTreeModel::~PaletteTreeModel() palettemodel.h:101
    #64 0x000127089ea8 in QObjectPrivate::deleteChildren() qobject.cpp:2212
    #65 0x000127089c84 in QObject::~QObject() qobject.cpp:1122
    #66 0x000109975140 in mu::palette::PaletteProvider::~PaletteProvider() paletteprovider.h:208
    #67 0x0001098cc9c8 in mu::palette::PaletteProvider::~PaletteProvider() paletteprovider.h:208
    #68 0x000109987d70 in void std::__1::__destroy_at[abi:nqe210106]<mu::palette::PaletteProvider, 0>(mu::palette::PaletteProvider*) construct_at.h:61
    #69 0x000109987cd8 in void std::__1::allocator_traits<std::__1::allocator<mu::palette::PaletteProvider>>::destroy[abi:nqe210106]<mu::palette::PaletteProvider, 0>(std::__1::allocator<mu::palette::PaletteProvider>&, mu::palette::PaletteProvider*) allocator_traits.h:313
    #70 0x000109987be8 in void std::__1::__shared_ptr_emplace<mu::palette::PaletteProvider, std::__1::allocator<mu::palette::PaletteProvider>>::__on_zero_shared_impl[abi:nqe210106]<std::__1::allocator<mu::palette::PaletteProvider>, 0>() shared_ptr.h:181
    #71 0x00010997b874 in std::__1::__shared_ptr_emplace<mu::palette::PaletteProvider, std::__1::allocator<mu::palette::PaletteProvider>>::__on_zero_shared() shared_ptr.h:184
    #72 0x000100f29d98 in std::__1::__shared_count::__release_shared[abi:nqe210106]() shared_count.h:92
    #73 0x000100f29cd0 in std::__1::__shared_weak_count::__release_shared[abi:nqe210106]() shared_count.h:121
    #74 0x000109976f98 in std::__1::shared_ptr<mu::palette::PaletteProvider>::~shared_ptr[abi:nqe210106]() shared_ptr.h:561
    #75 0x0001098485d8 in std::__1::shared_ptr<mu::palette::PaletteProvider>::~shared_ptr[abi:nqe210106]() shared_ptr.h:559
    #76 0x00010984b664 in std::__1::shared_ptr<mu::palette::PaletteProvider>::reset[abi:nqe210106]() shared_ptr.h:611
    #77 0x00010984ae34 in mu::palette::PaletteContext::onDeinit() palettemodule.cpp:133
    #78 0x00010d3b9b68 in muse::BaseApplication::doDestroyContext(muse::BaseApplication::ContextData const&) baseapplication.cpp:386
    #79 0x000108c7a0a8 in muse::ui::GuiApplication::doDestroyContext(muse::BaseApplication::ContextData const&) guiapplication.cpp:200
    #80 0x00010d3b91c4 in muse::BaseApplication::destroyContext(std::__1::shared_ptr<kors::modularity::Context> const&) baseapplication.cpp:378
    #81 0x00010d3baaf0 in muse::BaseApplication::doFinish() baseapplication.cpp:444
    #82 0x000108c774c4 in muse::ui::GuiApplication::doFinish() guiapplication.cpp:114
    #83 0x00010d3ba2ac in muse::BaseApplication::finish() baseapplication.cpp:422
    #84 0x000100f1f13c in main main.cpp:224
    #85 0x000189407dfc in start+0x1b4c (dyld:arm64e+0x1fdfc)

0x00014be24b58 is located 856 bytes inside of 252648-byte region [0x00014be24800,0x00014be622e8)
freed by thread T0 here:
    #0 0x0001282e0358 in _ZdlPv+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x50358)
    #1 0x00010be851b0 in mu::engraving::MasterScore::operator delete(void*) masterscore.h:81
    #2 0x00010c6e5220 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:106
    #3 0x00010b2ecdd8 in mu::engraving::PaletteScoreProvider::deinit() palettescoreprovider.cpp:70
    #4 0x00010cb8ff9c in mu::engraving::EngravingContext::onDeinit() engravingmodule.cpp:299
    #5 0x00010d3b9b68 in muse::BaseApplication::doDestroyContext(muse::BaseApplication::ContextData const&) baseapplication.cpp:386
    #6 0x000108c7a0a8 in muse::ui::GuiApplication::doDestroyContext(muse::BaseApplication::ContextData const&) guiapplication.cpp:200
    #7 0x00010d3b91c4 in muse::BaseApplication::destroyContext(std::__1::shared_ptr<kors::modularity::Context> const&) baseapplication.cpp:378
    #8 0x00010d3baaf0 in muse::BaseApplication::doFinish() baseapplication.cpp:444
    #9 0x000108c774c4 in muse::ui::GuiApplication::doFinish() guiapplication.cpp:114
    #10 0x00010d3ba2ac in muse::BaseApplication::finish() baseapplication.cpp:422
    #11 0x000100f1f13c in main main.cpp:224
    #12 0x000189407dfc in start+0x1b4c (dyld:arm64e+0x1fdfc)

previously allocated by thread T0 here:
    #0 0x0001282dff50 in _Znwm+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x4ff50)
    #1 0x00010be85128 in mu::engraving::MasterScore::operator new(unsigned long) masterscore.h:81
    #2 0x00010be84f14 in mu::engraving::compat::ScoreAccess::createMasterScore(std::__1::shared_ptr<kors::modularity::Context> const&) scoreaccess.cpp:34
    #3 0x00010b2ec19c in mu::engraving::PaletteScoreProvider::init() palettescoreprovider.cpp:49
    #4 0x00010cb8ff18 in mu::engraving::EngravingContext::onInit(muse::IApplication::RunMode const&) engravingmodule.cpp:292
    #5 0x00010d3b7c5c in muse::BaseApplication::setupContext(std::__1::shared_ptr<kors::modularity::Context> const&) baseapplication.cpp:347
    #6 0x00010d41a748 in muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()::operator()() const baseapplication.cpp:316
    #7 0x00010d41a558 in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()>::call(muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()&, void**)::'lambda'()::operator()() const qobjectdefs_impl.h:116
    #8 0x00010d41a4fc in void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()>::call(muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()&, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()>::call(muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()&, void**)::'lambda'()&&) qobjectdefs_impl.h:65
    #9 0x00010d41a44c in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()>::call(muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()&, void**) qobjectdefs_impl.h:115
    #10 0x00010d41a2a4 in void QtPrivate::FunctorCallable<muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()>::call<QtPrivate::List<>, void>(muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'()&, void*, void**) qobjectdefs_impl.h:337
    #11 0x00010d41a208 in QtPrivate::QCallableObject<muse::BaseApplication::setupNewContext(muse::StringList const&)::$_0::operator()() const::'lambda'(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) qobjectdefs_impl.h:547
    #12 0x00012708ad94 in QObject::event(QEvent*) qobject.cpp:1413
    #13 0x000125933f88 in QGuiApplication::event(QEvent*) qguiapplication.cpp:2100
    #14 0x000126432740 in QApplication::event(QEvent*) qapplication.cpp:1773
    #15 0x000126434010 in QApplicationPrivate::notify_helper(QObject*, QEvent*) qapplication.cpp:3305
    #16 0x000126435068 in QApplication::notify(QObject*, QEvent*) qapplication.cpp:3255
    #17 0x000127040e74 in QCoreApplication::sendEvent(QObject*, QEvent*) qcoreapplication.cpp:1549
    #18 0x000127041644 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) qcoreapplication.cpp:1904
    #19 0x000132b771f4 in QCocoaEventDispatcherPrivate::processPostedEvents() qcocoaeventdispatcher.mm:871
    #20 0x000132b78494 in QCocoaEventDispatcherPrivate::postedEventsSourceCallback(void*) qcocoaeventdispatcher.mm:893
    #21 0x000189882f2c in __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x18 (CoreFoundation:arm64e+0x7df2c)
    #22 0x000189882ec0 in __CFRunLoopDoSource0+0xa8 (CoreFoundation:arm64e+0x7dec0)
    #23 0x000189882c2c in __CFRunLoopDoSources0+0xe4 (CoreFoundation:arm64e+0x7dc2c)
    #24 0x000189881850 in __CFRunLoopRun+0x330 (CoreFoundation:arm64e+0x7c850)
    #25 0x0001899541c0 in _CFRunLoopRunSpecificWithOptions+0x210 (CoreFoundation:arm64e+0x14f1c0)
    #26 0x00019666755c in RunCurrentEventLoopInMode+0x13c (HIToolbox:arm64e+0xbd55c)
    #27 0x00019666a8b8 in ReceiveNextEventCommon+0x1e4 (HIToolbox:arm64e+0xc08b8)
    #28 0x0001967f4148 in _BlockUntilNextEventMatchingListInMode+0x2c (HIToolbox:arm64e+0x24a148)
    #29 0x00018e35c358 in _DPSBlockUntilNextEventMatchingListInMode+0xe0 (AppKit:arm64e+0x6e5358)

SUMMARY: AddressSanitizer: heap-use-after-free shared_ptr.h:631 in std::__1::shared_ptr<mu::engraving::IPaletteScoreProvider>::get[abi:nqe210106]() const
Shadow bytes around the buggy address:
  0x00014be24880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x00014be24b00: fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd
  0x00014be24b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24c00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24c80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x00014be24d80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==21479==ABORTING

</details>