### PR TITLE
Fix ascent descent height font metrics mismatch

### DIFF
--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -86,6 +86,13 @@ struct muse::draw::SymbolMetrics
     FT_Fixed linearAdvance = 0;
 };
 
+struct HeightMetrics
+{
+    f26dot6_t ascent = 0;
+    f26dot6_t descent = 0;
+    f26dot6_t leading = 0;
+};
+
 struct muse::draw::FData
 {
     ByteArray fontData;
@@ -94,7 +101,85 @@ struct muse::draw::FData
     std::unordered_map<glyph_idx_t, GlyphMetrics> glyphsMetrics;
     std::unordered_map<glyph_idx_t, SymbolMetrics> symbolMetrics;
     FT_Size_Metrics metrics;
+    HeightMetrics heightMetrics;
 };
+
+static f26dot6_t tableValueToF26Dot6(FT_Face face, long value, int pixelSize)
+{
+    if (!face || face->units_per_EM == 0) {
+        return 0;
+    }
+
+    return static_cast<f26dot6_t>(value * pixelSize * 64.0 / face->units_per_EM);
+}
+
+static bool processHheaTable(FT_Face face, int pixelSize, HeightMetrics& metrics)
+{
+    TT_HoriHeader* hhea = (TT_HoriHeader*)FT_Get_Sfnt_Table(face, ft_sfnt_hhea);
+    if (!hhea) {
+        return false;
+    }
+
+    if (hhea->Ascender == 0 && hhea->Descender == 0) {
+        return false;
+    }
+
+    metrics.ascent = tableValueToF26Dot6(face, hhea->Ascender, pixelSize);
+    metrics.descent = -tableValueToF26Dot6(face, hhea->Descender, pixelSize);
+    metrics.leading = tableValueToF26Dot6(face, hhea->Line_Gap, pixelSize);
+    return true;
+}
+
+static bool processOS2Table(FT_Face face, int pixelSize, bool preferTypoLineMetrics, HeightMetrics& metrics)
+{
+    TT_OS2* os2 = (TT_OS2*)FT_Get_Sfnt_Table(face, ft_sfnt_os2);
+    if (!os2) {
+        return false;
+    }
+
+    enum {
+        USE_TYPO_METRICS = 0x80
+    };
+    if (preferTypoLineMetrics || (os2->fsSelection & USE_TYPO_METRICS)) {
+        if (os2->sTypoAscender == 0 && os2->sTypoDescender == 0) {
+            return false;
+        }
+
+        metrics.ascent = tableValueToF26Dot6(face, os2->sTypoAscender, pixelSize);
+        metrics.descent = -tableValueToF26Dot6(face, os2->sTypoDescender, pixelSize);
+        metrics.leading = tableValueToF26Dot6(face, os2->sTypoLineGap, pixelSize);
+    } else {
+        if (os2->usWinAscent == 0 && os2->usWinDescent == 0) {
+            return false;
+        }
+
+        metrics.ascent = tableValueToF26Dot6(face, os2->usWinAscent, pixelSize);
+        metrics.descent = tableValueToF26Dot6(face, os2->usWinDescent, pixelSize);
+        metrics.leading = 0;
+    }
+
+    return true;
+}
+
+static HeightMetrics calculateHeightMetrics(FData* data, int pixelSize)
+{
+    const FT_Size_Metrics& metrics = data->metrics;
+    const double scale = static_cast<double>(pixelSize) / metrics.y_ppem;
+
+    HeightMetrics result;
+    result.ascent = static_cast<f26dot6_t>(metrics.ascender * scale);
+    result.descent = static_cast<f26dot6_t>(-metrics.descender * scale);
+    result.leading = static_cast<f26dot6_t>((metrics.height - metrics.ascender + metrics.descender) * scale);
+
+    processHheaTable(data->face, pixelSize, result);
+    processOS2Table(data->face, pixelSize, true, result);
+    return result;
+}
+
+static void initializeHeightMetrics(FData* data, int pixelSize)
+{
+    data->heightMetrics = calculateHeightMetrics(data, pixelSize);
+}
 
 FontFaceFT::FontFaceFT()
 {
@@ -151,6 +236,7 @@ bool FontFaceFT::load(const FaceKey& key, const io::path_t& path, bool isSymbolM
     }
 
     m_data->metrics = m_data->face->size->metrics;
+    initializeHeightMetrics(m_data, m_key.pixelSize);
 
     return true;
 }
@@ -335,21 +421,17 @@ const msdfgen::Shape& FontFaceFT::glyphShape(glyph_idx_t idx) const
 
 f26dot6_t FontFaceFT::leading() const
 {
-    const auto& metrics = m_data->metrics;
-    f26dot6_t v = metrics.height - metrics.ascender + metrics.descender;
-    return v;
+    return m_data->heightMetrics.leading;
 }
 
 f26dot6_t FontFaceFT::ascent() const
 {
-    f26dot6_t v = m_data->metrics.ascender;
-    return v;
+    return m_data->heightMetrics.ascent;
 }
 
 f26dot6_t FontFaceFT::descent() const
 {
-    f26dot6_t v = -m_data->metrics.descender;
-    return v;
+    return m_data->heightMetrics.descent;
 }
 
 f26dot6_t FontFaceFT::xHeight() const

--- a/framework/draw/tests/fontsprovider_qt_tests.cpp
+++ b/framework/draw/tests/fontsprovider_qt_tests.cpp
@@ -171,7 +171,7 @@ TEST_F(Draw_FontsProviderQtTests, lineSpacing)
     }
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_xHeight)
+TEST_F(Draw_FontsProviderQtTests, xHeight)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);
@@ -187,7 +187,7 @@ TEST_F(Draw_FontsProviderQtTests, DISABLED_xHeight)
     }
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_height)
+TEST_F(Draw_FontsProviderQtTests, height)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);
@@ -203,7 +203,7 @@ TEST_F(Draw_FontsProviderQtTests, DISABLED_height)
     }
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_ascent)
+TEST_F(Draw_FontsProviderQtTests, ascent)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);
@@ -219,7 +219,7 @@ TEST_F(Draw_FontsProviderQtTests, DISABLED_ascent)
     }
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_descent)
+TEST_F(Draw_FontsProviderQtTests, descent)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);


### PR DESCRIPTION
Qt 6 changed how font metrics are calculated compared to Qt 5: instead of relying mostly on platform/system font metrics, Qt now reads OpenType/TrueType tables directly, in particular hhea and OS/2 tables, and derives ascent, descent, leading/lineGap from those table values.
The implementation was aligned with Qt's current FreeType metric handling after reviewing the Qt 6 sources. It is adapted to our codebase, with the goal of avoiding metric differences between the Qt and FreeType providers.
The tests are not bit-exact in every value, but the remaining tiny differences are caused by our LOADED_PIXEL_SIZE scaling/cache model. As an experiment, when loading the font directly at the requested pixel size instead of using LOADED_PIXEL_SIZE, the test values became identical to Qt.

Before
height:
  5.62pt  q_val=93.984375   x_val=94.470000   diff=0.485625
ascent:
  5.62pt  q_val=69.265625   x_val=69.560000   diff=0.294375
descent:
  5.62pt  q_val=24.718750   x_val=24.910000   diff=0.191250

After:
height:
  5.62pt  q_val=93.984375   x_val=93.992656   diff=0.008281
ascent:
  5.62pt  q_val=69.265625   x_val=69.273594   diff=0.007969
descent:
  5.62pt  q_val=24.718750   x_val=24.719062   diff=0.000312

xHeight test is green now but it was fixed in previous PR, have noticed it only now