### PR TITLE
PolylinePlot refactoring

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -48,6 +48,8 @@ qt_add_qml_module(muse_uicomponents_qml
         iconview.h
         internal/focuslistener.cpp
         internal/focuslistener.h
+        internal/polylinepointstyle.h
+        internal/polylinepointstyle.cpp
         internal/popupviewclosecontroller.cpp
         internal/popupviewclosecontroller.h
         internal/tableviewheader.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.cpp
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "polylinepointstyle.h"
+
+using namespace muse::uicomponents;
+
+PolylinePointStyle::PolylinePointStyle(QObject* parent)
+    : QObject(parent)
+{
+}
+
+qreal PolylinePointStyle::centerRadius() const
+{
+    return m_centerRadius;
+}
+
+void PolylinePointStyle::setCenterRadius(qreal r)
+{
+    if (m_centerRadius == r) {
+        return;
+    }
+
+    m_centerRadius = r;
+    emit styleChanged();
+}
+
+QColor PolylinePointStyle::centerColor() const
+{
+    return m_centerColor;
+}
+
+void PolylinePointStyle::setCenterColor(const QColor& c)
+{
+    if (m_centerColor == c) {
+        return;
+    }
+
+    m_centerColor = c;
+    emit styleChanged();
+}
+
+qreal PolylinePointStyle::middleRingWidth() const
+{
+    return m_middleRingWidth;
+}
+
+void PolylinePointStyle::setMiddleRingWidth(qreal r)
+{
+    if (m_middleRingWidth == r) {
+        return;
+    }
+
+    m_middleRingWidth = r;
+    emit styleChanged();
+}
+
+QColor PolylinePointStyle::middleRingColor() const
+{
+    return m_middleRingColor;
+}
+
+void PolylinePointStyle::setMiddleRingColor(const QColor& c)
+{
+    if (m_middleRingColor == c) {
+        return;
+    }
+
+    m_middleRingColor = c;
+    emit styleChanged();
+}
+
+qreal PolylinePointStyle::outlineWidth() const
+{
+    return m_outlineWidth;
+}
+
+void PolylinePointStyle::setOutlineWidth(qreal w)
+{
+    if (m_outlineWidth == w) {
+        return;
+    }
+
+    m_outlineWidth = w;
+    emit styleChanged();
+}
+
+QColor PolylinePointStyle::outlineColor() const
+{
+    return m_outlineColor;
+}
+
+void PolylinePointStyle::setOutlineColor(const QColor& c)
+{
+    if (m_outlineColor == c) {
+        return;
+    }
+
+    m_outlineColor = c;
+    emit styleChanged();
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QColor>
+
+namespace muse::uicomponents {
+class PolylinePointStyle : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(qreal centerRadius READ centerRadius WRITE setCenterRadius NOTIFY styleChanged)
+    Q_PROPERTY(QColor centerColor READ centerColor WRITE setCenterColor NOTIFY styleChanged)
+
+    Q_PROPERTY(qreal middleRingWidth READ middleRingWidth WRITE setMiddleRingWidth NOTIFY styleChanged)
+    Q_PROPERTY(QColor middleRingColor READ middleRingColor WRITE setMiddleRingColor NOTIFY styleChanged)
+
+    Q_PROPERTY(qreal outlineWidth READ outlineWidth WRITE setOutlineWidth NOTIFY styleChanged)
+    Q_PROPERTY(QColor outlineColor READ outlineColor WRITE setOutlineColor NOTIFY styleChanged)
+
+public:
+    explicit PolylinePointStyle(QObject* parent = nullptr);
+
+    qreal centerRadius() const;
+    void setCenterRadius(qreal);
+
+    QColor centerColor() const;
+    void setCenterColor(const QColor&);
+
+    qreal middleRingWidth() const;
+    void setMiddleRingWidth(qreal);
+
+    QColor middleRingColor() const;
+    void setMiddleRingColor(const QColor&);
+
+    qreal outlineWidth() const;
+    void setOutlineWidth(qreal);
+
+    QColor outlineColor() const;
+    void setOutlineColor(const QColor&);
+
+signals:
+    void styleChanged();
+
+private:
+    qreal m_centerRadius = 3.0;
+    QColor m_centerColor;
+
+    qreal m_middleRingWidth = 0.0;
+    QColor m_middleRingColor;
+
+    qreal m_outlineWidth = 0.0;
+    QColor m_outlineColor;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -142,6 +142,21 @@ PolylinePlot::PolylinePlot(QQuickItem* parent)
 
     setAntialiasing(true);
     setOpaquePainting(false);
+
+    m_standardPointStyle = new PolylinePointStyle(this);
+    QObject::connect(m_standardPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
+        update();
+    });
+
+    m_hoveredPointStyle = new PolylinePointStyle(this);
+    QObject::connect(m_hoveredPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
+        update();
+    });
+
+    m_ghostPointStyle = new PolylinePointStyle(this);
+    QObject::connect(m_ghostPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
+        update();
+    });
 }
 
 void PolylinePlot::init()
