### PR TITLE
Fix lineSpacing font metrics DPI mismatch

### DIFF
--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -41,6 +41,23 @@ using namespace muse::draw;
 static const double DEFAULT_PIXEL_SIZE = 100.0;
 static const double SYMBOLS_PIXEL_SIZE = 200.0;
 static const double LOADED_PIXEL_SIZE = 200.0;
+static const double FONT_METRICS_DPI = 1200.0;
+static constexpr double PPI = 72.0;
+
+static int fontMetricsPixelSize(const Font& f)
+{
+    if (f.pixelSize() > 0) {
+        return f.pixelSize();
+    }
+
+    double pixelSize = f.pointSizeF() * FONT_METRICS_DPI / PPI;
+    return static_cast<int>(std::round(pixelSize));
+}
+
+static FaceKey faceKeyForMetricsFont(const Font& f)
+{
+    return FaceKey(dataKeyForFont(f), f.type(), fontMetricsPixelSize(f));
+}
 
 static inline RectF fromFBBox(const FBBox& bb, double scale)
 {
@@ -482,7 +499,7 @@ IFontFace* FontsEngine::createFontFace(const io::path_t& path) const
 FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode) const
 {
     //! NOTE This font is required
-    FaceKey requireKey = faceKeyForFont(f);
+    FaceKey requireKey = faceKeyForMetricsFont(f);
 
     //! NOTE If pixelSize is not set, then specify the default
     //! (this is the default pixelSize in Qt)

--- a/framework/draw/internal/qfontprovider.cpp
+++ b/framework/draw/internal/qfontprovider.cpp
@@ -44,6 +44,7 @@ protected:
     int metric(PaintDeviceMetric m) const override
     {
         switch (m) {
+        case QPaintDevice::PdmDpiX:
         case QPaintDevice::PdmDpiY:
             return MU_ENGRAVING_DPI;
         default:

--- a/framework/draw/tests/fontsprovider_qt_tests.cpp
+++ b/framework/draw/tests/fontsprovider_qt_tests.cpp
@@ -155,7 +155,7 @@ inline bool ValIsEqual(muse::RectF p1, muse::RectF p2, double epsilon)
            && ValIsEqual(p1.width(), p2.width(), epsilon) && ValIsEqual(p1.height(), p2.height(), epsilon);
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_lineSpacing)
+TEST_F(Draw_FontsProviderQtTests, lineSpacing)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);


### PR DESCRIPTION
fixed linespacing
before
pointSize: 5.62
    q_val: 112.781250
    x_val: 33.600000
    diff: 79.181250
after
pointSize: 5.62
    q_val: 112.781250
    x_val: 112.800000
    diff: 0.018750

Actually I think we should not use 1200 dpi here. I dont understand why it is 1200. I guess it is legacy from Muse Studio. But this repo is called muse_framework so MU_ENGRAVING_DPI doen't make sende. But this PR is to make FontrProvider like QFontProvider not to fix QFontProvider. Any changes in QFontProvider can effect Muse Studio