### PR TITLE
UIComponents. StyledMenu. Scroll improvements

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/internal/ArrowScrollButton.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/ArrowScrollButton.qml
@@ -27,8 +27,7 @@ FlatButton {
     property bool isScrollUp: false
     property Flickable view: null
 
-    visible: enabled && (isScrollUp ? (view.contentY !== 0)
-                                    : (view.contentY !== view.contentHeight - view.height))
+    visible: enabled && (isScrollUp ? !view.atYBeginning : !view.atYEnd)
 
     mouseArea.onContainsMouseChanged: {
         if (!mouseArea.containsMouse) {
@@ -74,17 +73,10 @@ FlatButton {
         interval: 20
         onTriggered: {
             if (isScrollUp) {
-                if (root.view.contentY - scrollStep <= 0) {
-                    root.view.contentY = 0
-                } else {
-                    root.view.contentY -= scrollStep
-                }
+                root.view.contentY = Math.max(root.view.contentY - scrollStep, root.view.originY)
             } else {
-                if (root.view.contentY + scrollStep + root.view.height >= root.view.contentHeight) {
-                    root.view.contentY = root.view.contentHeight - root.view.height
-                } else {
-                    root.view.contentY += scrollStep
-                }
+                root.view.contentY = Math.min(root.view.contentY + scrollStep,
+                                              root.view.originY + root.view.contentHeight - root.view.height)
             }
         }
     }

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -532,6 +532,8 @@ MenuView {
                                 }
                             }
 
+                            item.navigation.requestActive()
+
                             root.subMenuLoader.parent = item
                             root.subMenuLoader.open(subMenuItems)
                         }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll button behavior so it shows and hides more reliably at the start and end of scrolling.
  * Refined scroll movement to better respect content boundaries, including cases where scrolling starts from a non-zero offset.
  * Ensured menu items receive focus before a submenu opens, improving keyboard and navigation behavior in menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->