@@ -155,6 +170,21 @@ void PolylinePlot::init()
         m_hoveredOnLine = false;
         resetGestureState();
     });
+}
+
+PolylinePointStyle* PolylinePlot::standardPointStyle()
+{
+    return m_standardPointStyle;
+}
+
+PolylinePointStyle* PolylinePlot::hoveredPointStyle()
+{
+    return m_hoveredPointStyle;
+}
+
+PolylinePointStyle* PolylinePlot::ghostPointStyle()
+{
+    return m_ghostPointStyle;
 }
 
 QColor PolylinePlot::lineColor() const
@@ -224,100 +254,6 @@ void PolylinePlot::setBaselineN(qreal v)
     emit baselineNChanged();
 
     update();
-}
-
-qreal PolylinePlot::pointRadius() const
-{
-    return m_pointRadius;
-}
-
-void PolylinePlot::setPointRadius(qreal r)
-{
-    if (m_pointRadius == r) {
-        return;
-    }
-
-    m_pointRadius = r;
-    emit pointRadiusChanged();
-
-    update();
-}
-
-qreal PolylinePlot::ghostPointRadius() const
-{
-    return m_ghostPointRadius;
-}
-
-void PolylinePlot::setGhostPointRadius(qreal r)
-{
-    if (m_ghostPointRadius == r) {
-        return;
-    }
-
-    m_ghostPointRadius = r;
-    emit ghostPointRadiusChanged();
-
-    update();
-}
-
-qreal PolylinePlot::pointOutlineWidth() const
-{
-    return m_pointOutlineWidth;
-}
-
-void PolylinePlot::setPointOutlineWidth(qreal w)
-{
-    if (m_pointOutlineWidth == w) {
-        return;
-    }
-
-    m_pointOutlineWidth = w;
-    emit pointOutlineWidthChanged();
-}
-
-QColor PolylinePlot::pointOutlineColor() const
-{
-    return m_pointOutlineColor;
-}
-
-void PolylinePlot::setPointOutlineColor(const QColor& c)
-{
-    if (m_pointOutlineColor == c) {
-        return;
-    }
-
-    m_pointOutlineColor = c;
-    emit pointOutlineColorChanged();
-}
-
-QColor PolylinePlot::pointCentreColor() const
-{
-    return m_pointCentreColor;
-}
-
-void PolylinePlot::setPointCentreColor(const QColor& c)
-{
-    if (m_pointCentreColor == c) {
-        return;
-    }
-
-    m_pointCentreColor = c;
-    emit pointCentreColorChanged();
-}
-
-QColor PolylinePlot::ghostPointOutlineColor() const
-{
-    return m_ghostPointOutlineColor;
-}
-
-void PolylinePlot::setGhostPointOutlineColor(const QColor& c)
-{
-    if (m_ghostPointOutlineColor == c) {
-        return;
-    }
-
-    m_ghostPointOutlineColor = c;
-    emit ghostPointOutlineColorChanged();
 }
 
 qreal PolylinePlot::hitRadius() const
@@ -1091,6 +1027,46 @@ void PolylinePlot::geometryChange(const QRectF& newG, const QRectF& oldG)
     }
 }
 
