### PR TITLE
[DockWindow V2] Stabilization. Step 1

### DIFF
--- a/framework/dockwindow_v2/dockmodule.cpp
+++ b/framework/dockwindow_v2/dockmodule.cpp
@@ -35,6 +35,7 @@
 #include "kddockwidgets/src/qtquick/ViewFactory.h"
 #include "kddockwidgets/src/qtquick/Platform.h"
 #include "kddockwidgets/src/qtquick/QmlConfig.h"
+#include "kddockwidgets/src/qtquick/views/View.h"
 
 #include "modularity/ioc.h"
 #include "ui/iuiengine.h"
@@ -42,6 +43,21 @@
 #include "muse_framework_config.h"
 
 namespace muse::dock {
+class HiddenRubberBand : public KDDockWidgets::QtQuick::View
+{
+public:
+    explicit HiddenRubberBand(QQuickItem* parent)
+        : KDDockWidgets::QtQuick::View(nullptr, KDDockWidgets::Core::ViewType::RubberBand, parent)
+    {
+        KDDockWidgets::QtQuick::View::setVisible(false);
+    }
+
+    void setVisible(bool) override
+    {
+        KDDockWidgets::QtQuick::View::setVisible(false);
+    }
+};
+
 class DockWidgetFactory : public KDDockWidgets::QtQuick::ViewFactory
 {
 public:
@@ -53,6 +69,11 @@ public:
                                  KDDockWidgets::Core::View* parent = nullptr) const override
     {
         return new DropController(classicIndicators, parent, m_iocContext);
+    }
+
+    KDDockWidgets::Core::View* createRubberBand(KDDockWidgets::Core::View* parent) const override
+    {
+        return new HiddenRubberBand(KDDockWidgets::QtQuick::asQQuickItem(parent));
     }
 
     KDDockWidgets::Core::View* createSeparator(KDDockWidgets::Core::Separator* controller,

--- a/framework/dockwindow_v2/internal/dockbase.cpp
+++ b/framework/dockwindow_v2/internal/dockbase.cpp
@@ -728,23 +728,6 @@ void DockBase::applySizeConstraints()
         const QRect winRect(window->dragRect().topLeft(), winSize);
         window->view()->setGeometry(winRect);
     }
-
-    if (!group || !m_inited) {
-        return;
-    }
-
-    QSize currentSize = m_dockWidget->size();
-
-    //! NOTE: Initial size for all dock-widgets
-    //! See QWidgetAdapter_quick.cpp, QWidgetAdapter::QWidgetAdapter
-    static constexpr QSize INITIAL_DOCK_SIZE(800, 800);
-    if (currentSize == INITIAL_DOCK_SIZE) {
-        return;
-    }
-
-    if (sizeInRange(currentSize, minimumSize, maximumSize)) {
-        return;
-    }
 }
 
 void DockBase::syncLayoutItemMinSize()

--- a/framework/dockwindow_v2/internal/dockbase.cpp
+++ b/framework/dockwindow_v2/internal/dockbase.cpp
@@ -721,10 +721,16 @@ void DockBase::applySizeConstraints()
     dockWidgetView->setMaximumSize(maximumSize);
 
     if (KDDockWidgets::Core::FloatingWindow* window = m_dockWidget->floatingWindow()) {
-        window->view()->setMinimumSize(minimumSize);
-        window->view()->setMaximumSize(maximumSize);
+        //! NOTE: The floating window draws shadow around the dock content (see DockFloatingWindow.qml),
+        //! so the window must be larger than the content by that shadow on each side.
+        const int shadow = 2 * (DOCK_WINDOW_SHADOW + 1 /*border*/);
+        const QSize windowMinimumSize = minimumSize + QSize(shadow, shadow);
+        const QSize windowMaximumSize = maximumSize + QSize(shadow, shadow);
 
-        const QSize winSize = adjustSizeByConstraints(window->view()->geometry().size(), minimumSize, maximumSize);
+        window->view()->setMinimumSize(windowMinimumSize);
+        window->view()->setMaximumSize(windowMaximumSize);
+
+        const QSize winSize = adjustSizeByConstraints(window->view()->geometry().size(), windowMinimumSize, windowMaximumSize);
         const QRect winRect(window->dragRect().topLeft(), winSize);
         window->view()->setGeometry(winRect);
     }

