### PR TITLE
Rename plugin scanning command line option

### DIFF
--- a/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
+++ b/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
@@ -336,7 +336,8 @@ void RegisterAudioPluginsScenario::processPluginsRegistration(const io::paths_t&
             fileSystem()->remove(resultFile);
 
             const int code = process()->execute(appPath,
-                                                { "--register-audio-plugin", pluginPathStr, "--out", resultFile.toStdString() },
+                                                { "--register-audio-plugin", pluginPathStr, "--register-audio-plugin-out",
+                                                  resultFile.toStdString() },
                                                 AUDIO_PLUGIN_REGISTRATION_TIMEOUT_MS,
                                                 [this]() { return m_aborted.load() || m_progress.isCanceled(); });
 

--- a/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
+++ b/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
@@ -189,10 +189,10 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, UpdatePluginsRegistry)
     .Times(1);
 
     // [THEN] Processes started only for unregistered plugins; each gets an
-    // --out file, the main process is the sole cache writer.
+    // --register-audio-plugin-out file, the main process is the sole cache writer.
     paths_t alreadyRegisteredPaths { foundPluginPaths[0], foundPluginPaths[1] };
     for (const path_t& pluginPath : foundPluginPaths) {
-        auto argsMatch = ElementsAre("--register-audio-plugin", pluginPath.toStdString(), "--out", _);
+        auto argsMatch = ElementsAre("--register-audio-plugin", pluginPath.toStdString(), "--register-audio-plugin-out", _);
 
         if (muse::contains(alreadyRegisteredPaths, pluginPath)) {
             // Ignore already registered plugins
@@ -512,7 +512,8 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, UpdatePluginsRegistry_Left
     .WillOnce(Return(make_ok()));
 
     EXPECT_CALL(*m_process, execute(m_appPath,
-                                    ElementsAre("--register-audio-plugin", "/some/path/CRASHED.vst3", "--out", _), _, _))
+                                    ElementsAre("--register-audio-plugin", "/some/path/CRASHED.vst3", "--register-audio-plugin-out", _), _,
+                                    _))
     .WillOnce(Return(0));
 
     // [THEN] register loaded twice (once after registerNewPlugins, once at end of updatePluginsRegistry)
@@ -629,7 +630,8 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, FailedValidationRecordsErr
 
     // [GIVEN] The subprocess exits with a failure code
     EXPECT_CALL(*m_process, execute(m_appPath,
-                                    ElementsAre("--register-audio-plugin", pluginPath.toStdString(), "--out", _), _, _))
+                                    ElementsAre("--register-audio-plugin",
+                                                pluginPath.toStdString(), "--register-audio-plugin-out", _), _, _))
     .WillOnce(Return(-42));
 
     // [THEN] The main process records the Error entry itself (no second
@@ -664,7 +666,8 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, TimedOutValidationRecordsE
 
     // [GIVEN] The subprocess wrapper killed the hung validator
     EXPECT_CALL(*m_process, execute(m_appPath,
-                                    ElementsAre("--register-audio-plugin", pluginPath.toStdString(), "--out", _), _, _))
+                                    ElementsAre("--register-audio-plugin",
+                                                pluginPath.toStdString(), "--register-audio-plugin-out", _), _, _))
     .WillOnce(Return(muse::IProcess::ExecuteTimeoutCode));
 
     // [THEN] The plugin is recorded as failed with the timeout code
@@ -714,7 +717,8 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, CanceledValidationDoesNotR
     .Times(0);
 
     EXPECT_CALL(*m_process, execute(m_appPath,
-                                    ElementsAre("--register-audio-plugin", pluginPath.toStdString(), "--out", _), _, _))
+                                    ElementsAre("--register-audio-plugin",
+                                                pluginPath.toStdString(), "--register-audio-plugin-out", _), _, _))
     .WillOnce([&progress](const std::string&, const std::vector<std::string>&, int,
                           const std::function<bool()>& shouldCancel) {
         progress.cancel();
@@ -784,10 +788,10 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, RegisterNewPlugins_MainApp
     .Times(2)
     .WillRepeatedly(Return(make_ok()));
 
-    // [THEN] One subprocess invocation per path, each handed an --out file
+    // [THEN] One subprocess invocation per path, each handed an --register-audio-plugin-out file
     for (const path_t& path : paths) {
         EXPECT_CALL(*m_process, execute(m_appPath,
-                                        ElementsAre("--register-audio-plugin", path.toStdString(), "--out", _), _, _))
+                                        ElementsAre("--register-audio-plugin", path.toStdString(), "--register-audio-plugin-out", _), _, _))
         .WillOnce(Return(0));
     }
 


### PR DESCRIPTION
rename --out command line option to --register-audio-plugin-out for consistency

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
