### PR TITLE
UIComponents. ButtonBox. For left-side button always add separator

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/ButtonBox.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/ButtonBox.qml
@@ -181,8 +181,10 @@ Container {
                 }
             }
 
-            if (buttonsWidths + buttonsTypes.length * root.spacing > root.width) {
-                return
+            if (lastLeftSideButtonType === -1) {
+                if (buttonsWidths + buttonsTypes.length * root.spacing > root.width) {
+                    return
+                }
             }
 
             insertSeparator(lastLeftSideButtonType)


### PR DESCRIPTION
If there is a left-side button, always add a separator to separate this button from the right-side ones. 

Solves the problem when the total content size is greater than or equal to the root width - in this case we ignored adding a separator, although later we could expand the box so that we needed a separator

https://github.com/user-attachments/assets/b68b12a6-acc1-4e0b-b2f2-26899308e7e8