+void PolylinePlot::paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre) const
+{
+    IF_ASSERT_FAILED(painter && style) {
+        return;
+    }
+
+    const qreal centerRadius = style->centerRadius();
+    const qreal middleRingWidth = style->middleRingWidth();
+    const qreal outlineWidth = style->outlineWidth();
+
+    if (middleRingWidth > 0.0) {
+        const qreal middleRadius = centerRadius + middleRingWidth;
+        const qreal outerRadius = middleRadius + outlineWidth;
+
+        painter->setPen(Qt::NoPen);
+
+        painter->setBrush(style->outlineColor());
+        painter->drawEllipse(centre, outerRadius, outerRadius);
+
+        painter->setBrush(style->middleRingColor());
+        painter->drawEllipse(centre, middleRadius, middleRadius);
+
+        painter->setBrush(style->centerColor());
+        painter->drawEllipse(centre, centerRadius, centerRadius);
+        return;
+    }
+
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(style->centerColor());
+    painter->drawEllipse(centre, centerRadius, centerRadius);
+
+    if (outlineWidth > 0.0) {
+        QPen pen(style->outlineColor());
+        pen.setWidthF(outlineWidth);
+        painter->setPen(pen);
+        painter->setBrush(Qt::NoBrush);
+        painter->drawEllipse(centre, centerRadius, centerRadius);
+    }
+}
+
 void PolylinePlot::paint(QPainter* painter)
 {
     if (!painter) {
@@ -1126,45 +1102,21 @@ void PolylinePlot::paint(QPainter* painter)
     }
 
     // draw points
-    painter->setPen(Qt::NoPen);
-    painter->setBrush(m_lineColor);
+    IF_ASSERT_FAILED(m_standardPointStyle && m_hoveredPointStyle && m_ghostPointStyle) {
+        return;
+    }
 
     const int n = m_pointsNVisible.size();
     const int hoveredIndex = pointIndexAtPx(m_hoverPx);
     for (int i = 0; i < n; ++i) {
         QPointF pN = m_pointsNVisible[i];
-        const QPointF c(toPxX(this, pN.x()), toPxY(this, pN.y()));
+        const QPointF centre(toPxX(this, pN.x()), toPxY(this, pN.y()));
 
         const int domainIdx
             =(i < m_visibleToDomainIndex.size()) ? m_visibleToDomainIndex[i] : INVALID_POINT_IDX;
         const bool isHovered = (domainIdx >= 0 && domainIdx == hoveredIndex);
-        if (isHovered) {
-            const qreal regularOuterRadius = m_pointRadius + (m_pointOutlineWidth * 0.5);
-            const qreal hoveredOuterRadius = regularOuterRadius + 1.0;
-
-            painter->setPen(Qt::NoPen);
-            painter->setBrush(m_pointOutlineColor);
-            painter->drawEllipse(c, hoveredOuterRadius, hoveredOuterRadius);
-
-            painter->setBrush(Qt::black);
-            painter->drawEllipse(c, m_pointRadius - 1.0, m_pointRadius - 1.0);
-
-            painter->setBrush(Qt::white);
-            painter->drawEllipse(c, m_pointRadius - 3.0, m_pointRadius - 3.0);
-        } else {
-            // fill
-            painter->setPen(Qt::NoPen);
-            painter->setBrush(m_pointCentreColor);
-            painter->drawEllipse(c, m_pointRadius, m_pointRadius);
-
-            // outline
-            QPen innerPen(m_pointOutlineColor);
-            innerPen.setWidthF(m_pointOutlineWidth);
-            painter->setPen(innerPen);
-            painter->setBrush(Qt::NoBrush);
-
-            painter->drawEllipse(c, m_pointRadius, m_pointRadius);
-        }
+        const PolylinePointStyle* style = isHovered ? m_hoveredPointStyle : m_standardPointStyle;
+        paintPoint(painter, style, centre);
     }
 
     // draw hover ghost point
@@ -1181,18 +1133,7 @@ void PolylinePlot::paint(QPainter* painter)
         }
 
         if (pointIndexAtPx(hp) < 0 && isNearLinePx(hp)) {
-            // fill
-            painter->setPen(Qt::NoPen);
-            painter->setBrush(m_ghostPointOutlineColor);
-            painter->drawEllipse(hp, m_ghostPointRadius, m_ghostPointRadius);
-
-            // outline
-            QPen innerPen(m_ghostPointOutlineColor);
-            innerPen.setWidthF(m_pointOutlineWidth);
-            painter->setPen(innerPen);
-            painter->setBrush(Qt::NoBrush);
-
-            painter->drawEllipse(hp, m_ghostPointRadius, m_ghostPointRadius);
+            paintPoint(painter, m_ghostPointStyle, hp);
         }
     }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
@@ -35,6 +35,8 @@
 #include "actions/iactionsdispatcher.h"
 #include "ui/iuiconfiguration.h"
 
