### PR TITLE
preserve image logical size via Pixmap::pixelSize

### DIFF
--- a/framework/draw/internal/qimageprovider.cpp
+++ b/framework/draw/internal/qimageprovider.cpp
@@ -1,5 +1,6 @@
 #include "qimageprovider.h"
 
+#include <algorithm>
 #include <QBuffer>
 
 #include "qimagepainterprovider.h"
@@ -31,10 +32,28 @@ std::shared_ptr<Pixmap> QImageProvider::createPixmap(int w, int h, int dpm, cons
 
 Pixmap QImageProvider::scaled(const Pixmap& origin, const Size& s) const
 {
-    QPixmap qtPixmap = Pixmap::toQPixmap(origin);
-    qtPixmap = qtPixmap.scaled(s.width(), s.height());
+    int w = s.width();
+    int h = s.height();
 
-    return Pixmap::fromQPixmap(qtPixmap);
+    if (m_maxScaledDim > 0) {
+        int maxSide = std::max(w, h);
+        if (maxSide > m_maxScaledDim) {
+            double ratio = static_cast<double>(m_maxScaledDim) / maxSide;
+            w = std::max(1, static_cast<int>(w * ratio));
+            h = std::max(1, static_cast<int>(h * ratio));
+        }
+    }
+
+    QPixmap qtPixmap = Pixmap::toQPixmap(origin);
+    qtPixmap = qtPixmap.scaled(w, h);
+
+    Pixmap result = Pixmap::fromQPixmap(qtPixmap);
+    if (result.size() != s) {
+        result.setPixelSize(result.size());
+        result.setSize(s);
+    }
+
+    return result;
 }
 
 std::shared_ptr<IPaintProvider> QImageProvider::painterForImage(std::shared_ptr<Pixmap> pixmap)

--- a/framework/draw/internal/qimageprovider.h
+++ b/framework/draw/internal/qimageprovider.h
@@ -34,5 +34,8 @@ public:
 
     IPaintProviderPtr painterForImage(std::shared_ptr<Pixmap> pixmap) override;
     void saveAsPng(std::shared_ptr<Pixmap> px, io::IODevice* device) override;
+
+private:
+    int m_maxScaledDim = 4096;
 };
 }

--- a/framework/draw/internal/qpainterprovider.cpp
+++ b/framework/draw/internal/qpainterprovider.cpp
@@ -267,7 +267,15 @@ void QPainterProvider::drawPixmap(const PointF& point, const Pixmap& pm)
         QPixmapCache::insert(key, pixmap);
     }
 
-    m_painter->drawPixmap(QPointF(point.x(), point.y()), pixmap);
+    if (pm.pixelSize() != pm.size()) {
+        m_painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+        QRectF target(point.x(), point.y(), pm.width(), pm.height());
+        QRectF source(0, 0, pm.pixelSize().width(), pm.pixelSize().height());
+        m_painter->drawPixmap(target, pixmap, source);
+        m_painter->setRenderHint(QPainter::SmoothPixmapTransform, false);
+    } else {
+        m_painter->drawPixmap(QPointF(point.x(), point.y()), pixmap);
+    }
 }
 
 void QPainterProvider::drawTiledPixmap(const RectF& rect, const Pixmap& pm, const PointF& offset)

--- a/framework/draw/tests/CMakeLists.txt
+++ b/framework/draw/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULE_TEST muse_draw_tests)
 
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/painter_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/qimageprovider_tests.cpp
 )
 
 set(MODULE_TEST_LINK muse_draw)

--- a/framework/draw/tests/qimageprovider_tests.cpp
+++ b/framework/draw/tests/qimageprovider_tests.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include <QImage>
+
+#include "draw/types/pixmap.h"
+#include "draw/internal/qimageprovider.h"
+
+using namespace muse;
+using namespace muse::draw;
+
+class Draw_QImageProviderTests : public ::testing::Test
+{
+public:
+};
+
+static Pixmap makeTestPixmap(int w, int h)
+{
+    QImage img(w, h, QImage::Format_ARGB32_Premultiplied);
+    img.fill(Qt::blue);
+    return Pixmap::fromQImage(img);
+}
+
+TEST_F(Draw_QImageProviderTests, Scaled_BelowLimit_NoClamp)
+{
+    QImageProvider provider;
+    Pixmap origin = makeTestPixmap(100, 80);
+
+    Size requested(2000, 1600);
+    Pixmap result = provider.scaled(origin, requested);
+
+    EXPECT_EQ(result.size(), requested);
+    EXPECT_EQ(result.pixelSize(), requested);
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST_F(Draw_QImageProviderTests, Scaled_AboveLimit_ClampPreservesLogicalSize)
+{
+    QImageProvider provider;
+    Pixmap origin = makeTestPixmap(100, 80);
+
+    Size requested(8000, 6000);
+    Pixmap result = provider.scaled(origin, requested);
+
+    // logical size = requested
+    EXPECT_EQ(result.size(), requested);
+
+    // pixel size clamped: max side <= 4096
+    Size ps = result.pixelSize();
+    EXPECT_LE(ps.width(), 4096);
+    EXPECT_LE(ps.height(), 4096);
+    EXPECT_EQ(std::max(ps.width(), ps.height()), 4096);
+
+    // pixel size != logical size
+    EXPECT_NE(result.pixelSize(), result.size());
+
+    EXPECT_FALSE(result.isNull());
+}

--- a/framework/draw/types/pixmap.h
+++ b/framework/draw/types/pixmap.h
@@ -48,6 +48,11 @@ public:
     int width() const { return m_size.width(); }
     int height() const { return m_size.height(); }
     Size size() const { return m_size; }
+    void setSize(const Size& s) { m_size = s; }
+
+    Size pixelSize() const { return m_pixelSize.isNull() ? m_size : m_pixelSize; }
+    void setPixelSize(const Size& s) { m_pixelSize = s; }
+
     ByteArray data() const { return m_data; }
 
     bool isNull() const { return m_data.empty(); }
@@ -124,7 +129,8 @@ private:
     }
 
     Size m_size;
-    ByteArray m_data; //! usually png
+    Size m_pixelSize;   //! actual pixel dimensions (may differ from m_size after clamped scaling)
+    ByteArray m_data;   //! usually png
     unsigned int m_key = 0;
 };
 }


### PR DESCRIPTION
Image can get too big for qt to show (so it disappears with zoom), also RAM can grow up to several GB

https://github.com/musescore/MuseScore/issues/34026