### PR TITLE
KDDockWidgets v2 pull directly from fork main

### DIFF
--- a/buildscripts/cmake/ExtDepsManifest.cmake
+++ b/buildscripts/cmake/ExtDepsManifest.cmake
@@ -9,10 +9,6 @@ if (MUSE_MODULE_DRAW)
     require_dep(harfbuzz)
 endif()
 
-if (MUSE_MODULE_DOCKWINDOW AND MUSE_MODULE_DOCKWINDOW_KDDOCKWIDGETS_V2)
-    require_source_dep(kddockwidgets)
-endif()
-
 if (OS_IS_WIN AND MUSE_MODULE_AUDIO)
     require_source_dep(asiosdk)
 endif()

--- a/framework/dockwindow_v2/CMakeLists.txt
+++ b/framework/dockwindow_v2/CMakeLists.txt
@@ -47,11 +47,28 @@ target_sources(muse_dockwindow PRIVATE
 # Setup the KDDockWidgets lib
 ###########################################
 
-kddockwidgets_add_to_build()
+# TODO: use muse_deps
+include(FetchContent)
+
+set(kddockwidgets_src_dir ${FETCHCONTENT_BASE_DIR}/kddockwidgets)
+FetchContent_Declare(kddockwidgets
+    GIT_REPOSITORY https://github.com/musescore/KDDockWidgets.git
+    GIT_TAG main
+    SOURCE_DIR ${kddockwidgets_src_dir}/kddockwidgets
+)
+
+if (NOT BUILD_SHARED_LIBS)
+    set(KDDockWidgets_STATIC ON CACHE BOOL "Build static versions of the libraries" FORCE)
+endif()
+set(KDDockWidgets_QT6 ON CACHE BOOL "Build against Qt 6" FORCE)
+set(KDDockWidgets_FRONTENDS "qtquick" CACHE STRING "Frontends to build" FORCE)
+set(KDDockWidgets_EXAMPLES OFF CACHE BOOL "Build the examples" FORCE)
+set(KDDockWidgets_TESTS OFF CACHE BOOL "Build the tests" FORCE)
+
+FetchContent_MakeAvailable(kddockwidgets)
 
 target_link_libraries(muse_dockwindow PRIVATE kddockwidgets)
 
-get_property(kddockwidgets_src_dir GLOBAL PROPERTY kddockwidgets_SOURCE_DIR)
 target_include_directories(muse_dockwindow SYSTEM PRIVATE
     ${kddockwidgets_src_dir}
     ${kddockwidgets_src_dir}/kddockwidgets/src


### PR DESCRIPTION
This is temporary change and should be reverted when KDDockWidgets v2 port is stable

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [ ] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
