### PR TITLE
Buffers selected event types delivered before the app installs its owns consumers

### DIFF
--- a/framework/global/iapplication.h
+++ b/framework/global/iapplication.h
@@ -29,8 +29,9 @@
 #include "modularity/ioc.h"
 
 #ifndef NO_QT_SUPPORT
+#include <QEvent>
+
 class QObject;
-class QEvent;
 class QWindow;
 #endif
 
@@ -81,6 +82,7 @@ public:
     virtual bool notify(QObject* object, QEvent* event) = 0;
 
     virtual Qt::KeyboardModifiers keyboardModifiers() const = 0;
+    virtual std::vector<std::unique_ptr<QEvent> > takeEarlyEvents(QEvent::Type) { return {}; }
 #endif
 };
 }

--- a/framework/ui/CMakeLists.txt
+++ b/framework/ui/CMakeLists.txt
@@ -49,6 +49,8 @@ target_sources(muse_ui PRIVATE
     api/keyboardapi.cpp
     api/keyboardapi.h
 
+    internal/earlyeventsbuffer.cpp
+    internal/earlyeventsbuffer.h
     internal/guiapplication.cpp
     internal/guiapplication.h
     internal/uistate.cpp

--- a/framework/ui/internal/earlyeventsbuffer.cpp
+++ b/framework/ui/internal/earlyeventsbuffer.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "earlyeventsbuffer.h"
+
+#include "log.h"
+
+using namespace muse::ui;
+
+EarlyEventsBuffer::EarlyEventsBuffer(const std::set<QEvent::Type>& types, QObject* parent)
+    : QObject(parent), m_types(types)
+{
+}
+
+std::vector<std::unique_ptr<QEvent> > EarlyEventsBuffer::take(QEvent::Type type)
+{
+    IF_ASSERT_FAILED(m_types.count(type)) {
+        return {};
+    }
+
+    std::vector<std::unique_ptr<QEvent> > taken;
+    for (auto it = m_events.begin(); it != m_events.end();) {
+        if ((*it)->type() == type) {
+            taken.push_back(std::move(*it));
+            it = m_events.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    return taken;
+}
+
+bool EarlyEventsBuffer::eventFilter(QObject* watched, QEvent* event)
+{
+    if (m_types.count(event->type())) {
+        if (QEvent* cloned = event->clone()) {
+            m_events.push_back(std::unique_ptr<QEvent>(cloned));
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
+}

--- a/framework/ui/internal/earlyeventsbuffer.h
+++ b/framework/ui/internal/earlyeventsbuffer.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include <QEvent>
+#include <QObject>
+
+namespace muse::ui {
+//! Buffers selected event types delivered before the app installs its own consumers
+// (e.g. on macOS the launch url arrives as a one-shot QFileOpenEvent during an early startup)
+class EarlyEventsBuffer : public QObject
+{
+public:
+    EarlyEventsBuffer(const std::set<QEvent::Type>& types, QObject* parent);
+
+    std::vector<std::unique_ptr<QEvent> > take(QEvent::Type type);
+
+private:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    std::set<QEvent::Type> m_types;
+    std::vector<std::unique_ptr<QEvent> > m_events;
+};
+}

--- a/framework/ui/internal/guiapplication.cpp
+++ b/framework/ui/internal/guiapplication.cpp
@@ -38,9 +38,38 @@
 using namespace muse;
 using namespace muse::ui;
 
-GuiApplication::GuiApplication(const std::shared_ptr<CmdOptions>& options)
+GuiApplication::GuiApplication(const std::shared_ptr<CmdOptions>& options, const std::set<QEvent::Type>& earlyEventTypes)
     : BaseApplication(options)
 {
+    IF_ASSERT_FAILED(qApp) {
+        return;
+    }
+
+    if (!earlyEventTypes.empty()) {
+        m_earlyEventTypes = earlyEventTypes;
+        m_earlyEventsBuffer = new EarlyEventsBuffer(m_earlyEventTypes, qApp);
+        qApp->installEventFilter(m_earlyEventsBuffer);
+    }
+}
+
+std::vector<std::unique_ptr<QEvent> > GuiApplication::takeEarlyEvents(QEvent::Type type)
+{
+    if (!m_earlyEventsBuffer) {
+        return {};
+    }
+
+    if (m_earlyEventTypes.empty()) {
+        return {};
+    }
+
+    auto eventList = m_earlyEventsBuffer->take(type);
+    m_earlyEventTypes.erase(type);
+
+    if (m_earlyEventTypes.empty()) {
+        qApp->removeEventFilter(m_earlyEventsBuffer);
+    }
+
+    return eventList;
 }
 
 void GuiApplication::doSetup(const std::shared_ptr<CmdOptions>& options)

--- a/framework/ui/internal/guiapplication.h
+++ b/framework/ui/internal/guiapplication.h
@@ -29,13 +29,17 @@
 #include "global/internal/baseapplication.h"
 #include "global/internal/cmdoptions.h"
 
+#include "earlyeventsbuffer.h"
+
 class QQuickWindow;
 
 namespace muse::ui {
 class GuiApplication : public BaseApplication
 {
 public:
-    GuiApplication(const std::shared_ptr<CmdOptions>& options);
+    GuiApplication(const std::shared_ptr<CmdOptions>& options, const std::set<QEvent::Type>& earlyEventTypes = {});
+
+    std::vector<std::unique_ptr<QEvent> > takeEarlyEvents(QEvent::Type type) override;
 
 protected:
 
@@ -55,5 +59,9 @@ protected:
     QTimer m_delayedInitTimer;
 
     std::map<muse::modularity::IoCID, QQuickWindow*> m_windows;
+
+private:
+    EarlyEventsBuffer* m_earlyEventsBuffer = nullptr;
+    std::set<QEvent::Type> m_earlyEventTypes = {};
 };
 }


### PR DESCRIPTION
On macOS the launch url starts the app and a QFileOpenEvent arrives during an early startup before the app install an event filter to handle this events.
This change buffers selected event types to be retrieved later.

Resolves: https://github.com/audacity/audacity/issues/10966 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
