### PR TITLE
Identify crash in Shortcuts v1 and fix build of Shortcuts v2

### DIFF
--- a/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/framework/shortcuts/internal/shortcutsregister.cpp
@@ -317,9 +317,9 @@ bool ShortcutsRegister::readFromFile(ShortcutList& shortcuts, const io::path_t& 
 
 Shortcut ShortcutsRegister::readShortcut(XmlStreamReader& reader) const
 {
-    Shortcut shortcut;
+    Shortcut shortcut; // Memory corruption or undefined behavior here...
 
-    while (reader.readNextStartElement()) {
+    while (reader.readNextStartElement()) { // ...causes CRASH here.
         const std::string tag(reader.name());
 
         if (tag == ACTION_CODE_TAG) {

--- a/framework/stubs/shortcuts/shortcutsconfigurationstub.h
+++ b/framework/stubs/shortcuts/shortcutsconfigurationstub.h
@@ -21,9 +21,13 @@
  */
 #pragma once
 
-#include "shortcuts/ishortcutsconfiguration.h"
-
 #include "muse_framework_config.h"
+
+#ifdef MUSE_MODULE_SHORTCUTS_V2
+#include "shortcuts_v2/ishortcutsconfiguration.h"
+#else
+#include "shortcuts/ishortcutsconfiguration.h"
+#endif
 
 namespace muse::shortcuts {
 class ShortcutsConfigurationStub : public IShortcutsConfiguration


### PR DESCRIPTION
@igorkorsukov, my local build of musescore/MuseScore@bd0e15537e01edea9ea6e793af1bad6d886c6c00 (current [main](https://github.com/musescore/MuseScore/tree/main)) with **Shortcuts v1** compiles OK but it crashes on startup for reasons I don't understand. See code comments for details. I'm using macOS 26.5 on Apple Silicon.

When I switch to **Shortcuts v2**, it fails to compile unless I make the following code change to the stub module. With this change, the app successfully compiles and there's no crash on startup. (But it still crashes with **Shortcuts v1**.)

**Note:** `shortcutsconfigurationstub.h` isn't the only file that `#includes` from the shortcuts module.