### PR TITLE
Append default suffix when saving/exporting with a single filter

### DIFF
--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -329,6 +329,19 @@ static UriQuery makeSelectFileQuery(FileDialogMode mode, const std::string& titl
         q.set("folder", QUrl::fromLocalFile(current.toQString()).toString().toStdString());
     } else if (mode == FileDialogMode::SaveFile) {
         q.set("currentFile", QUrl::fromLocalFile(current.toQString()).toString().toStdString());
+
+        // Some Linux native/portal dialogs don't auto-append the extension when the user
+        // doesn't type one, which then leaves the caller without a way to pick the right
+        // writer. Only do this when there is a single filter on offer: some callers (e.g.
+        // "Save As" with the experimental uncompressed-folder option) present more than one
+        // filter, where a global default suffix would be applied regardless of the filter
+        // the user actually selected, defeating the alternate option.
+        if (filter.size() == 1) {
+            std::string suffix = io::suffix(current);
+            if (!suffix.empty()) {
+                q.set("defaultSuffix", suffix);
+            }
+        }
     }
 
     return q;


### PR DESCRIPTION
## Summary

On some Linux desktop environments, the native/portal file dialog used for
saving and exporting doesn't auto-append the file extension when the user
doesn't type one. This leaves the caller (e.g. PDF export in the main
MuseScore repo) unable to pick the correct writer for the returned path,
causing exports to silently fail.

- In `makeSelectFileQuery()` (`interactive.cpp`), when opening a `SaveFile`
  dialog, request a `defaultSuffix` from the dialog derived from the
  suggested `current` path's own suffix.
- This is only done when the caller offers a **single** filter. Some
  callers (e.g. "Save As" for a MuseScore project) offer two filters at
  once — the normal `*.mscz` format and an experimental uncompressed-folder
  option — and a dialog-wide default suffix would be applied regardless of
  which filter the user actually selected, silently defeating the
  alternate option. That ambiguous case is left untouched.

## Companion PR

This is a companion fix to a related PR in `musescore/MuseScore`
(`src/app/main.cpp` and `src/project/internal/exportprojectscenario.cpp`),
which adds a safety net that enforces the correct suffix after the dialog
returns, regardless of dialog backend.

## Testing

Verified with a full local Debug build of MuseScore Studio (main repo,
pointing at this branch) on KDE Plasma Wayland:
- Exporting to PDF without typing an extension now correctly produces a
  `.pdf` file.
- Exporting to PDF while typing `.pdf` explicitly still works, without a
  duplicated suffix.
- Keyboard interaction inside the file dialog (arrow keys, typing, Enter to
  confirm) verified unaffected — this was a deliberate regression check,
  since a past issue (#13113) was caused by a different, broken Linux file
  dialog swallowing keyboard input.

## Disclaimer

This change was implemented with the assistance of Claude Code (Anthropic),
which performed the code changes, the build, and the testing steps
described above. A human reviewed and validated the entire process step by
step, and endorses the final result.