### PR TITLE
shortcuts: Add color property

### DIFF
--- a/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -33,6 +33,7 @@ ValueList {
     valueRoleName: "sequence"
     valueTitle: qsTrc("shortcuts", "shortcut")
     iconRoleName: "icon"
+    iconColorRoleName: "iconColor"
     readOnly: true
 
     property var sourceModel: null

--- a/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -54,6 +54,7 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
     switch (role) {
     case RoleTitle: return item.title;
     case RoleIcon: return item.icon;
+    case RoleIconColor: return item.iconColor;
     case RoleSequence: return item.sequence;
     case RoleSearchKey: return item.searchKey + item.sequence;
     }
@@ -87,6 +88,7 @@ QHash<int, QByteArray> ShortcutsModel::roleNames() const
     static const QHash<int, QByteArray> roles {
         { RoleTitle, "title" },
         { RoleIcon, "icon" },
+        { RoleIconColor, "iconColor" },
         { RoleSequence, "sequence" },
         { RoleSearchKey, "searchKey" }
     };
@@ -156,6 +158,7 @@ void ShortcutsModel::load()
             item.shortcut = shortcut;
             item.title = actionText(action.code);
             item.icon = static_cast<int>(action.iconCode);
+            item.iconColor = action.iconColor;
             item.sequence = sequencesToNativeText(shortcut.sequences);
             item.searchKey = QString::fromStdString(action.code)
                              + action.title.qTranslatedWithoutMnemonic()

--- a/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.h
+++ b/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.h
@@ -97,6 +97,7 @@ private:
     enum Roles {
         RoleTitle = Qt::UserRole + 1,
         RoleIcon,
+        RoleIconColor,
         RoleSequence,
         RoleSearchKey
     };
@@ -106,6 +107,7 @@ private:
         QString group;
         QString title;
         int icon = 0;
+        QString iconColor;
         QString sequence;
         QString searchKey;
     };

--- a/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
@@ -47,6 +47,7 @@ Item {
     property string minValueRoleName: "min"
     property string maxValueRoleName: "max"
     property string iconRoleName: "icon"
+    property string iconColorRoleName: "iconColor"
 
     property alias hasSelection: selectionModel.hasSelection
     readonly property var selection: sortFilterProxyModel.mapSelectionToSource(selectionModel.selection)
@@ -276,6 +277,7 @@ Item {
             minValueRoleName: root.minValueRoleName
             maxValueRoleName: root.maxValueRoleName
             iconRoleName: root.iconRoleName
+            iconColorRoleName: root.iconColorRoleName
 
             isSelected: selectionModel.hasSelection && selectionModel.isSelected(modelIndex)
             readOnly: root.readOnly

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListItem.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListItem.qml
@@ -37,6 +37,7 @@ ListItemBlank {
     property string minValueRoleName: "min"
     property string maxValueRoleName: "max"
     property string iconRoleName: "icon"
+    property string iconColorRoleName: "iconColor"
 
     property bool readOnly: false
     //! NOTE: is keys column generally editable
@@ -120,6 +121,7 @@ ListItemBlank {
             StyledIconLabel {
                 id: icon
                 iconCode: Boolean(root.item[iconRoleName]) ? root.item[iconRoleName] : IconCode.NONE
+                color: Boolean(root.item[iconColorRoleName]) ? root.item[iconColorRoleName] : ui.theme.fontPrimaryColor
             }
 
             Loader {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10002

<!-- Add a short description of and motivation for the changes here -->

Audacity has some actions with the same icon but different colors.
When setting a shortcut I would like to differentiate between those actions.

<img width="877" height="669" alt="Screenshot 2026-07-09 at 06 22 12" src="https://github.com/user-attachments/assets/237c9f04-26a4-4087-9beb-964e672d8b4e" />


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
