### PR TITLE
Allow equal sign in the parameter value

### DIFF
--- a/framework/global/tests/uri_tests.cpp
+++ b/framework/global/tests/uri_tests.cpp
@@ -112,6 +112,21 @@ TEST_F(Global_UriTests, UriQuery_Parse_Quoted)
     EXPECT_EQ(q.param("param3"), Val("x=5"));
 }
 
+TEST_F(Global_UriTests, UriQuery_Parse_EqualSignInValueAllowed)
+{
+    //! GIVEN Valid uriquery with a value containing a few equal signs
+
+    UriQuery q("muse://some/path?param=SGV5IHRoZXJlIQ==");
+
+    EXPECT_TRUE(q.isValid());
+    EXPECT_EQ(q.uri().scheme(), "muse");
+    EXPECT_EQ(q.uri().path(), "some/path");
+    EXPECT_EQ(q.uri().toString(), "muse://some/path");
+
+    EXPECT_EQ(q.params().size(), 1);
+    EXPECT_EQ(q.param("param"), Val("SGV5IHRoZXJlIQ=="));
+}
+
 TEST_F(Global_UriTests, UriQuery_ToString)
 {
     //! GIVEN Valid uriquery

--- a/framework/global/types/uri.cpp
+++ b/framework/global/types/uri.cpp
@@ -197,16 +197,15 @@ void UriQuery::parseParams(const std::string& uri, Params& out) const
     strings::split(paramsStr, paramsPairs, "&");
 
     for (const std::string& pair : paramsPairs) {
-        std::vector<std::string> param;
-        strings::split(pair, param, "=");
-        if (param.size() != 2) {
+        size_t eqPos = pair.find('=');
+        if (eqPos == std::string::npos) {
             LOGE() << "Invalid param: " << pair << ", in uri: " << uri;
             continue;
         }
-        std::string key = param.at(0);
+        std::string key = pair.substr(0, eqPos);
         strings::trim(key);
 
-        std::string val = param.at(1);
+        std::string val = pair.substr(eqPos + 1);
 
         //! NOTE Val is bool?
         if (URI_VAL_TRUE == val || URI_VAL_FALSE == val) {


### PR DESCRIPTION
This is allowed by https://url.spec.whatwg.org/#urlencoded-parsing

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