+#include "internal/polylinepointstyle.h"
+
 // NOTE: all of fooN() function are normalized, returning 0..1 values
 
 namespace muse::uicomponents {
@@ -47,17 +49,15 @@ class PolylinePlot : public QQuickPaintedItem, public muse::async::Asyncable, pu
 {
     Q_OBJECT
 
+    Q_PROPERTY(PolylinePointStyle * standardPointStyle READ standardPointStyle CONSTANT)
+    Q_PROPERTY(PolylinePointStyle * hoveredPointStyle READ hoveredPointStyle CONSTANT)
+    Q_PROPERTY(PolylinePointStyle * ghostPointStyle READ ghostPointStyle CONSTANT)
+
     Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor NOTIFY lineColorChanged)
     Q_PROPERTY(qreal lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged)
     Q_PROPERTY(bool drawBackground READ drawBackground WRITE setDrawBackground NOTIFY drawBackgroundChanged)
     Q_PROPERTY(qreal baselineN READ baselineN WRITE setBaselineN NOTIFY baselineNChanged)
-    Q_PROPERTY(qreal pointRadius READ pointRadius WRITE setPointRadius NOTIFY pointRadiusChanged)
-    Q_PROPERTY(qreal ghostPointRadius READ ghostPointRadius WRITE setGhostPointRadius NOTIFY ghostPointRadiusChanged)
-    Q_PROPERTY(qreal pointOutlineWidth READ pointOutlineWidth WRITE setPointOutlineWidth NOTIFY pointOutlineWidthChanged)
-    Q_PROPERTY(QColor pointOutlineColor READ pointOutlineColor WRITE setPointOutlineColor NOTIFY pointOutlineColorChanged)
-    Q_PROPERTY(QColor pointCentreColor READ pointCentreColor WRITE setPointCentreColor NOTIFY pointCentreColorChanged)
-    Q_PROPERTY(
-        QColor ghostPointOutlineColor READ ghostPointOutlineColor WRITE setGhostPointOutlineColor NOTIFY ghostPointOutlineColorChanged)
+
     Q_PROPERTY(qreal hitRadius READ hitRadius WRITE setHitRadius NOTIFY hitRadiusChanged)
 
     Q_PROPERTY(bool isSnapEnabled READ isSnapEnabled WRITE setIsSnapEnabled NOTIFY isSnapEnabledChanged)
@@ -95,6 +95,10 @@ public:
 
     Q_INVOKABLE void init();
 
+    PolylinePointStyle* standardPointStyle();
+    PolylinePointStyle* hoveredPointStyle();
+    PolylinePointStyle* ghostPointStyle();
+
     QColor lineColor() const;
     void setLineColor(const QColor&);
 
@@ -106,24 +110,6 @@ public:
 
     qreal baselineN() const;
     void setBaselineN(qreal);
-
-    qreal pointRadius() const;
-    void setPointRadius(qreal);
-
-    qreal ghostPointRadius() const;
-    void setGhostPointRadius(qreal);
-
-    qreal pointOutlineWidth() const;
-    void setPointOutlineWidth(qreal);
-
-    QColor pointOutlineColor() const;
-    void setPointOutlineColor(const QColor&);
-
-    QColor pointCentreColor() const;
-    void setPointCentreColor(const QColor&);
-
-    QColor ghostPointOutlineColor() const;
-    void setGhostPointOutlineColor(const QColor&);
 
     qreal hitRadius() const;
     void setHitRadius(qreal);
@@ -174,12 +160,7 @@ signals:
     void lineWidthChanged();
     void drawBackgroundChanged();
     void baselineNChanged();
-    void pointRadiusChanged();
-    void ghostPointRadiusChanged();
-    void pointOutlineWidthChanged();
-    void pointOutlineColorChanged();
-    void pointCentreColorChanged();
-    void ghostPointOutlineColorChanged();
+
     void hitRadiusChanged();
     void isSnapEnabledChanged();
     void snapThresholdPxChanged();
@@ -242,16 +223,17 @@ private:
     QPointF snapToNeighbor(qreal dragPxX, QPointF pDomain) const;
     void updateActivePoint();
 
+    void paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre) const;
+
 private:
     QColor m_lineColor;
     qreal m_lineWidth = 1.0;
-    qreal m_baselineN =0.5;
-    qreal m_pointRadius = 3.0;
-    qreal m_ghostPointRadius = 3.0;
-    qreal m_pointOutlineWidth = 1.0;
-    QColor m_pointOutlineColor;
-    QColor m_pointCentreColor;
-    QColor m_ghostPointOutlineColor;
+    qreal m_baselineN = 0.5;
+
+    PolylinePointStyle* m_standardPointStyle = nullptr;
+    PolylinePointStyle* m_hoveredPointStyle = nullptr;
+    PolylinePointStyle* m_ghostPointStyle = nullptr;
+
     qreal m_hitRadius = 9.0;
     bool m_isSnapEnabled = true;
     qreal m_snapThresholdPx = 7.0;


### PR DESCRIPTION
Our polyline point drawing logic is going to get slightly more complex going forward. To prevent `PolylinePlot` from becoming unwieldy, this PR encapsulates "point properties" into a style class. Three different styles are introduced for the polyline (standard, hovered, and ghost).

This PR also unifies the painting logic of standard, hovered, and ghost points into a single method.