### PR TITLE
Porting MuseScore Studio fixes to framework

### DIFF
--- a/framework/extensions/internal/extensionsprovider.cpp
+++ b/framework/extensions/internal/extensionsprovider.cpp
@@ -112,8 +112,8 @@ const Manifest& ExtensionsProvider::manifest(const Uri& uri) const
         return *it;
     }
 
-    static Manifest _dymmy;
-    return _dymmy;
+    static Manifest _dummy;
+    return _dummy;
 }
 
 muse::async::Channel<Manifest> ExtensionsProvider::manifestChanged() const

--- a/framework/extensions/internal/scriptengine.cpp
+++ b/framework/extensions/internal/scriptengine.cpp
@@ -40,10 +40,10 @@ ScriptEngine::ScriptEngine(const modularity::ContextPtr& iocCtx, int apiversion)
     : m_iocContext(iocCtx)
 {
     m_engine = new QJSEngine();
-    m_apiengine = new JsApiEngine(m_engine, m_iocContext);
 
     m_engine->installExtensions(QJSEngine::ConsoleExtension);
     m_engine->setProperty("apiversion", apiversion);
+    m_apiengine = new JsApiEngine(m_engine, m_iocContext);
 
     QJSValue globalObj = m_engine->globalObject();
     if (apiversion == 1) {

--- a/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
@@ -226,7 +226,6 @@ void MenuView::updateGeometry()
         } else {
             // move to the left to an area that doesn't fit
             movePos(m_globalPos.x() - (viewRect.right() - paddedAnchorRect.right()) + padding() * 2, m_globalPos.y());
-            newPopupPos = PopupPosition::Left;
         }
     }
 


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/33833
Resolves: https://github.com/musescore/MuseScore/issues/33751

Ports: https://github.com/musescore/MuseScore/pull/33867
Resolves: https://github.com/musescore/MuseScore/issues/33531

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
