### PR TITLE
fixed build on mac

### DIFF
--- a/framework/midi/CMakeLists.txt
+++ b/framework/midi/CMakeLists.txt
@@ -49,6 +49,14 @@ if (OS_IS_MAC)
         internal/platform/osx/coremidiinport.h
     )
 
+    set_source_files_properties(
+        internal/platform/osx/coremidioutport.cpp
+        internal/platform/osx/coremidiinport.cpp
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+        SKIP_PRECOMPILE_HEADERS ON
+    )
+
     find_library(CoreMIDI NAMES CoreMIDI)
     find_library(CoreAudio NAMES CoreAudio)
     target_link_libraries(muse_midi PRIVATE ${CoreMIDI} ${CoreAudio})


### PR DESCRIPTION
compile error like this 

```
/Applications/Xcode_26.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/host_info.h:77:9: error: reference to 'integer_t' is ambiguous
   77 | typedef integer_t       *host_info_t;           /* varying array of int. */
      |         ^
/Applications/Xcode_26.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/arm/vm_types.h:97:33: note: candidate found by name lookup is 'integer_t'
   97 | typedef int                     integer_t;
      |                                 ^
../muse/framework/global/types/number.h:137:7: note: candidate found by name lookup is 'muse::integer_t'
  137 | using integer_t = number_t<int>;
      |       ^
In file included from muse/framework/midi/CMakeFiles/muse_midi.dir/Unity/unity_0_cxx.cxx:22:
In file included from /Users/runner/work/MuseScore/MuseScore/muse/framework/midi/internal/platform/osx/coremidioutport.cpp:25:
```