### PR TITLE
transform playback actions to commands

### DIFF
--- a/framework/audio/main/internal/transporteventscontroller.cpp
+++ b/framework/audio/main/internal/transporteventscontroller.cpp
@@ -23,6 +23,7 @@
 #include "transporteventscontroller.h"
 
 #include "audio/common/audiosanitizer.h"
+#include "rcommand/commandtypes.h"
 
 using namespace muse::audio;
 using namespace muse::audio::rpc;
@@ -58,18 +59,18 @@ void TransportEventsController::onEventReceived(const TransportEvent& event)
 
     switch (event.type) {
     case TransportEvent::Type::Play:
-        dispatcher()->dispatch("play");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/play"));
         break;
     case TransportEvent::Type::Pause:
-        dispatcher()->dispatch("pause");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/pause"));
         break;
     case TransportEvent::Type::Stop:
-        dispatcher()->dispatch("stop");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/stop"));
         break;
     case TransportEvent::Type::Seek:
         if (std::holds_alternative<TransportEvent::SeekData>(event.data)) {
             const secs_t pos = std::get<TransportEvent::SeekData>(event.data).position;
-            dispatcher()->dispatch("rewind", ActionData::make_arg1<secs_t>(pos));
+            commandDispatcher()->dispatch(rcommand::make_query("command://playback/rewind", { { "position", Val(pos) } }));
         }
         break;
     case TransportEvent::Type::Unknown:

--- a/framework/audio/main/internal/transporteventscontroller.h
+++ b/framework/audio/main/internal/transporteventscontroller.h
@@ -25,13 +25,13 @@
 #include "modularity/ioc.h"
 
 #include "audio/common/rpc/irpcchannel.h"
-#include "actions/iactionsdispatcher.h"
+#include "rcommand/icommanddispatcher.h"
 
 namespace muse::audio {
 class TransportEventsController : public async::Asyncable, public Contextable
 {
     GlobalInject<rpc::IRpcChannel> channel;
-    ContextInject<actions::IActionsDispatcher> dispatcher = { this };
+    ContextInject<rcommand::ICommandDispatcher> commandDispatcher = { this };
 
 public:
     TransportEventsController(const muse::modularity::ContextPtr& iocCtx)

--- a/framework/global/stringutils.cpp
+++ b/framework/global/stringutils.cpp
@@ -196,13 +196,47 @@ bool muse::strings::startsWith(const std::string& str, const std::string& start)
     return true;
 }
 
+bool muse::strings::startsWith(const std::string& str, const std::string_view& start)
+{
+    if (str.size() < start.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < start.size(); ++i) {
+        if (str.at(i) != start.at(i)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool muse::strings::startsWith(const std::string& str, const char* start)
+{
+    return startsWith(str, std::string_view(start));
+}
+
 bool muse::strings::endsWith(const std::string& str, const std::string& ending)
 {
     if (ending.size() > str.size()) {
         return false;
     }
     std::string ss = str.substr(str.size() - ending.size());
-    return ss.compare(ending.c_str()) == 0;
+    return ss == ending;
+}
+
+bool muse::strings::endsWith(const std::string& str, const std::string_view& ending)
+{
+    if (ending.size() > str.size()) {
+        return false;
+    }
+    std::string ss = str.substr(str.size() - ending.size());
+    return ss == ending;
+}
+
+bool muse::strings::endsWith(const std::string& str, const char* end)
+{
+    return endsWith(str, std::string_view(end));
 }
 
 std::string muse::strings::leftJustified(const std::string& val, size_t width)

--- a/framework/global/stringutils.h
+++ b/framework/global/stringutils.h
@@ -40,7 +40,11 @@ void trim(std::string& s);
 
 std::string toLower(const std::string& source);
 bool startsWith(const std::string& str, const std::string& start);
+bool startsWith(const std::string& str, const std::string_view& start);
+bool startsWith(const std::string& str, const char* start);
 bool endsWith(const std::string& str, const std::string& end);
+bool endsWith(const std::string& str, const std::string_view& end);
+bool endsWith(const std::string& str, const char* end);
 std::string leftJustified(const std::string& val, size_t width);
 
 // Locale-independent version of std::to_string

--- a/framework/global/types/val.h
+++ b/framework/global/types/val.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <map>
 
+#include "number.h"
 #include "io/path.h"
 
 #ifndef NO_QT_SUPPORT
@@ -62,6 +63,9 @@ public:
     explicit Val(int val);
     explicit Val(int64_t val);
     explicit Val(double val);
+    template<typename T>
+    explicit Val(number_t<T> val)
+        : Val{val.raw()} {}
     explicit Val(const std::string& str);
     explicit Val(const char* str);
     explicit Val(const io::path_t& path);

--- a/framework/midiremote/internal/midiremote.cpp
+++ b/framework/midiremote/internal/midiremote.cpp
@@ -26,10 +26,9 @@
 #include "global/io/buffer.h"
 #include "global/serialization/xmlstreamreader.h"
 #include "global/serialization/xmlstreamwriter.h"
+#include "global/stringutils.h"
 
 #include "multiwindows/resourcelockguard.h"
-
-#include "actions/actiontypes.h"
 
 #include "log.h"
 
@@ -132,6 +131,11 @@ Ret MidiRemote::process(const Event& ev)
 
     for (const MidiControlsMapping& midiMapping : m_midiMappings) {
         if (midiMapping.event == event) {
+            if (muse::strings::startsWith(midiMapping.action, rcommand::COMMAND_SCHEME)) {
+                commandDispatcher()->dispatch(rcommand::Command(midiMapping.action));
+            } else {
+                dispatcher()->dispatch(midiMapping.action);
+            }
             dispatcher()->dispatch(midiMapping.action);
             return make_ret(Ret::Code::Ok);
         }
@@ -289,18 +293,18 @@ void MidiRemote::processMMC(const MMCMessage& msg)
 {
     switch (msg.command) {
     case MMCCommand::Play:
-        dispatcher()->dispatch("play");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/play"));
         break;
     case MMCCommand::Pause:
-        dispatcher()->dispatch("pause");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/pause"));
         break;
     case MMCCommand::Stop:
-        dispatcher()->dispatch("stop");
+        commandDispatcher()->dispatch(rcommand::Command("command://playback/stop"));
         break;
     case MMCCommand::Locate: {
         const std::optional<double> pos = m_mmcDecoder->locateToSeconds(msg);
         if (pos.has_value()) {
-            dispatcher()->dispatch("rewind", actions::ActionData::make_arg1<secs_t>(pos.value()));
+            commandDispatcher()->dispatch(rcommand::make_query("command://playback/rewind", { { "position", Val(pos.value()) } }));
         }
     } break;
     default: break;

--- a/framework/midiremote/internal/midiremote.h
+++ b/framework/midiremote/internal/midiremote.h
@@ -30,6 +30,7 @@
 #include "io/ifilesystem.h"
 #include "actions/iactionsdispatcher.h"
 #include "multiwindows/imultiwindowsprovider.h"
+#include "rcommand/icommanddispatcher.h"
 
 #include "midiremote/immcdecoderfactory.h"
 
@@ -46,7 +47,7 @@ class MidiRemote : public IMidiRemote, public Contextable, public async::Asyncab
     GlobalInject<mi::IMultiWindowsProvider> multiwindowsProvider;
     GlobalInject<IMMCDecoderFactory> mmcDecoderFactory;
     ContextInject<muse::actions::IActionsDispatcher> dispatcher = { this };
-
+    ContextInject<rcommand::ICommandDispatcher> commandDispatcher = { this };
 public:
     MidiRemote(const modularity::ContextPtr& iocCtx)
         : Contextable(iocCtx) {}

--- a/framework/midiremote/qml/Muse/MidiRemote/mididevicemappingmodel.cpp
+++ b/framework/midiremote/qml/Muse/MidiRemote/mididevicemappingmodel.cpp
@@ -22,11 +22,9 @@
 
 #include "mididevicemappingmodel.h"
 
-#include "ui/view/iconcodes.h"
-#include "shortcuts/shortcutstypes.h"
+#include "translation.h"
 
 #include "log.h"
-#include "translation.h"
 
 using namespace muse::midi;
 using namespace muse::midiremote;
@@ -40,13 +38,13 @@ static const QString ENABLED_KEY("enabled");
 static const QString MAPPED_TYPE_KEY("mappedType");
 static const QString MAPPED_VALUE_KEY("mappedValue");
 
-inline ActionCodeList allMidiActions()
+inline static ActionCodeList allMidiActions()
 {
     return {
-        "rewind",
-        "loop",
-        "play",
-        "stop",
+        "command://playback/rewind",
+        "command://playback/loop",
+        "command://playback/play",
+        "command://playback/stop",
         "note-input",
         "pad-note-1",
         "pad-note-2",

--- a/framework/rcommand/commandtypes.h
+++ b/framework/rcommand/commandtypes.h
@@ -37,6 +37,15 @@ constexpr std::string_view COMMAND_SCHEME = "command://";
 using Command = Uri;
 using CommandQuery = UriQuery;
 
+inline CommandQuery make_query(const std::string& command, const std::vector<std::pair<std::string, Val> >& params)
+{
+    CommandQuery query(command);
+    for (const auto& param : params) {
+        query.addParam(param.first, param.second);
+    }
+    return query;
+}
+
 // Info
 
 enum class DataType {
@@ -55,6 +64,10 @@ struct Arg {
     String description;
     Val min;
     Val max;
+
+    Arg() = default;
+    Arg(DataType type, const String& description, const Val& min = Val(), const Val& max = Val())
+        : type(type), description(description), min(min), max(max) {}
 };
 
 struct InputSchema {
@@ -76,6 +89,8 @@ struct Decoration {
         : iconCode(iconCode) {}
     Decoration(ui::IconCode::Code iconCode, Color iconColor)
         : iconCode(iconCode), iconColor(iconColor) {}
+    Decoration(ui::IconCode::Code iconCode, Checkable checkable)
+        : iconCode(iconCode), checkable(checkable) {}
     Decoration(ui::IconCode::Code iconCode, Color iconColor, Checkable checkable)
         : iconCode(iconCode), iconColor(iconColor), checkable(checkable) {}
 };
@@ -87,6 +102,8 @@ struct CommandInfo
     TranslatableString description;
     InputSchema inputSchema;
     Decoration decoration;
+
+    bool isValid() const { return command.isValid(); }
 };
 
 struct CommandState {

--- a/framework/rcommand/icommanddispatcher.h
+++ b/framework/rcommand/icommanddispatcher.h
@@ -34,10 +34,13 @@ public:
     virtual ~ICommandDispatcher() = default;
 
     using CallBack = std::function<Response (const Request& request)>;
+    using CallBackRet = std::function<Ret ()>;
 
     virtual async::Promise<Response> dispatch(const Request& request) = 0;
     virtual void onRequest(Commandable* client, const Command& command, const CallBack& callback) = 0;
     virtual void unreg(Commandable* client) = 0;
+
+    // Helpers for convenience
 
     async::Promise<Response> dispatch(const CommandQuery& query)
     {
@@ -47,6 +50,13 @@ public:
     async::Promise<Response> dispatch(const Command& query)
     {
         return dispatch(CommandQuery(query));
+    }
+
+    void onRequest(Commandable* client, const Command& command, const CallBackRet& callback)
+    {
+        onRequest(client, command, [callback](const Request& request) {
+            return make_response(request, callback());
+        });
     }
 };
 }

--- a/framework/rcommand/icommandsregister.h
+++ b/framework/rcommand/icommandsregister.h
@@ -36,6 +36,7 @@ public:
     virtual IModuleCommandsRegisterPtr moduleRegister(const std::string& moduleName) const = 0;
 
     virtual std::vector<CommandInfo> commandInfoList() const = 0;
+    virtual const CommandInfo& commandInfo(const Command& command) const = 0;
 
     virtual const std::string& commandModuleName(const Command& command) const = 0;
 };

--- a/framework/rcommand/internal/commandsregister.cpp
+++ b/framework/rcommand/internal/commandsregister.cpp
@@ -85,6 +85,21 @@ std::vector<CommandInfo> CommandsRegister::commandInfoList() const
     return commands;
 }
 
+const CommandInfo& CommandsRegister::commandInfo(const Command& command) const
+{
+    for (const auto& module : m_modules) {
+        const auto& infos = module.second->commandInfoList();
+        for (const auto& info : infos) {
+            if (info.command == command) {
+                return info;
+            }
+        }
+    }
+
+    static CommandInfo null;
+    return null;
+}
+
 const std::string& CommandsRegister::commandModuleName(const Command& command) const
 {
     auto it = m_commandModuleNames.find(command);

--- a/framework/rcommand/internal/commandsregister.h
+++ b/framework/rcommand/internal/commandsregister.h
@@ -34,6 +34,7 @@ public:
     IModuleCommandsRegisterPtr moduleRegister(const std::string& moduleName) const override;
 
     std::vector<CommandInfo> commandInfoList() const override;
+    const CommandInfo& commandInfo(const Command& command) const override;
 
     const std::string& commandModuleName(const Command& command) const override;
 

--- a/framework/shortcuts/internal/commandshortcutsregister.cpp
+++ b/framework/shortcuts/internal/commandshortcutsregister.cpp
@@ -30,28 +30,6 @@ using namespace muse::async;
 
 static const std::string COMMAND_SHORTCUTS_TAG("CommandShortcuts");
 
-static const std::map<QKeySequence::StandardKey, QKeyCombination> COMMAND_SHORTCUTS_EXPAND_IGNORE_MAP = {
-    { QKeySequence::StandardKey::HelpContents, Qt::Key_Help },
-    { QKeySequence::StandardKey::Open, Qt::Key_Open },
-    { QKeySequence::StandardKey::Close, Qt::Key_Close },
-    { QKeySequence::StandardKey::Save, Qt::Key_Save },
-    { QKeySequence::StandardKey::New, Qt::Key_New },
-    { QKeySequence::StandardKey::Cut, Qt::Key_Cut },
-    { QKeySequence::StandardKey::Copy, Qt::Key_Copy },
-    { QKeySequence::StandardKey::Paste, Qt::Key_Paste },
-    { QKeySequence::StandardKey::Undo, Qt::Key_Undo },
-    { QKeySequence::StandardKey::Redo, Qt::Key_Redo },
-    { QKeySequence::StandardKey::Forward, Qt::Key_Forward },
-    { QKeySequence::StandardKey::Refresh, Qt::Key_Refresh },
-    { QKeySequence::StandardKey::ZoomIn, Qt::Key_ZoomIn },
-    { QKeySequence::StandardKey::ZoomOut, Qt::Key_ZoomOut },
-    { QKeySequence::StandardKey::Find, Qt::Key_Find },
-    { QKeySequence::StandardKey::SaveAs, (Qt::SHIFT | Qt::Key_Save) },
-    { QKeySequence::StandardKey::Preferences, Qt::Key_Settings },
-    { QKeySequence::StandardKey::Quit, Qt::Key_Exit },
-    { QKeySequence::StandardKey::Cancel, Qt::Key_Cancel }
-};
-
 void CommandShortcutsRegister::init()
 {
     multiwindowsProvider()->resourceChanged().onReceive(this, [this](const std::string& resourceName) {
@@ -76,8 +54,6 @@ void CommandShortcutsRegister::reload(bool onlyDef)
     bool ok = readFromFile(m_defaultShortcuts, defPath);
 
     if (ok) {
-        expandStandardKeys(m_defaultShortcuts);
-
         if (!onlyDef) {
             if (!io::File::exists(userPath)) {
                 ok = false;
@@ -101,7 +77,6 @@ void CommandShortcutsRegister::reload(bool onlyDef)
     }
 
     if (ok) {
-        expandStandardKeys(m_shortcuts);
         makeUnique(m_shortcuts);
         m_shortcutsChanged.notify();
     }
@@ -176,64 +151,6 @@ void CommandShortcutsRegister::makeUnique(ShortcutList& shortcuts)
         }
 
         foundSc.sequences.insert(foundSc.sequences.end(), sc.sequences.begin(), sc.sequences.end());
-    }
-}
-
-void CommandShortcutsRegister::expandStandardKeys(ShortcutList& shortcuts) const
-{
-    TRACEFUNC;
-
-    ShortcutList expanded;
-    ShortcutList notbonded;
-
-    for (Shortcut& shortcut : shortcuts) {
-        QKeySequence ignoredSeq = QKeySequence(muse::value(COMMAND_SHORTCUTS_EXPAND_IGNORE_MAP, shortcut.standardKey, Qt::Key_unknown));
-
-        if (!shortcut.sequences.empty()) {
-            std::string ignoredSeqStr = ignoredSeq.toString().toStdString();
-            muse::remove_if(shortcut.sequences, [&ignoredSeqStr](const std::string& seq) {
-                return seq == ignoredSeqStr;
-            });
-
-            continue;
-        }
-
-        QList<QKeySequence> kslist = QKeySequence::keyBindings(shortcut.standardKey);
-        if (kslist.isEmpty()) {
-            notbonded.push_back(shortcut);
-            continue;
-        }
-
-        const QKeySequence& first = kslist.first();
-        shortcut.sequences.push_back(first.toString().toStdString());
-        //LOGD() << "for standard key: " << sc.standardKey << ", sequence: " << sc.sequence;
-
-        //! NOTE If the keyBindings contains more than one result,
-        //! these can be considered alternative shortcuts on the same platform for the given key.
-        for (int i = 1; i < kslist.count(); ++i) {
-            const QKeySequence& seq = kslist.at(i);
-            if (seq == ignoredSeq) {
-                continue;
-            }
-
-            Shortcut esc = shortcut;
-            esc.sequences = { seq.toString().toStdString() };
-            //LOGD() << "for standard key: " << esc.standardKey << ", alternative sequence: " << esc.sequence;
-            expanded.push_back(esc);
-        }
-    }
-
-    if (!notbonded.empty()) {
-        LOGD() << "removed " << notbonded.size() << " shortcut, because they are not bound to standard key";
-        for (const Shortcut& sc : notbonded) {
-            shortcuts.remove(sc);
-        }
-    }
-
-    if (!expanded.empty()) {
-        LOGD() << "added " << expanded.size() << " shortcut, because they are alternative shortcuts for the given standard keys";
-
-        shortcuts.splice(shortcuts.end(), expanded);
     }
 }
 

--- a/framework/shortcuts/internal/commandshortcutsregister.h
+++ b/framework/shortcuts/internal/commandshortcutsregister.h
@@ -69,7 +69,6 @@ private:
     void mergeAdditionalShortcuts(ShortcutList& shortcuts);
 
     void makeUnique(ShortcutList& shortcuts);
-    void expandStandardKeys(ShortcutList& shortcuts) const;
 
     ShortcutList filterAndUpdateAdditionalShortcuts(const ShortcutList& shortcuts);
 

--- a/framework/ui/internal/uiactionsregister.cpp
+++ b/framework/ui/internal/uiactionsregister.cpp
@@ -22,6 +22,7 @@
 #include "uiactionsregister.h"
 
 #include "global/async/async.h"
+#include "global/stringutils.h"
 
 #include "muse_framework_config.h"
 
@@ -43,6 +44,10 @@ void UiActionsRegister::init()
             requestUpdateEnabledAll();
         });
     }
+
+    commandsState()->commandStateChanged().onReceive(this, [this](const rcommand::Command& command, const rcommand::CommandState&) {
+        m_actionStateChanged.send({ command.toString() });
+    });
 }
 
 void UiActionsRegister::reg(const IUiActionsModulePtr& module)
@@ -129,6 +134,31 @@ std::vector<UiAction> UiActionsRegister::actionList() const
 
 const UiAction& UiActionsRegister::action(const ActionCode& code) const
 {
+    if (muse::strings::startsWith(code, rcommand::COMMAND_SCHEME)) {
+        auto it = m_commandActions.find(code);
+        if (it != m_commandActions.end()) {
+            return it->second;
+        }
+
+        const rcommand::CommandInfo& info = commandsRegister()->commandInfo(rcommand::Command(code));
+        if (!info.isValid()) {
+            LOGE() << "not valid command: " << code;
+            static UiAction null;
+            return null;
+        }
+
+        UiAction action;
+        action.code = code;
+        action.title = info.title;
+        action.description = info.description;
+        action.iconCode = info.decoration.iconCode;
+        action.iconColor = QString::fromStdString(info.decoration.iconColor.toString());
+        action.checkable = static_cast<Checkable>(info.decoration.checkable);
+
+        it = m_commandActions.emplace(code, action).first;
+        return it->second;
+    }
+
     return info(code).action;
 }
 
@@ -151,6 +181,11 @@ async::Channel<UiActionList> UiActionsRegister::actionsChanged() const
 
 UiActionState UiActionsRegister::actionState(const ActionCode& code) const
 {
+    if (muse::strings::startsWith(code, rcommand::COMMAND_SCHEME)) {
+        const rcommand::CommandState& state = commandsState()->commandState(rcommand::Command(code));
+        return UiActionState { state.enabled, state.checked };
+    }
+
     const Info& inf = info(code);
     if (!inf.action.isValid()) {
         LOGE() << "not found action with code: " << code;

--- a/framework/ui/internal/uiactionsregister.h
+++ b/framework/ui/internal/uiactionsregister.h
@@ -30,9 +30,14 @@
 #include "iuicontextresolver.h"
 #include "async/asyncable.h"
 
+#include "rcommand/icommandsregister.h"
+#include "rcommand/icommandsstate.h"
+
 namespace muse::ui {
 class UiActionsRegister : public IUiActionsRegister, public Contextable, public async::Asyncable
 {
+    GlobalInject<rcommand::ICommandsRegister> commandsRegister;
+    ContextInject<rcommand::ICommandsState> commandsState = { this };
     ContextInject<IUiContextResolver> uicontextResolver = { this };
 
 public:
@@ -83,6 +88,7 @@ private:
     void updateChecked(const actions::ActionCodeList& codes);
 
     std::unordered_map<actions::ActionCode, Info> m_actions;
+    mutable std::unordered_map<actions::ActionCode, UiAction> m_commandActions;
     async::Channel<UiActionList> m_actionsChanged;
     async::Channel<actions::ActionCodeList> m_actionStateChanged;
 

--- a/framework/uicomponents/qml/Muse/UiComponents/abstractmenumodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/abstractmenumodel.cpp
@@ -21,6 +21,7 @@
  */
 #include "abstractmenumodel.h"
 
+#include "thirdparty/kors_logger/src/log_base.h"
 #include "types/translatablestring.h"
 
 #include "log.h"
@@ -86,11 +87,22 @@ void AbstractMenuModel::handleMenuItem(const QString& itemId)
 
 void AbstractMenuModel::dispatch(const ActionCode& actionCode, const ActionData& args)
 {
+    if (muse::strings::startsWith(actionCode, "command://")) {
+        DO_ASSERT(args.empty());
+        commandDispatcher()->dispatch(rcommand::Command(actionCode));
+        return;
+    }
+
     dispatcher()->dispatch(actionCode, args);
 }
 
 void AbstractMenuModel::dispatch(const muse::actions::ActionQuery& actionQuery)
 {
+    if (actionQuery.uri().scheme() == "command") {
+        commandDispatcher()->dispatch(actionQuery);
+        return;
+    }
+
     dispatcher()->dispatch(actionQuery);
 }
 

--- a/framework/uicomponents/qml/Muse/UiComponents/abstractmenumodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/abstractmenumodel.h
@@ -32,6 +32,7 @@
 #include "ui/iuiactionsregister.h"
 #include "shortcuts/ishortcutsregister.h"
 #include "actions/iactionsdispatcher.h"
+#include "rcommand/icommanddispatcher.h"
 
 namespace muse::uicomponents {
 class AbstractMenuModel : public QAbstractListModel, public muse::Contextable, public async::Asyncable
@@ -47,6 +48,7 @@ public:
     muse::ContextInject<ui::IUiActionsRegister> uiActionsRegister = { this };
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher = { this };
     muse::ContextInject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
+    muse::ContextInject<rcommand::ICommandDispatcher> commandDispatcher = { this };
 
 public:
     explicit AbstractMenuModel(QObject* parent = nullptr);


### PR DESCRIPTION
MSS: https://github.com/musescore/MuseScore/pull/34048

Main ideas:
* Command constants have appeared (I didn't want to introduce them for a long time, but it's still convenient and clear) 
* Now the state is calculated only in PlaybackCommandsState  (enabled, checked)
* Now the toolbar settings are located in the toolbar model 
* Command handlers should now return a result (Ret). This may change slightly in the future, but I noticed a couple of asynchronous handlers (questions for the user are being asked). 
 * Now, only the commands listed in shortcuts.json will be available in the shortcut list (previously, all non-disabled commands were available). 
* The shortcut system will be further developed. The main idea is that the scope (global, page, panel) will be specified. This will solve a number of issues.