### PR TITLE
Fix advance of string font metrics mismatch

### DIFF
--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -76,6 +76,21 @@ static const IFontFace* findSubtitutionFont(char32_t ch, const std::vector<IFont
     return founded;
 }
 
+static bool isZeroAdvanceChar(char32_t ch)
+{
+    return ch == U'\n' || ch == U'\r';
+}
+
+static bool isZeroAdvanceText(const char32_t* text, int length)
+{
+    for (int i = 0; i < length; ++i) {
+        if (!isZeroAdvanceChar(text[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool FontsEngine::RequireFace::isSymbolMode() const
 {
     return face ? face->isSymbolMode() : false;
@@ -198,10 +213,27 @@ double FontsEngine::horizontalAdvance(const Font& f, const std::u32string& text)
         return 0.0;
     }
 
-    std::vector<GlyphPos> glyphs = rf->face->glyphs(&text[0], (int)text.size());
     f26dot6_t advance = 0;
-    for (const GlyphPos& g : glyphs) {
-        advance += g.x_advance;
+
+    TextBlock textBlock;
+    textBlock.text = &text[0];
+    textBlock.lenght = static_cast<int>(text.size());
+
+    std::vector<FontFaceTextBlock> fontFaceBlocks = splitTextByFontFaces(rf, textBlock);
+    for (const FontFaceTextBlock& ffBlock : fontFaceBlocks) {
+        const IFontFace* fontFace = ffBlock.face;
+        if (!fontFace) {
+            if (isZeroAdvanceText(ffBlock.text.text, ffBlock.text.lenght)) {
+                continue;
+            }
+
+            fontFace = rf->face;
+        }
+
+        std::vector<GlyphPos> glyphs = fontFace->glyphs(ffBlock.text.text, ffBlock.text.lenght);
+        for (const GlyphPos& g : glyphs) {
+            advance += g.x_advance;
+        }
     }
 
     return from_f26d6(advance) * rf->pixelScale();
@@ -239,19 +271,13 @@ RectF FontsEngine::boundingRect(const Font& f, const std::u32string& text) const
         lineRect = FBBox();
         isFirstInLine = true;
 
-        std::vector<TextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
-        for (const TextBlock& ffBlock : fontFaceBlocks) {
-            const IFontFace* fontFace = nullptr;
-            if (rf->face->glyphIndex(*ffBlock.text) != 0) {
-                fontFace = rf->face;
-            } else {
-                fontFace = findSubtitutionFont(*ffBlock.text, rf->subtitutionFaces);
-            }
-            if (!fontFace) {
+        std::vector<FontFaceTextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
+        for (const FontFaceTextBlock& ffBlock : fontFaceBlocks) {
+            if (!ffBlock.face) {
                 continue;
             }
 
-            std::vector<GlyphPos> glyphs = fontFace->glyphs(ffBlock.text, ffBlock.lenght);
+            std::vector<GlyphPos> glyphs = ffBlock.face->glyphs(ffBlock.text.text, ffBlock.text.lenght);
 
             for (const GlyphPos& g : glyphs) {
                 FBBox bbox = rf->face->glyphBbox(g.idx);
@@ -301,21 +327,16 @@ RectF FontsEngine::tightBoundingRect(const Font& f, const std::u32string& text) 
         isFirstInLine = true;
         f26dot6_t advance = 0;
 
-        std::vector<TextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
+        std::vector<FontFaceTextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
 
         GlyphPos lastGlyph;
-        for (const TextBlock& ffBlock : fontFaceBlocks) {
-            const IFontFace* fontFace = nullptr;
-            if (rf->face->glyphIndex(*ffBlock.text) != 0) {
-                fontFace = rf->face;
-            } else {
-                fontFace = findSubtitutionFont(*ffBlock.text, rf->subtitutionFaces);
-            }
-            if (!fontFace) {
+        const IFontFace* lastGlyphFace = nullptr;
+        for (const FontFaceTextBlock& ffBlock : fontFaceBlocks) {
+            if (!ffBlock.face) {
                 continue;
             }
 
-            std::vector<GlyphPos> glyphs = fontFace->glyphs(ffBlock.text, ffBlock.lenght);
+            std::vector<GlyphPos> glyphs = ffBlock.face->glyphs(ffBlock.text.text, ffBlock.text.lenght);
 
             for (const GlyphPos& g : glyphs) {
                 FBBox bbox = rf->face->glyphBbox(g.idx);
@@ -331,9 +352,14 @@ RectF FontsEngine::tightBoundingRect(const Font& f, const std::u32string& text) 
                 advance += g.x_advance;
             }
             lastGlyph = glyphs.back();
+            lastGlyphFace = ffBlock.face;
         }
 
-        advance -= (lastGlyph.x_advance - rf->face->glyphBbox(lastGlyph.idx).width());
+        IF_ASSERT_FAILED(lastGlyphFace) {
+            continue;
+        }
+
+        advance -= (lastGlyph.x_advance - lastGlyphFace->glyphBbox(lastGlyph.idx).width());
         lineRect.setWidth(advance);
 
         if (isFirstLine) {
@@ -441,26 +467,20 @@ std::vector<GlyphImage> FontsEngine::render(const Font& f, const std::u32string&
     for (const TextBlock& l : lines) {
         double glyphLeft = 0;
 
-        std::vector<TextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
-        for (const TextBlock& ffBlock : fontFaceBlocks) {
-            const IFontFace* fontFace = nullptr;
-            if (rf->face->glyphIndex(*ffBlock.text) != 0) {
-                fontFace = rf->face;
-            } else {
-                fontFace = findSubtitutionFont(*ffBlock.text, rf->subtitutionFaces);
-            }
-            if (!fontFace) {
+        std::vector<FontFaceTextBlock> fontFaceBlocks = splitTextByFontFaces(rf, l);
+        for (const FontFaceTextBlock& ffBlock : fontFaceBlocks) {
+            if (!ffBlock.face) {
                 continue;
             }
 
-            std::vector<GlyphPos> glyphs = fontFace->glyphs(ffBlock.text, ffBlock.lenght);
+            std::vector<GlyphPos> glyphs = ffBlock.face->glyphs(ffBlock.text.text, ffBlock.text.lenght);
 
             for (const GlyphPos& g : glyphs) {
                 if (NOT_RENDER_GLYPHS.find(g.idx) == NOT_RENDER_GLYPHS.end()) {
-                    GlyphImage image;// = m_renderCache.load(fontFace->key(), g.idx);
+                    GlyphImage image;// = m_renderCache.load(ffBlock.face->key(), g.idx);
                     if (image.isNull()) {
-                        generateSdf(image, g.idx, fontFace);
-                        //m_renderCache.store(fontFace->key(), g.idx, image);
+                        generateSdf(image, g.idx, ffBlock.face);
+                        //m_renderCache.store(ffBlock.face->key(), g.idx, image);
                     }
 
                     image.rect = scaleRect(image.rect, pixelScale);
@@ -624,40 +644,36 @@ std::vector<FontsEngine::TextBlock> FontsEngine::splitTextByLines(const std::u32
     return lines;
 }
 
-std::vector<FontsEngine::TextBlock> FontsEngine::splitTextByFontFaces(const RequireFace* rf, const TextBlock& text) const
+std::vector<FontsEngine::FontFaceTextBlock> FontsEngine::splitTextByFontFaces(const RequireFace* rf, const TextBlock& text) const
 {
-    std::vector<TextBlock> textBlocks;
+    std::vector<FontFaceTextBlock> textBlocks;
 
-    TextBlock txtBlock;
-    const IFontFace* current = rf->face;
+    FontFaceTextBlock txtBlock;
+    txtBlock.text.text = &text.text[0];
+    const IFontFace* current = nullptr;
     for (int i = 0; i < text.lenght; ++i) {
-        if (!txtBlock.text) {
-            txtBlock.text = &text.text[i];
-        }
-
+        const IFontFace* newFace = nullptr;
         if (rf->face->glyphIndex(text.text[i]) != 0) {
-            if (current->key() != rf->face->key()) {
-                current = rf->face;
-                textBlocks.push_back(txtBlock);
-                txtBlock.text = &text.text[i];
-                txtBlock.lenght = 0;
-            }
-        } else if (rf->face->glyphIndex(text.text[i]) == 0) {
-            auto newSubFace = findSubtitutionFont(text.text[i], rf->subtitutionFaces);
-            if (newSubFace && newSubFace->key() != current->key() && txtBlock.lenght != 0) {
-                current = newSubFace;
-                textBlocks.push_back(txtBlock);
-                txtBlock.text = &text.text[i];
-                txtBlock.lenght = 0;
-            }
+            newFace = rf->face;
+        } else {
+            newFace = findSubtitutionFont(text.text[i], rf->subtitutionFaces);
         }
 
-        ++txtBlock.lenght;
+        if (txtBlock.text.lenght > 0 && newFace != current) {
+            txtBlock.face = current;
+            textBlocks.push_back(txtBlock);
+            txtBlock.text.text = &text.text[i];
+            txtBlock.text.lenght = 0;
+        }
+
+        current = newFace;
+        ++txtBlock.text.lenght;
 
         if (i == (text.lenght - 1)) {
+            txtBlock.face = current;
             textBlocks.push_back(txtBlock);
-            txtBlock.text = nullptr;
-            txtBlock.lenght = 0;
+            txtBlock.text.text = nullptr;
+            txtBlock.text.lenght = 0;
         }
     }
 

--- a/framework/draw/internal/fontsengine.h
+++ b/framework/draw/internal/fontsengine.h
@@ -74,6 +74,11 @@ private:
         int lenght = 0;
     };
 
+    struct FontFaceTextBlock {
+        TextBlock text;
+        const IFontFace* face = nullptr;
+    };
+
     struct RequireFace {
         IFontFace* face = nullptr;   // real loaded face
         std::vector<IFontFace*> subtitutionFaces;
@@ -87,7 +92,7 @@ private:
     RequireFace* fontFace(const Font& f, bool isSymbolMode = false) const;
 
     std::vector<TextBlock> splitTextByLines(const std::u32string& text) const;
-    std::vector<TextBlock> splitTextByFontFaces(const RequireFace* rf, const TextBlock& text) const;
+    std::vector<FontFaceTextBlock> splitTextByFontFaces(const RequireFace* rf, const TextBlock& text) const;
 
     FontFaceFactory m_fontFaceFactory;
 

--- a/framework/draw/tests/fontsprovider_qt_tests.cpp
+++ b/framework/draw/tests/fontsprovider_qt_tests.cpp
@@ -253,7 +253,7 @@ TEST_F(Draw_FontsProviderQtTests, DISABLED_horizontalAdvance_Char)
     }
 }
 
-TEST_F(Draw_FontsProviderQtTests, DISABLED_horizontalAdvance_String)
+TEST_F(Draw_FontsProviderQtTests, horizontalAdvance_String)
 {
     Env env;
     Font f(u"Edwin", Font::Type::Text);


### PR DESCRIPTION
This PR fixes `horizontalAdvance(string)` behavior for strings containing `\n`. horizontalAdvance_String tests were green for all test strings except string contatning '\n'

Qt handles multi-line text through text layout APIs / boundingRect overloads with layout flags, not through the simple QFontMetricsF::horizontalAdvance(QString) metric call.(for example `QFontMetrics::boundingRect(const QRect& rect, int flags, const QString& text, ...)` )

Our FreeType provider previously shaped the whole string as-is, so `\n` could contribute its own glyph advance and make the result significantly wider than Qt. The implementation now splits text by available font faces and skips blocks that have no matching font face, so `\n` no longer contributes to the advance.

This matches the Qt font metrics API behavior. In engraving, newline handling happens at the layout level, not inside `FontProvider::horizontalAdvance(string)` that's why we haven't notices that difference.

before: FPrivider  =  2572.724375
after:  FPrivider  =    2399.499375
QProvider:                2399.531250

difference 0.032 px or 0.0013% which is enough