--- a/framework/dockwindow_v2/internal/dockbase.cpp
+++ b/framework/dockwindow_v2/internal/dockbase.cpp
@@ -570,55 +570,46 @@ void DockBase::resize(int width, int height)
 {
     TRACEFUNC;
 
-    if (width == this->width() && height == this->height()) {
-        return;
-    }
-
     if (!m_dockWidget) {
         return;
     }
 
-    KDDockWidgets::Core::Group* group = groupForDockWidget(m_dockWidget);
-    if (!group || m_dockWidget != group->currentDockWidget()) {
+    width = std::max(width, m_minimumWidth);
+    height = std::max(height, m_minimumHeight);
+
+    if (m_maximumWidth > 0) {
+        width = std::min(width, std::max(m_maximumWidth, m_minimumWidth));
+    }
+
+    if (m_maximumHeight > 0) {
+        height = std::min(height, std::max(m_maximumHeight, m_minimumHeight));
+    }
+
+    const int deltaWidth = width - static_cast<int>(this->width());
+    const int deltaHeight = height - static_cast<int>(this->height());
+    if (deltaWidth == 0 && deltaHeight == 0) {
         return;
     }
 
-    const KDDockWidgets::Core::Item* item = group->layoutItem();
-    if (!item) {
-        return;
+    int left = 0;
+    int top = 0;
+    int right = 0;
+    int bottom = 0;
+
+    switch (location()) {
+    case Location::Bottom: top = deltaHeight;
+        break;
+    case Location::Top: bottom = deltaHeight;
+        break;
+    case Location::Left: right = deltaWidth;
+        break;
+    case Location::Right: left = deltaWidth;
+        break;
+    case Location::Center:
+    case Location::Undefined: break;
     }
 
-    KDDockWidgets::Core::ItemBoxContainer* parentContainer = item->parentBoxContainer();
-    if (!parentContainer) {
-        return;
-    }
-
-    width = qBound(m_minimumWidth, width, m_maximumWidth);
-    height = qBound(m_minimumHeight, height, m_maximumHeight);
-
-    QSize minSizeBackup = QSize(m_minimumWidth, m_minimumHeight);
-    QSize maxSizeBackup = QSize(m_maximumWidth, m_maximumHeight);
-
-    m_minimumWidth = width;
-    m_maximumWidth = width;
-
-    KDDockWidgets::QtQuick::Group* groupView = groupViewFor(group);
-    QQuickItem* visualItem = groupView ? groupView->visualItem() : nullptr;
-    int extraHeight = visualItem ? visualItem->property("nonContentsHeight").toInt() : 0;
-    height += extraHeight;
-
-    m_minimumHeight = height;
-    m_maximumHeight = height;
-
-    applySizeConstraints();
-    parentContainer->layoutEqually();
-
-    m_minimumWidth = minSizeBackup.width();
-    m_maximumWidth = maxSizeBackup.width();
-    m_minimumHeight = minSizeBackup.height();
-    m_maximumHeight = maxSizeBackup.height();
-
-    applySizeConstraints();
+    m_dockWidget->resizeInLayout(left, top, right, bottom);
 }
 
 muse::ui::INavigationSection* DockBase::navigationSection() const

--- a/framework/dockwindow_v2/qml/Muse/Dock/dockwindow.cpp
+++ b/framework/dockwindow_v2/qml/Muse/Dock/dockwindow.cpp
@@ -158,12 +158,14 @@ void DockWindow::geometryChange(const QRectF& newGeometry, const QRectF& oldGeom
     const bool widthChanged = m_currentPage && !qFuzzyCompare(newGeometry.width(), oldGeometry.width());
     const bool shrinking = widthChanged && newGeometry.width() < oldGeometry.width();
 
-    if (shrinking) {
+    if (widthChanged) {
         m_pendingWidth = int(newGeometry.width());
 
-        //! NOTE: Unpin the paddings first so compact mode can actually shrink the toolbars' content
-        for (DockToolBarView* toolBar : topLevelToolBars(m_currentPage)) {
-            toolBar->setMinimumWidth(toolBar->contentWidth());
+        if (shrinking) {
+            //! NOTE: Unpin the paddings first so compact mode can actually shrink the toolbars' content
+            for (DockToolBarView* toolBar : topLevelToolBars(m_currentPage)) {
+                toolBar->setMinimumWidth(toolBar->contentWidth());
+            }
         }
 
         adjustContentForAvailableSpace(m_currentPage);
@@ -180,13 +182,6 @@ void DockWindow::geometryChange(const QRectF& newGeometry, const QRectF& oldGeom
     }
 
     QQuickItem::geometryChange(newGeometry, oldGeometry);
-
-    if (!widthChanged || shrinking) {
-        return;
-    }
-
-    adjustContentForAvailableSpace(m_currentPage);
-    alignTopLevelToolBars(m_currentPage);
 }
 
 void DockWindow::applyLayoutSizeToFitWindow()

--- a/framework/dockwindow_v2/qml/Muse/Dock/dockwindow.cpp
+++ b/framework/dockwindow_v2/qml/Muse/Dock/dockwindow.cpp
@@ -877,7 +877,7 @@ void DockWindow::initDocks(DockPageView* page)
 
     for (DockToolBarView* toolbar : topLevelToolBars(page)) {
         connect(toolbar, &DockToolBarView::floatingChanged,
-                holder, &UniqueConnectionHolder::alignTopLevelToolBars, Qt::UniqueConnection);
+                this, &DockWindow::scheduleDeferredLayoutFix, Qt::UniqueConnection);
 
         connect(toolbar, &DockToolBarView::contentSizeChanged,
                 holder, &UniqueConnectionHolder::alignTopLevelToolBars, Qt::UniqueConnection);


### PR DESCRIPTION
Fixed: 
- When dragging panels to dock them, the "shadow" seems to be drawing twice - sometimes directly overlaid (effectively changing the opacity of the shadow), and sometimes the size/position is different.
- Mixer: gap at the top, vertical position change when toggle on/off
- Playback toolbar is cut off in undocked state
- On Win, Parts, Mixer Auto section changes center position after resize/maximize or dock/undock Transport panel