### PR TITLE
accessibility: guard expired controller in AccessibleItemInterface

### DIFF
--- a/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -74,28 +74,48 @@ QRect AccessibleItemInterface::rect() const
 
 QAccessibleInterface* AccessibleItemInterface::parent() const
 {
-    QAccessibleInterface* iface = m_object->controller().lock()->parentIface(m_object->item());
+    auto controller = m_object->controller().lock();
+    if (!controller) {
+        return nullptr;
+    }
+
+    QAccessibleInterface* iface = controller->parentIface(m_object->item());
     MYLOG() << "item: " << m_object->item()->accessibleName() << ", parent: " << (iface ? iface->text(QAccessible::Name) : "null");
     return iface;
 }
 
 int AccessibleItemInterface::childCount() const
 {
-    int count = m_object->controller().lock()->childCount(m_object->item());
+    auto controller = m_object->controller().lock();
+    if (!controller) {
+        return 0;
+    }
+
+    int count = controller->childCount(m_object->item());
     MYLOG() << "item: " << m_object->item()->accessibleName() << ", childCount: " << count;
     return count;
 }
 
 QAccessibleInterface* AccessibleItemInterface::child(int index) const
 {
-    QAccessibleInterface* iface = m_object->controller().lock()->child(m_object->item(), index);
+    auto controller = m_object->controller().lock();
+    if (!controller) {
+        return nullptr;
+    }
+
+    QAccessibleInterface* iface = controller->child(m_object->item(), index);
     MYLOG() << "item: " << m_object->item()->accessibleName() << ", child: " << index << " " << iface->text(QAccessible::Name);
     return iface;
 }
 
 int AccessibleItemInterface::indexOfChild(const QAccessibleInterface* iface) const
 {
-    int idx = m_object->controller().lock()->indexOfChild(m_object->item(), iface);
+    auto controller = m_object->controller().lock();
+    if (!controller) {
+        return -1;
+    }
+
+    int idx = controller->indexOfChild(m_object->item(), iface);
     MYLOG() << "item: " << m_object->item()->accessibleName() << ", indexOfChild: " << iface->text(QAccessible::Name) << " = " << idx;
     return idx;
 }
@@ -108,7 +128,12 @@ QAccessibleInterface* AccessibleItemInterface::childAt(int, int) const
 
 QAccessibleInterface* AccessibleItemInterface::focusChild() const
 {
-    QAccessibleInterface* child = m_object->controller().lock()->focusedChild(m_object->item());
+    auto controller = m_object->controller().lock();
+    if (!controller) {
+        return nullptr;
+    }
+
+    QAccessibleInterface* child = controller->focusedChild(m_object->item());
     MYLOG() << "item: " << m_object->item()->accessibleName() << ", focused child: " << (child ? child->text(QAccessible::Name) : "null");
     return child;
 }
@@ -237,7 +262,8 @@ QAccessible::State AccessibleItemInterface::state() const
     } break;
     }
 
-    if (IAccessible* pretendFocus = m_object->controller().lock()->pretendFocus()) {
+    auto controller = m_object->controller().lock();
+    if (IAccessible* pretendFocus = controller ? controller->pretendFocus() : nullptr) {
         if (item == pretendFocus) {
             // Pretend to have focus.
             state.focusable = true;


### PR DESCRIPTION
## Problem

`AccessibleItemInterface` keeps the `AccessibilityController` as a `weak_ptr` (through `AccessibleObject`). Several `QAccessibleInterface` overrides did:

```cpp
m_object->controller().lock()->parentIface(m_object->item());
```

i.e. they dereferenced the result of `lock()` without checking it. When the controller has expired (or the `weak_ptr` resolves null in a teardown/registration race), `lock()` returns `nullptr` and this is an immediate null dereference → `EXC_BAD_ACCESS` at `0x0`.

## How it crashes

Reproducible as a crash (or a multi-second main-thread hang) when opening the **Export** / **Save As** dialog on a populated score. Building the dialog's navigation controls registers new accessible items; `AccessibilityController::reg()` then sends an `ObjectCreated` event and Qt synchronously calls back into `parent()` / `child()` / `childCount()` / `state()` on the new item, where the unchecked `lock()` brings down the app.

Two separate macOS crashpad minidumps (MuseScore Studio 4.7.3, Apple Silicon) decode to the **identical** faulting stack:

```
muse::accessibility::AccessibleItemInterface::parent() const   ← null deref @ 0x0
muse::accessibility::AccessibilityController::reg(IAccessible*)
muse::ui::AbstractNavigation::componentComplete()
muse::ui::InteractiveProvider::fillData / fireOpen / openQml / openAsync
mu::project::ProjectActionsController::exportScore()
muse::actions::ActionsDispatcher::doDispatch  ("file-export")
```

### Conditions (why it's intermittent)

- **An assistive technology must be active.** `reg()` reaches `parent()` only via `sendEvent(QAccessibleEvent)`, which the platform forwards back into the interface **only when `QAccessible::isActive()`** (a screen reader / AX client attached). With no AX client, the dialog opens instantly and never crashes. This does **not** require VoiceOver specifically — any app holding macOS Accessibility permission and observing the AX tree (window managers, keyboard remappers, text expanders, automation tools, etc.) is enough.
- **It is a race even when AX is active.** In one captured session the same score in the same process exported successfully once and crashed on a later Export a few minutes later. The `lock()` resolves null only at certain instants, so reproduction may take a few attempts.
- **Path matters.** Re-saving an existing `.mscz` (Cmd+S, no dialog) never hits this; only the dialog-constructing paths do — File ▸ Export…, Save As, or the first Save of an unsaved (e.g. MusicXML-imported) score.

## Fix

Lock the controller once into a local and return a safe default when it has expired, in the six unguarded sites: `parent()`, `child()`, `childCount()`, `indexOfChild()`, `focusChild()` and the `pretendFocus()` lookup in `state()`. No behaviour change when the controller is alive.

`parentIface()` etc. already null-check `item`/`parent`; this PR closes the remaining gap — the unchecked `lock()` result itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
