### PR TITLE
dock: Use correct context on separator creator

### DIFF
--- a/framework/dockwindow/thirdparty/KDDockWidgets/src/Config.cpp
+++ b/framework/dockwindow/thirdparty/KDDockWidgets/src/Config.cpp
@@ -76,8 +76,11 @@ Config::Config(int ctx)
     d->fixFlags();
 
     // stuff in multisplitter/ can't include the framework widget factory, so set it here
-    auto separatorCreator = [ctx](Layouting::Widget *parent) {
-        return Config::self(ctx).frameworkWidgetFactory()->createSeparator(parent);
+    auto separatorCreator = [](Layouting::Widget* parent) {
+        // Resolve it from the layout host widget the separator is being created for
+        auto host = parent ? qobject_cast<QWidgetAdapter*>(parent->asQObject()) : nullptr;
+        Q_ASSERT(host);
+        return Config::self(host->ctx()).frameworkWidgetFactory()->createSeparator(parent);
     };
 
     Layouting::Config::self().setSeparatorFactoryFunc(separatorCreator);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11293 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

`Layouting` class does not hold the window context. It is a singleton for all contexts.
Dock `Config` constructor pass to `Layouting` a separator creator what captures the current context.
This happens on each new created window / context.
So separator creator will always use to the last created window / context, even if this windows was closed later on.
This change consists in pass a `separatorCreator` that uses the context from the parent element to create the separator. This will use the correct context always.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
