### PR TITLE
Fuzzy text search, part 1: algorithm & searching shortcuts

### DIFF
--- a/framework/extensions/internal/extensionsession.cpp
+++ b/framework/extensions/internal/extensionsession.cpp
@@ -18,6 +18,8 @@
  */
 #include "extensionsession.h"
 
+#include "extensions/extensionstypes.h"
+
 using namespace muse;
 using namespace muse::extensions;
 

--- a/framework/extensions/internal/extensionsession.h
+++ b/framework/extensions/internal/extensionsession.h
@@ -22,6 +22,8 @@
 #include "scriptengine.h"
 
 namespace muse::extensions {
+struct Manifest;
+
 class ExtensionSession final : public IExtensionSession
 {
 public:

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(muse_global PRIVATE
     functional/inplace_function_mv.h
     dataformatter.cpp
     dataformatter.h
+    stringsearch.cpp
+    stringsearch.h
     stringutils.cpp
     stringutils.h
     ptrutils.h

--- a/framework/global/stringsearch.cpp
+++ b/framework/global/stringsearch.cpp
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "stringsearch.h"
+
+#include <algorithm>
+
+bool muse::operator==(const FuzzyMatch& left, const FuzzyMatch& right)
+{
+    return left.beginPos == right.beginPos
+           && left.endPos == right.endPos
+           && left.editDistance == right.editDistance;
+}
+
+bool muse::operator!=(const FuzzyMatch& left, const FuzzyMatch& right)
+{
+    return !(left == right);
+}
+
+namespace muse {
+FuzzyMatcher& FuzzyMatcher::operator()(const std::u32string_view text, const std::u32string_view pattern, const std::size_t maxDistance)
+{
+    return match(text, pattern, maxDistance);
+}
+
+FuzzyMatcher& FuzzyMatcher::match(const std::u32string_view text, const std::u32string_view pattern, const std::size_t maxDistance)
+{
+    m_textSize = text.size();
+    m_patternSize = pattern.size();
+    m_suffixTable.clear();
+    m_suffixTable.resize((m_patternSize + 1) * (m_textSize + 1));
+    m_maxDistance = maxDistance;
+
+    for (std::size_t textSuffixSize = 0; textSuffixSize <= m_textSize; ++textSuffixSize) {
+        const std::size_t endPos = text.size() - textSuffixSize;
+        // 0 insertions to transform empty pattern to text suffix.
+        // This allows the match to be at any position in text.
+        m_suffixTable[index(0, textSuffixSize)] = SuffixMatch{ endPos, 0 };
+    }
+
+    for (std::size_t patternSuffixSize = 1; patternSuffixSize <= m_patternSize; ++patternSuffixSize) {
+        // patternSuffixSize deletions to transform pattern suffix to empty text
+        m_suffixTable[index(patternSuffixSize, 0)] = SuffixMatch{ 0, patternSuffixSize };
+
+        const std::size_t patternIdx = pattern.size() - patternSuffixSize;
+        for (std::size_t textSuffixSize = 1; textSuffixSize <= m_textSize; ++textSuffixSize) {
+            const std::size_t textIdx = text.size() - textSuffixSize;
+
+            if (pattern[patternIdx] == text[textIdx]) {
+                m_suffixTable[index(patternSuffixSize, textSuffixSize)] = m_suffixTable[index(patternSuffixSize - 1, textSuffixSize - 1)];
+                continue;
+            }
+
+            const SuffixMatch insertMatch = m_suffixTable[index(patternSuffixSize, textSuffixSize - 1)];
+            const SuffixMatch replaceMatch = m_suffixTable[index(patternSuffixSize - 1, textSuffixSize - 1)];
+            const SuffixMatch deleteMatch = m_suffixTable[index(patternSuffixSize - 1, textSuffixSize)];
+            SuffixMatch minMatch = std::min(insertMatch, std::min(replaceMatch, deleteMatch));
+
+            if (patternSuffixSize > 1 && textSuffixSize > 1
+                && pattern[patternIdx] == text[textIdx + 1]
+                && pattern[patternIdx + 1] == text[textIdx]) {
+                const SuffixMatch transpositionMatch = m_suffixTable[index(patternSuffixSize - 2, textSuffixSize - 2)];
+                minMatch = std::min(transpositionMatch, minMatch);
+            }
+
+            m_suffixTable[index(patternSuffixSize, textSuffixSize)] = SuffixMatch{ minMatch.endPos, minMatch.editDistance + 1 };
+        }
+    }
+
+    return *this;
+}
+
+std::optional<FuzzyMatch> FuzzyMatcher::findMatch(const std::size_t textBeginPos) const
+{
+    if (m_suffixTable.empty() || textBeginPos > m_textSize) {
+        return std::nullopt;
+    }
+
+    for (std::size_t beginPos = textBeginPos; beginPos <= m_textSize; ++beginPos) {
+        const std::size_t textSuffixSize = m_textSize - beginPos;
+        const SuffixMatch match = m_suffixTable[index(m_patternSize, textSuffixSize)];
+        if (match.editDistance <= m_maxDistance) {
+            return FuzzyMatch{ beginPos, match.endPos, match.editDistance };
+        }
+    }
+
+    return std::nullopt;
+}
+
+bool FuzzyMatcher::empty() const
+{
+    return !findMatch(0).has_value();
+}
+
+void FuzzyMatcher::clear()
+{
+    m_textSize = 0;
+    m_patternSize = 0;
+    m_suffixTable.clear();
+}
+
+FuzzyMatcher::const_iterator FuzzyMatcher::begin() const
+{
+    return Iterator(*this);
+}
+
+FuzzyMatcher::const_iterator FuzzyMatcher::end() const
+{
+    return Iterator();
+}
+
+std::size_t FuzzyMatcher::index(const std::size_t patternSuffixSize, const std::size_t textSuffixSize) const
+{
+    return (m_textSize + 1) * patternSuffixSize + textSuffixSize;
+}
+
+FuzzyMatcher::Iterator::Iterator(const FuzzyMatcher& matcher)
+    : m_matcher{&matcher}
+{
+    next(0);
+}
+
+FuzzyMatcher::Iterator::reference FuzzyMatcher::Iterator::operator*() const
+{
+    return *m_match;
+}
+
+FuzzyMatcher::Iterator::pointer FuzzyMatcher::Iterator::operator->() const
+{
+    return m_match.operator->();
+}
+
+FuzzyMatcher::Iterator& FuzzyMatcher::Iterator::operator++()
+{
+    next(m_match->beginPos + 1);
+    return *this;
+}
+
+FuzzyMatcher::Iterator FuzzyMatcher::Iterator::operator++(int)
+{
+    Iterator prev = *this;
+    operator++();
+
+    return prev;
+}
+
+bool FuzzyMatcher::Iterator::operator==(const Iterator& right) const
+{
+    return m_matcher == right.m_matcher && m_match == right.m_match;
+}
+
+bool FuzzyMatcher::Iterator::operator!=(const Iterator& right) const
+{
+    return !(*this == right);
+}
+
+void FuzzyMatcher::Iterator::next(const std::size_t textBeginPos)
+{
+    m_match = m_matcher->findMatch(textBeginPos);
+    if (!m_match) {
+        m_matcher = nullptr;
+    }
+}
+}

--- a/framework/global/stringsearch.h
+++ b/framework/global/stringsearch.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace muse {
+struct FuzzyMatch {
+    std::size_t beginPos = 0;
+    std::size_t endPos = 0;
+    std::size_t editDistance = 0;
+};
+
+bool operator==(const FuzzyMatch&, const FuzzyMatch&);
+bool operator!=(const FuzzyMatch&, const FuzzyMatch&);
+
+class FuzzyMatcher
+{
+public:
+    using value_type = FuzzyMatch;
+
+    static constexpr auto UNLIMITED_DISTANCE = static_cast<std::size_t>(-1);
+
+    FuzzyMatcher() = default;
+
+    FuzzyMatcher& operator()(std::u32string_view text, std::u32string_view pattern, std::size_t maxDistance = UNLIMITED_DISTANCE);
+    FuzzyMatcher& match(std::u32string_view text, std::u32string_view pattern, std::size_t maxDistance = UNLIMITED_DISTANCE);
+
+    bool empty() const;
+    std::optional<FuzzyMatch> findMatch(std::size_t textBeginPos) const;
+
+    void clear();
+
+    class Iterator
+    {
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = FuzzyMatcher::value_type;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+        using iterator_category = std::input_iterator_tag;
+
+        Iterator() = default;
+        explicit Iterator(const FuzzyMatcher&);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        Iterator& operator++();
+        Iterator operator++(int);
+
+        bool operator==(const Iterator&) const;
+        bool operator!=(const Iterator&) const;
+
+    private:
+        void next(std::size_t textBeginPos);
+
+        const FuzzyMatcher* m_matcher = nullptr;
+        std::optional<FuzzyMatch> m_match;
+    };
+
+    using const_iterator = Iterator;
+
+    const_iterator begin() const;
+    const_iterator end() const;
+
+private:
+    struct SuffixMatch {
+        std::size_t endPos = 0;
+        std::size_t editDistance = 0;
+
+        friend bool operator<(const SuffixMatch& left, const SuffixMatch& right)
+        {
+            return left.editDistance < right.editDistance;
+        }
+    };
+
+    std::size_t index(std::size_t patternSuffixSize, std::size_t textSuffixSize) const;
+
+    std::size_t m_textSize = 0;
+    std::size_t m_patternSize = 0;
+    std::size_t m_maxDistance = 0;
+    std::vector<SuffixMatch> m_suffixTable;
+};
+}

--- a/framework/global/tests/CMakeLists.txt
+++ b/framework/global/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/geometry_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sharedmap_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sharedhashmap_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/stringsearch_tests.cpp
 )
 
 include(SetupGTest)

--- a/framework/global/tests/stringsearch_tests.cpp
+++ b/framework/global/tests/stringsearch_tests.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <ostream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "global/stringsearch.h"
+
+using ::testing::ElementsAre;
+
+namespace muse {
+void PrintTo(const FuzzyMatch& match, std::ostream* os)
+{
+    *os << "(beginPos: " << match.beginPos
+        << ", endPos: " << match.endPos
+        << ", editDistance: " << match.editDistance << ")";
+}
+
+TEST(Global_StringSearchTests, testFuzzyMatcherEmpty)
+{
+    FuzzyMatcher matcher;
+    EXPECT_TRUE(matcher.empty());
+    EXPECT_FALSE(matcher.findMatch(0).has_value());
+}
+
+TEST(Global_StringSearchTests, testFuzzyMatcherEdgeCases)
+{
+    FuzzyMatcher matcher;
+    EXPECT_THAT(matcher(U"", U""), ElementsAre(FuzzyMatch { 0, 0, 0 }));
+    EXPECT_THAT(matcher(U"hay", U""), ElementsAre(FuzzyMatch { 0, 0, 0 }, FuzzyMatch { 1, 1, 0 },
+                                                  FuzzyMatch { 2, 2, 0 }, FuzzyMatch { 3, 3, 0 }));
+    EXPECT_THAT(matcher(U"", U"needle"), ElementsAre(FuzzyMatch { 0, 0, 6 }));
+}
+
+TEST(Global_StringSearchTests, testFuzzyMatcher)
+{
+    FuzzyMatcher matcher;
+    EXPECT_THAT(matcher(U"surgery", U"survey", 2), ElementsAre(FuzzyMatch { 0, 7, 2 }));
+
+    // exact
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"needle", 0), ElementsAre(FuzzyMatch { 6, 12, 0 }));
+
+    // 1 insertion
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"neele", 1), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 change
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"nnedle", 1), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 deletion
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"neoedle", 1), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+    // 1 transposition
+    EXPECT_THAT(matcher(U"hayhayneedlehayhayhay", U"neelde", 1), ElementsAre(FuzzyMatch { 6, 12, 1 }));
+
+    // multiple matches with different edit distance
+    EXPECT_THAT(matcher(U"haynedlehayneedlehayhayhay", U"needle", 1),
+                ElementsAre(FuzzyMatch { 3, 8, 1 }, FuzzyMatch { 10, 17, 1 }, FuzzyMatch { 11, 17, 0 },
+                            FuzzyMatch { 12, 17, 1 }));
+    // return best match
+    EXPECT_THAT(matcher(U"haynedlehayneedlehayhayhay", U"needle", 0), ElementsAre(FuzzyMatch { 11, 17, 0 }));
+    // correct start pos
+    EXPECT_THAT(matcher(U"aaab", U"ab", 0), ElementsAre(FuzzyMatch { 2, 4, 0 }));
+}
+}

--- a/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -48,14 +48,23 @@ ValueList {
 
         filters: [
             FilterValue {
-                roleName: "searchKey"
-                roleValue: root.searchText
-                compareType: CompareType.Contains
-            },
-            FilterValue {
                 roleName: "title"
                 roleValue: ""
                 compareType: CompareType.NotEqual
+            },
+            FuzzyFilter {
+                id: fuzzyFilter
+
+                enabled: Boolean(fuzzyPattern)
+                fuzzyPattern: root.searchText
+                roleName: "searchKey"
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        ]
+        sorters: [
+            FuzzyScoreSorter {
+                fuzzyFilter: fuzzyFilter
+                enabled: fuzzyFilter.enabled
             }
         ]
     }

--- a/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "shortcutsmodel.h"
 
+#include <QStringList>
+
 #include "containers.h"
 #include "translation.h"
 #include "types/mnemonicstring.h"
@@ -57,10 +59,12 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
     case RoleSequence: return sequencesToNativeText(shortcut.sequences);
     case RoleSearchKey: {
         const UiAction& action = this->action(shortcut.action);
-        return QString::fromStdString(action.code)
-               + action.title.qTranslatedWithoutMnemonic()
-               + action.description.qTranslated()
-               + sequencesToNativeText(shortcut.sequences);
+        QStringList searchKeyItems;
+        searchKeyItems << QString::fromStdString(action.code)
+                       << action.title.qTranslatedWithoutMnemonic()
+                       << action.description.qTranslated()
+                       << sequencesToNativeText(shortcut.sequences);
+        return searchKeyItems.join(u' ');
     }
     }
 

--- a/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -266,6 +266,10 @@ void ShortcutsModel::notifyAboutShortcutChanged(const QModelIndex& index)
 void ShortcutsModel::resetToDefaultSelectedShortcuts()
 {
     auto resolveConflicts = [this](const Shortcut& shortcut) {
+        if (shortcut.sequences.empty()) {
+            return;
+        }
+
         for (int i = 0; i < m_shortcuts.size(); ++i) {
             Shortcut& sc = m_shortcuts[i];
 

--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -49,14 +49,23 @@ ValueList {
 
         filters: [
             FilterValue {
-                roleName: "searchKey"
-                roleValue: root.searchText
-                compareType: CompareType.Contains
-            },
-            FilterValue {
                 roleName: "title"
                 roleValue: ""
                 compareType: CompareType.NotEqual
+            },
+            FuzzyFilter {
+                id: fuzzyFilter
+
+                enabled: Boolean(fuzzyPattern)
+                fuzzyPattern: root.searchText
+                roleName: "searchKey"
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        ]
+        sorters: [
+            FuzzyScoreSorter {
+                fuzzyFilter: fuzzyFilter
+                enabled: fuzzyFilter.enabled
             }
         ]
     }

--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "shortcutsmodel.h"
 
+#include <QStringList>
+
 #include "containers.h"
 #include "translation.h"
 #include "types/mnemonicstring.h"
@@ -57,7 +59,12 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
     case RoleIcon: return item.icon;
     case RoleIconColor: return item.iconColor;
     case RoleSequence: return item.sequence;
-    case RoleSearchKey: return item.searchKey + item.sequence;
+    case RoleSearchKey: {
+        QStringList searchKeyItems;
+        searchKeyItems << item.searchKey
+                       << item.sequence;
+        return searchKeyItems.join(u' ');
+    }
     }
 
     return QVariant();
@@ -130,9 +137,12 @@ void ShortcutsModel::load()
 
             item.icon = static_cast<int>(info.decoration.iconCode);
             item.sequence = sequencesToNativeText(shortcut.sequences);
-            item.searchKey = QString::fromStdString(info.command.toString())
-                             + info.title.qTranslatedWithoutMnemonic()
-                             + info.description.qTranslated();
+
+            QStringList searchKeyItems;
+            searchKeyItems << QString::fromStdString(info.command.toString())
+                           << info.title.qTranslatedWithoutMnemonic()
+                           << info.description.qTranslated();
+            item.searchKey = searchKeyItems.join(u' ');
 
             m_items.append(item);
         }
@@ -161,9 +171,12 @@ void ShortcutsModel::load()
             item.icon = static_cast<int>(action.iconCode);
             item.iconColor = action.iconColor;
             item.sequence = sequencesToNativeText(shortcut.sequences);
-            item.searchKey = QString::fromStdString(action.code)
-                             + action.title.qTranslatedWithoutMnemonic()
-                             + action.description.qTranslated();
+
+            QStringList searchKeyItems;
+            searchKeyItems << QString::fromStdString(action.code)
+                           << action.title.qTranslatedWithoutMnemonic()
+                           << action.description.qTranslated();
+            item.searchKey = searchKeyItems.join(u' ');
 
             m_items.append(item);
         }

--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -349,6 +349,10 @@ void ShortcutsModel::notifyAboutShortcutChanged(const QModelIndex& index)
 void ShortcutsModel::resetToDefaultSelectedShortcuts()
 {
     auto resolveConflicts = [this](const Shortcut& shortcut) {
+        if (shortcut.sequences.empty()) {
+            return;
+        }
+
         for (int i = 0; i < m_items.size(); ++i) {
             Shortcut& sc = m_items[i].shortcut;
 

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -46,6 +46,10 @@ qt_add_qml_module(muse_uicomponents_qml
         filteredflyoutmodel.h
         filtervalue.cpp
         filtervalue.h
+        fuzzyfilter.cpp
+        fuzzyfilter.h
+        fuzzyscoresorter.cpp
+        fuzzyscoresorter.h
         iconview.cpp
         iconview.h
         internal/focuslistener.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -78,6 +78,8 @@ qt_add_qml_module(muse_uicomponents_qml
         selectableitemlistmodel.h
         selectmultipledirectoriesmodel.cpp
         selectmultipledirectoriesmodel.h
+        sorter.cpp
+        sorter.h
         sortervalue.cpp
         sortervalue.h
         sortfilterproxymodel.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -40,6 +40,8 @@ qt_add_qml_module(muse_uicomponents_qml
         dropdownview.h
         filepickermodel.cpp
         filepickermodel.h
+        filter.cpp
+        filter.h
         filteredflyoutmodel.cpp
         filteredflyoutmodel.h
         filtervalue.cpp

--- a/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/ValueList.qml
@@ -82,20 +82,17 @@ Item {
         property real spacing: 4
         property real sideMargin: 30
 
-        function toggleSorter(sorter) {
+        function toggleSorter(sorter: Sorter) {
             if (!sorter.enabled) {
-                setSorterEnabled(sorter, true)
+                sorter.sortOrder = Qt.AscendingOrder
+                sorter.enabled = true
             } else if (sorter.sortOrder === Qt.AscendingOrder) {
                 sorter.sortOrder = Qt.DescendingOrder
             } else {
-                setSorterEnabled(sorter, false)
+                sorter.enabled = false
             }
 
             selectionModel.clear()
-        }
-
-        function setSorterEnabled(sorter, enable) {
-            sorter.enabled = enable
         }
     }
 
@@ -188,7 +185,7 @@ Item {
                 }
 
                 prv.toggleSorter(keySorter)
-                prv.setSorterEnabled(valueSorter, false)
+                valueSorter.enabled = false
             }
         }
 
@@ -219,7 +216,7 @@ Item {
                 }
 
                 prv.toggleSorter(valueSorter)
-                prv.setSorterEnabled(keySorter, false)
+                keySorter.enabled = false
             }
         }
     }

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "filter.h"
+
+namespace muse::uicomponents {
+Filter::Filter(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool Filter::enabled() const
+{
+    return m_enabled;
+}
+
+void Filter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit dataChanged();
+}
+
+bool Filter::async() const
+{
+    return m_async;
+}
+
+void Filter::setAsync(const bool async)
+{
+    if (m_async == async) {
+        return;
+    }
+
+    m_async = async;
+    emit dataChanged();
+}
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.cpp
@@ -44,6 +44,7 @@ void Filter::setEnabled(const bool enabled)
     }
 
     m_enabled = enabled;
+    emit enabledChanged();
     emit dataChanged();
 }
 
@@ -59,6 +60,7 @@ void Filter::setAsync(const bool async)
     }
 
     m_async = async;
+    emit asyncChanged();
     emit dataChanged();
 }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include <QObject>
+
+class QModelIndex;
+
+namespace muse::uicomponents {
+class SortFilterProxyModel;
+
+class Filter : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
+    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+
+public:
+    explicit Filter(QObject* parent = nullptr);
+
+    virtual bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) = 0;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    bool async() const;
+    void setAsync(bool async);
+
+signals:
+    void dataChanged();
+
+private:
+    bool m_enabled = true;
+    bool m_async = false;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.h
@@ -45,6 +45,7 @@ public:
     explicit Filter(QObject* parent = nullptr);
 
     virtual bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) = 0;
+    virtual void invalidate();
 
     bool enabled() const;
     void setEnabled(bool enabled);

--- a/framework/uicomponents/qml/Muse/UiComponents/filter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filter.h
@@ -37,9 +37,9 @@ class Filter : public QObject
     QML_ELEMENT;
     QML_UNCREATABLE("")
 
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
-    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
+    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY asyncChanged)
 
 public:
     explicit Filter(QObject* parent = nullptr);
@@ -55,6 +55,8 @@ public:
 
 signals:
     void dataChanged();
+    void enabledChanged();
+    void asyncChanged();
 
 private:
     bool m_enabled = true;

--- a/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/filtervalue.cpp
@@ -19,33 +19,50 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "filtervalue.h"
+
+#include "global/log.h"
+
+#include "sortfilterproxymodel.h"
 
 using namespace muse::uicomponents;
 
 FilterValue::FilterValue(QObject* parent)
-    : QObject(parent)
+    : Filter(parent)
 {
+}
+
+bool FilterValue::acceptsRow(const int sourceRow, const QModelIndex& sourceParent,
+                             const SortFilterProxyModel& proxyModel)
+{
+    const int roleId = proxyModel.roleIdFromName(m_roleName);
+    if (roleId < 0) {
+        return true;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    IF_ASSERT_FAILED(sourceModel) {
+        return true;
+    }
+
+    const QModelIndex index = sourceModel->index(sourceRow, 0, sourceParent);
+    const QVariant data = sourceModel->data(index, roleId);
+    switch (m_compareType) {
+    case CompareType::Equal:
+        return data == m_roleValue;
+    case CompareType::NotEqual:
+        return data != m_roleValue;
+    case CompareType::Contains:
+        return data.toString().contains(m_roleValue.toString(), Qt::CaseInsensitive);
+    }
+
+    return false;
 }
 
 QString FilterValue::roleName() const
 {
     return m_roleName;
-}
-
-QVariant FilterValue::roleValue() const
-{
-    return m_roleValue;
-}
-
-CompareType::Type FilterValue::compareType() const
-{
-    return m_compareType;
-}
-
-bool FilterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void FilterValue::setRoleName(QString roleName)
@@ -58,6 +75,11 @@ void FilterValue::setRoleName(QString roleName)
     emit dataChanged();
 }
 
+QVariant FilterValue::roleValue() const
+{
+    return m_roleValue;
+}
+
 void FilterValue::setRoleValue(QVariant value)
 {
     if (m_roleValue == value) {
@@ -68,6 +90,11 @@ void FilterValue::setRoleValue(QVariant value)
     emit dataChanged();
 }
 
+CompareType::Type FilterValue::compareType() const
+{
+    return m_compareType;
+}
+
 void FilterValue::setCompareType(CompareType::Type type)
 {
     if (m_compareType == type) {
@@ -75,30 +102,5 @@ void FilterValue::setCompareType(CompareType::Type type)
     }
 
     m_compareType = type;
-    emit dataChanged();
-}
-
-void FilterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-    emit dataChanged();
-}
-
-bool FilterValue::async() const
-{
-    return m_async;
-}
-
-void FilterValue::setAsync(bool async)
-{
-    if (m_async == async) {
-        return;
-    }
-
-    m_async = async;
     emit dataChanged();
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filtervalue.h
@@ -24,8 +24,10 @@
 
 #include <qqmlintegration.h>
 
-#include <QObject>
+#include <QString>
 #include <QVariant>
+
+#include "filter.h"
 
 namespace muse::uicomponents {
 namespace CompareType {
@@ -41,7 +43,7 @@ enum Type
 Q_ENUM_NS(Type)
 }
 
-class FilterValue : public QObject
+class FilterValue : public Filter
 {
     Q_OBJECT
     QML_ELEMENT
@@ -49,36 +51,24 @@ class FilterValue : public QObject
     Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
     Q_PROPERTY(QVariant roleValue READ roleValue WRITE setRoleValue NOTIFY dataChanged)
     Q_PROPERTY(muse::uicomponents::CompareType::Type compareType READ compareType WRITE setCompareType NOTIFY dataChanged)
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
-
-    /// Determines whether the SortFilterProxyModel should react asynchronously to the `dataChanged` signal.
-    Q_PROPERTY(bool async READ async WRITE setAsync NOTIFY dataChanged)
 
 public:
     explicit FilterValue(QObject* parent = nullptr);
 
+    bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) override;
+
     QString roleName() const;
-    QVariant roleValue() const;
-    CompareType::Type compareType() const;
-    bool enabled() const;
-
-    bool async() const;
-    void setAsync(bool async);
-
-public slots:
     void setRoleName(QString roleName);
-    void setRoleValue(QVariant roleValue);
-    void setCompareType(muse::uicomponents::CompareType::Type compareType);
-    void setEnabled(bool enabled);
 
-signals:
-    void dataChanged();
+    QVariant roleValue() const;
+    void setRoleValue(QVariant roleValue);
+
+    CompareType::Type compareType() const;
+    void setCompareType(muse::uicomponents::CompareType::Type compareType);
 
 private:
     QString m_roleName;
     QVariant m_roleValue;
     CompareType::Type m_compareType = CompareType::Equal;
-    bool m_enabled = true;
-    bool m_async = false;
 };
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "fuzzyfilter.h"
+
+#include <algorithm>
+#include <iterator>
+
+#include "sortfilterproxymodel.h"
+
+namespace muse::uicomponents {
+FuzzyFilter::FuzzyFilter(QObject* parent)
+    : Filter(parent)
+{
+}
+
+bool FuzzyFilter::acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel& proxyModel)
+{
+    const QModelIndex sourceIndex = proxyModel.sourceModel()->index(sourceRow, 0, sourceParent);
+    const std::optional<double> score = getScore(sourceIndex, proxyModel);
+
+    return score.has_value();
+}
+
+void FuzzyFilter::invalidate()
+{
+    clearScoreCache();
+    emit dataChanged();
+}
+
+QString FuzzyFilter::fuzzyPattern() const
+{
+    return m_fuzzyPattern;
+}
+
+void FuzzyFilter::setFuzzyPattern(const QString& fuzzyPattern)
+{
+    const QString simplifiedPattern = fuzzyPattern.simplified();
+    if (m_fuzzyPattern == simplifiedPattern) {
+        return;
+    }
+
+    m_fuzzyPattern = simplifiedPattern;
+    compilePattern();
+
+    emit dataChanged();
+}
+
+QString FuzzyFilter::roleName() const
+{
+    return m_roleName;
+}
+
+void FuzzyFilter::setRoleName(const QString& roleName)
+{
+    if (m_roleName == roleName) {
+        return;
+    }
+
+    clearScoreCache();
+
+    m_roleName = roleName;
+    emit dataChanged();
+}
+
+Qt::CaseSensitivity FuzzyFilter::caseSensitivity() const
+{
+    return m_caseSensitivity;
+}
+
+void FuzzyFilter::setCaseSensitivity(const Qt::CaseSensitivity caseSensitivity)
+{
+    if (m_caseSensitivity == caseSensitivity) {
+        return;
+    }
+
+    m_caseSensitivity = caseSensitivity;
+    compilePattern();
+    emit dataChanged();
+}
+
+std::optional<double> FuzzyFilter::getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+{
+    auto scoreIt = m_scoreCache.find(sourceIndex);
+    if (scoreIt != m_scoreCache.end()) {
+        return scoreIt.value();
+    }
+
+    std::optional<double> score = calcScore(sourceIndex, proxyModel);
+    // don't cache score of filtered out items because the cache
+    // is always reset before filtering and therefore only used for sorting
+    // already filtered items
+    if (!score) {
+        return score;
+    }
+
+    m_scoreCache.try_emplace(sourceIndex, *score);
+
+    return score;
+}
+
+void FuzzyFilter::compilePattern()
+{
+    clearScoreCache();
+
+    m_patternTokens.clear();
+
+    const QString caseAdjustedPattern = caseSensitivity() == Qt::CaseInsensitive
+                                        ? m_fuzzyPattern.toLower()
+                                        : m_fuzzyPattern;
+
+    const QStringList tokens = caseAdjustedPattern.split(u' ');
+    std::transform(tokens.begin(), tokens.end(), std::back_inserter(m_patternTokens), [](const QString& token) {
+        return token.toStdU32String();
+    });
+}
+
+std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+{
+    const int role = proxyModel.roleIdFromName(m_roleName);
+    if (role == -1) {
+        return std::nullopt;
+    }
+
+    const QString rawText = proxyModel.sourceModel()->data(sourceIndex, role)
+                            .toString();
+    const std::u32string text = caseSensitivity() == Qt::CaseInsensitive
+                                ? rawText.toLower().toStdU32String()
+                                : rawText.toStdU32String();
+
+    double score = 0.0;
+    for (const auto& patternToken : m_patternTokens) {
+        const std::size_t tokenSize = patternToken.size();
+        if (tokenSize == 0) {
+            continue;
+        }
+
+        constexpr std::size_t MIN_TOKEN_SIZE_FOR_FUZZY_MATCH = 4;
+        constexpr std::size_t CHARS_PER_ERROR = 8;
+        const std::size_t maxDistance = tokenSize >= MIN_TOKEN_SIZE_FOR_FUZZY_MATCH
+                                        ? 1 + (tokenSize / CHARS_PER_ERROR)
+                                        : 0;
+
+        const double inverseTokenSize = 1.0 / tokenSize;
+        std::optional<double> bestTokenScore;
+
+        for (const auto& match : m_matcher(text, patternToken, maxDistance)) {
+            const double matchSimilarity = 1.0 - (match.editDistance * inverseTokenSize);
+            double matchScore = 5.0 * matchSimilarity;
+
+            const bool isMatchStartAtStartOfWord = match.beginPos == 0
+                                                   || text[match.beginPos - 1] == U' ';
+            if (isMatchStartAtStartOfWord) {
+                const bool isMatchEndAtEndOfWord = match.endPos == text.size()
+                                                   || text[match.endPos] == U' ';
+                if (isMatchEndAtEndOfWord) {
+                    matchScore += 2.0 * inverseTokenSize;
+                } else {
+                    matchScore += inverseTokenSize;
+                }
+            }
+
+            if (bestTokenScore < matchScore) {
+                bestTokenScore = matchScore;
+            }
+        }
+
+        // no match for token found -> no score for entire pattern
+        if (!bestTokenScore) {
+            return bestTokenScore;
+        }
+
+        score += *bestTokenScore;
+    }
+
+    return score;
+}
+
+void FuzzyFilter::clearScoreCache()
+{
+    m_scoreCache.clear();
+}
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -44,7 +44,6 @@ bool FuzzyFilter::acceptsRow(int sourceRow, const QModelIndex& sourceParent, con
 void FuzzyFilter::invalidate()
 {
     clearScoreCache();
-    emit dataChanged();
 }
 
 QString FuzzyFilter::fuzzyPattern() const

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -62,6 +62,7 @@ void FuzzyFilter::setFuzzyPattern(const QString& fuzzyPattern)
     m_fuzzyPattern = simplifiedPattern;
     compilePattern();
 
+    emit fuzzyPatternChanged();
     emit dataChanged();
 }
 
@@ -79,6 +80,7 @@ void FuzzyFilter::setRoleName(const QString& roleName)
     clearScoreCache();
 
     m_roleName = roleName;
+    emit roleNameChanged();
     emit dataChanged();
 }
 
@@ -95,6 +97,7 @@ void FuzzyFilter::setCaseSensitivity(const Qt::CaseSensitivity caseSensitivity)
 
     m_caseSensitivity = caseSensitivity;
     compilePattern();
+    emit caseSensitivityChanged();
     emit dataChanged();
 }
 

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
@@ -41,9 +41,9 @@ class FuzzyFilter : public Filter
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(QString fuzzyPattern READ fuzzyPattern WRITE setFuzzyPattern NOTIFY dataChanged)
-    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
-    Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity NOTIFY dataChanged)
+    Q_PROPERTY(QString fuzzyPattern READ fuzzyPattern WRITE setFuzzyPattern NOTIFY fuzzyPatternChanged)
+    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY roleNameChanged)
+    Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity NOTIFY caseSensitivityChanged)
 
 public:
     explicit FuzzyFilter(QObject* parent = nullptr);
@@ -61,6 +61,11 @@ public:
     void setCaseSensitivity(Qt::CaseSensitivity);
 
     std::optional<double> getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel&);
+
+signals:
+    void fuzzyPatternChanged();
+    void roleNameChanged();
+    void caseSensitivityChanged();
 
 private:
     void compilePattern();

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <QtQmlIntegration/qqmlintegration.h>
+#include <QObject>
+#include <QPersistentModelIndex>
+#include <QString>
+
+#include "global/stringsearch.h"
+
+#include "filter.h"
+
+namespace muse::uicomponents {
+class FuzzyFilter : public Filter
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(QString fuzzyPattern READ fuzzyPattern WRITE setFuzzyPattern NOTIFY dataChanged)
+    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+    Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity NOTIFY dataChanged)
+
+public:
+    explicit FuzzyFilter(QObject* parent = nullptr);
+
+    bool acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel&) override;
+    void invalidate() override;
+
+    QString fuzzyPattern() const;
+    void setFuzzyPattern(const QString&);
+
+    QString roleName() const;
+    void setRoleName(const QString&);
+
+    Qt::CaseSensitivity caseSensitivity() const;
+    void setCaseSensitivity(Qt::CaseSensitivity);
+
+    std::optional<double> getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel&);
+
+private:
+    void compilePattern();
+
+    std::optional<double> calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel&);
+    void clearScoreCache();
+
+    QString m_fuzzyPattern;
+    QString m_roleName;
+    Qt::CaseSensitivity m_caseSensitivity = Qt::CaseSensitive;
+
+    std::vector<std::u32string> m_patternTokens;
+    FuzzyMatcher m_matcher;
+    QHash<QPersistentModelIndex, double> m_scoreCache;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "fuzzyscoresorter.h"
+
+namespace muse::uicomponents {
+FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
+    : Sorter(parent)
+{
+    setSortOrder(Qt::DescendingOrder);
+}
+
+bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
+                                const SortFilterProxyModel& proxyModel)
+{
+    if (!m_fuzzyFilter) {
+        return sourceLeft < sourceRight;
+    }
+
+    const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft, proxyModel);
+    const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight, proxyModel);
+
+    return leftScore < rightScore;
+}
+
+FuzzyFilter* FuzzyScoreSorter::fuzzyFilter() const
+{
+    return m_fuzzyFilter;
+}
+
+void FuzzyScoreSorter::setFuzzyFilter(FuzzyFilter* fuzzyFilter)
+{
+    if (m_fuzzyFilter == fuzzyFilter) {
+        return;
+    }
+
+    disconnect(m_filterChangedConnection);
+
+    m_fuzzyFilter = fuzzyFilter;
+    emit dataChanged();
+
+    if (m_fuzzyFilter) {
+        m_filterChangedConnection = connect(m_fuzzyFilter, &Filter::dataChanged, this, &Sorter::dataChanged);
+    }
+}
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -56,10 +56,12 @@ void FuzzyScoreSorter::setFuzzyFilter(FuzzyFilter* fuzzyFilter)
     disconnect(m_filterChangedConnection);
 
     m_fuzzyFilter = fuzzyFilter;
-    emit dataChanged();
 
     if (m_fuzzyFilter) {
         m_filterChangedConnection = connect(m_fuzzyFilter, &Filter::dataChanged, this, &Sorter::dataChanged);
     }
+
+    emit fuzzyFilterChanged();
+    emit dataChanged();
 }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
@@ -36,7 +36,7 @@ class FuzzyScoreSorter : public Sorter
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(muse::uicomponents::FuzzyFilter* fuzzyFilter READ fuzzyFilter WRITE setFuzzyFilter NOTIFY dataChanged REQUIRED)
+    Q_PROPERTY(muse::uicomponents::FuzzyFilter* fuzzyFilter READ fuzzyFilter WRITE setFuzzyFilter NOTIFY fuzzyFilterChanged REQUIRED)
 
 public:
     explicit FuzzyScoreSorter(QObject* parent = nullptr);
@@ -45,6 +45,9 @@ public:
 
     FuzzyFilter* fuzzyFilter() const;
     void setFuzzyFilter(FuzzyFilter*);
+
+signals:
+    void fuzzyFilterChanged();
 
 private:
     QPointer<FuzzyFilter> m_fuzzyFilter;

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.h
@@ -20,45 +20,34 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "filter.h"
+#pragma once
+
+#include <QtQmlIntegration/qqmlintegration.h>
+#include <QMetaObject>
+#include <QObject>
+#include <QPointer>
+
+#include "fuzzyfilter.h"
+#include "sorter.h"
 
 namespace muse::uicomponents {
-Filter::Filter(QObject* parent)
-    : QObject(parent)
+class FuzzyScoreSorter : public Sorter
 {
-}
+    Q_OBJECT
+    QML_ELEMENT
 
-void Filter::invalidate()
-{
-}
+    Q_PROPERTY(muse::uicomponents::FuzzyFilter* fuzzyFilter READ fuzzyFilter WRITE setFuzzyFilter NOTIFY dataChanged REQUIRED)
 
-bool Filter::enabled() const
-{
-    return m_enabled;
-}
+public:
+    explicit FuzzyScoreSorter(QObject* parent = nullptr);
 
-void Filter::setEnabled(const bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
+    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
 
-    m_enabled = enabled;
-    emit dataChanged();
-}
+    FuzzyFilter* fuzzyFilter() const;
+    void setFuzzyFilter(FuzzyFilter*);
 
-bool Filter::async() const
-{
-    return m_async;
-}
-
-void Filter::setAsync(const bool async)
-{
-    if (m_async == async) {
-        return;
-    }
-
-    m_async = async;
-    emit dataChanged();
-}
+private:
+    QPointer<FuzzyFilter> m_fuzzyFilter;
+    QMetaObject::Connection m_filterChangedConnection;
+};
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
@@ -40,6 +40,7 @@ void Sorter::setSortOrder(const Qt::SortOrder sortOrder)
     }
 
     m_sortOrder = sortOrder;
+    emit sortOrderChanged();
     emit dataChanged();
 }
 
@@ -55,6 +56,7 @@ void Sorter::setEnabled(const bool enabled)
     }
 
     m_enabled = enabled;
+    emit enabledChanged();
     emit dataChanged();
 }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.cpp
@@ -2,10 +2,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
- * MuseScore Studio
+ * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,31 +20,41 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include <qqmlintegration.h>
-
-#include <QString>
-
 #include "sorter.h"
 
 namespace muse::uicomponents {
-class SorterValue : public Sorter
+Sorter::Sorter(QObject* parent)
+    : QObject(parent)
 {
-    Q_OBJECT
-    QML_ELEMENT
+}
 
-    Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY dataChanged)
+Qt::SortOrder Sorter::sortOrder() const
+{
+    return m_sortOrder;
+}
 
-public:
-    explicit SorterValue(QObject* parent = nullptr);
+void Sorter::setSortOrder(const Qt::SortOrder sortOrder)
+{
+    if (m_sortOrder == sortOrder) {
+        return;
+    }
 
-    bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) override;
+    m_sortOrder = sortOrder;
+    emit dataChanged();
+}
 
-    QString roleName() const;
-    void setRoleName(QString roleName);
+bool Sorter::enabled() const
+{
+    return m_enabled;
+}
 
-private:
-    QString m_roleName;
-};
+void Sorter::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    emit dataChanged();
+}
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.h
@@ -38,8 +38,8 @@ class Sorter : public QObject
     QML_ELEMENT;
     QML_UNCREATABLE("")
 
-    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY dataChanged)
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY sortOrderChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
 
 public:
     explicit Sorter(QObject* parent = nullptr);
@@ -54,6 +54,8 @@ public:
 
 signals:
     void dataChanged();
+    void sortOrderChanged();
+    void enabledChanged();
 
 private:
     Qt::SortOrder m_sortOrder = Qt::AscendingOrder;

--- a/framework/uicomponents/qml/Muse/UiComponents/sorter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sorter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtQmlIntegration/qqmlintegration.h>
+
+#include <QObject>
+#include <QtCore/qnamespace.h>
+
+class QModelIndex;
+
+namespace muse::uicomponents {
+class SortFilterProxyModel;
+
+class Sorter : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT;
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY dataChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY dataChanged)
+
+public:
+    explicit Sorter(QObject* parent = nullptr);
+
+    virtual bool lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight, const SortFilterProxyModel&) = 0;
+
+    Qt::SortOrder sortOrder() const;
+    void setSortOrder(Qt::SortOrder sortOrder);
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+signals:
+    void dataChanged();
+
+private:
+    Qt::SortOrder m_sortOrder = Qt::AscendingOrder;
+    bool m_enabled = false;
+};
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortervalue.cpp
@@ -19,28 +19,46 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortervalue.h"
+
+#include "global/log.h"
+
+#include "sortfilterproxymodel.h"
 
 using namespace muse::uicomponents;
 
 SorterValue::SorterValue(QObject* parent)
-    : QObject(parent)
+    : Sorter(parent)
 {
+}
+
+bool SorterValue::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
+                           const SortFilterProxyModel& proxyModel)
+{
+    const int roleId = proxyModel.roleIdFromName(m_roleName);
+    if (roleId < 0) {
+        return sourceLeft < sourceRight;
+    }
+
+    const QAbstractItemModel* sourceModel = proxyModel.sourceModel();
+    IF_ASSERT_FAILED(sourceModel) {
+        return sourceLeft < sourceRight;
+    }
+
+    const QVariant leftData = sourceModel->data(sourceLeft, roleId);
+    const QVariant rightData = sourceModel->data(sourceRight, roleId);
+    const QPartialOrdering ordering = QVariant::compare(leftData, rightData);
+    if (ordering == QPartialOrdering::Unordered || ordering == QPartialOrdering::Equivalent) {
+        return sourceLeft < sourceRight;
+    }
+
+    return ordering == QPartialOrdering::Less;
 }
 
 QString SorterValue::roleName() const
 {
     return m_roleName;
-}
-
-Qt::SortOrder SorterValue::sortOrder() const
-{
-    return m_sortOrder;
-}
-
-bool SorterValue::enabled() const
-{
-    return m_enabled;
 }
 
 void SorterValue::setRoleName(QString roleName)
@@ -50,30 +68,5 @@ void SorterValue::setRoleName(QString roleName)
     }
 
     m_roleName = roleName;
-    emit dataChanged();
-}
-
-void SorterValue::setSortOrder(Qt::SortOrder sortOrder)
-{
-    if (m_sortOrder == sortOrder) {
-        return;
-    }
-
-    m_sortOrder = sortOrder;
-    emit dataChanged();
-}
-
-void SorterValue::setEnabled(bool enabled)
-{
-    if (m_enabled == enabled) {
-        return;
-    }
-
-    m_enabled = enabled;
-
-    if (!enabled) {
-        m_sortOrder = Qt::AscendingOrder;
-    }
-
     emit dataChanged();
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -163,11 +163,19 @@ QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
 
 void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
 {
-    if (m_subSourceModelConnection) {
-        disconnect(m_subSourceModelConnection);
-    }
+    disconnect(m_subSourceModelConnection);
+    disconnect(m_sourceModelAboutToBeResetConnection);
+    disconnect(m_sourceDataChangedConnection);
+    invalidateFilters();
 
     QSortFilterProxyModel::setSourceModel(sourceModel);
+
+    if (sourceModel) {
+        m_sourceDataChangedConnection = connect(sourceModel, &QAbstractItemModel::dataChanged,
+                                                this, &SortFilterProxyModel::invalidateFilters);
+        m_sourceModelAboutToBeResetConnection = connect(sourceModel, &QAbstractItemModel::modelAboutToBeReset,
+                                                        this, &SortFilterProxyModel::invalidateFilters);
+    }
 
     emit sourceModelRoleNamesChanged();
 
@@ -223,5 +231,13 @@ void SortFilterProxyModel::updateRoleIds()
     for (const auto& [roleId, roleName] : roleNames.asKeyValueRange()) {
         const auto [it, didInsert] = m_roleIds.try_emplace(roleName, roleId);
         DO_ASSERT_X(didInsert, "duplicate role name");
+    }
+}
+
+void SortFilterProxyModel::invalidateFilters()
+{
+    const QList<Filter*> filters = m_filters.list();
+    for (auto* filter : filters) {
+        filter->invalidate();
     }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -22,6 +22,8 @@
 
 #include "sortfilterproxymodel.h"
 
+#include <algorithm>
+
 #include <QTimer>
 #include <QtVersionChecks>
 
@@ -49,8 +51,8 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 #endif
     };
 
-    auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
-        if (changedFilterValue->async()) {
+    auto onFilterChanged = [this, invalidateRows](Filter* changedFilter) {
+        if (changedFilter->async()) {
             QTimer::singleShot(0, this, invalidateRows);
         } else {
             invalidateRows();
@@ -58,13 +60,12 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     };
 
     connect(m_filters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onFilterChanged](int index) {
-        FilterValue* filter = m_filters.at(index);
-
+        Filter* filter = m_filters.at(index);
         if (filter->enabled()) {
             onFilterChanged(filter);
         }
 
-        connect(filter, &FilterValue::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
+        connect(filter, &Filter::dataChanged, this, [onFilterChanged, filter] { onFilterChanged(filter); });
     });
 
     auto onSortersChanged = [this] {
@@ -91,7 +92,7 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 }
 
-QQmlListProperty<FilterValue> SortFilterProxyModel::filters()
+QQmlListProperty<Filter> SortFilterProxyModel::filters()
 {
     return m_filters.property();
 }
@@ -185,39 +186,10 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
         return false;
     }
 
-    const QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-    const QList<FilterValue*> filters = m_filters.list();
-    for (auto* filter : filters) {
-        if (!filter->enabled()) {
-            continue;
-        }
-
-        const int roleId = roleIdFromName(filter->roleName());
-        if (roleId < 0) {
-            continue;
-        }
-
-        const QVariant data = sourceModel()->data(index, roleId);
-        switch (filter->compareType()) {
-        case CompareType::Equal:
-            if (data != filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::NotEqual:
-            if (data == filter->roleValue()) {
-                return false;
-            }
-            break;
-        case CompareType::Contains:
-            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
-                return false;
-            }
-            break;
-        }
-    }
-
-    return true;
+    const QList<Filter*> filters = m_filters.list();
+    return std::all_of(filters.begin(), filters.end(), [&] (Filter* filter) {
+        return !filter->enabled() || filter->acceptsRow(sourceRow, sourceParent, *this);
+    });
 }
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -25,27 +25,35 @@
 #include <QTimer>
 #include <QtVersionChecks>
 
-#include "global/defer.h"
+#include "global/log.h"
 #include "global/types/val.h"
 
 #include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
 
-static const int INVALID_KEY = -1;
+static constexpr int INVALID_ROLE_ID = -1;
 
 SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     : QSortFilterProxyModel(parent), m_filters(this), m_sorters(this)
 {
     ModelUtils::connectRowCountChangedSignal(this, &SortFilterProxyModel::rowCountChanged);
+    connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, &SortFilterProxyModel::updateRoleIds);
 
-    auto onFilterChanged = [this](FilterValue* changedFilterValue) {
+    const auto invalidateRows = [this] {
+        beginFilterChange();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(Direction::Rows);
+#else
+        invalidateFilter();
+#endif
+    };
+
+    auto onFilterChanged = [this, invalidateRows](FilterValue* changedFilterValue) {
         if (changedFilterValue->async()) {
-            QTimer::singleShot(0, this, [this](){
-                fillRoleIds();
-            });
+            QTimer::singleShot(0, this, invalidateRows);
         } else {
-            fillRoleIds();
+            invalidateRows();
         }
     };
 
@@ -80,7 +88,6 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
         invalidate();
-        fillRoleIds();
     });
 }
 
@@ -140,7 +147,7 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
 
 int SortFilterProxyModel::roleIdFromName(const QString& roleName) const
 {
-    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+    return m_roleIds.value(roleName.toUtf8(), INVALID_ROLE_ID);
 }
 
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
@@ -178,32 +185,32 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
         return false;
     }
 
-    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-
-    QHashIterator<int, FilterValue*> it(m_roleIdToFilterValueHash);
-    while (it.hasNext()) {
-        it.next();
-
-        QVariant data = sourceModel()->data(index, it.key());
-        FilterValue* value = it.value();
-
-        if (!value->enabled()) {
+    const QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+    const QList<FilterValue*> filters = m_filters.list();
+    for (auto* filter : filters) {
+        if (!filter->enabled()) {
             continue;
         }
 
-        switch (value->compareType()) {
+        const int roleId = roleIdFromName(filter->roleName());
+        if (roleId < 0) {
+            continue;
+        }
+
+        const QVariant data = sourceModel()->data(index, roleId);
+        switch (filter->compareType()) {
         case CompareType::Equal:
-            if (data != value->roleValue()) {
+            if (data != filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::NotEqual:
-            if (data == value->roleValue()) {
+            if (data == filter->roleValue()) {
                 return false;
             }
             break;
         case CompareType::Contains:
-            if (!data.toString().contains(value->roleValue().toString(), Qt::CaseInsensitive)) {
+            if (!data.toString().contains(filter->roleValue().toString(), Qt::CaseInsensitive)) {
                 return false;
             }
             break;
@@ -228,40 +235,6 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
     return leftData < rightData;
 }
 
-void SortFilterProxyModel::fillRoleIds()
-{
-    beginFilterChange();
-
-    DEFER {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        endFilterChange(QSortFilterProxyModel::Direction::Rows);
-#else
-        invalidateFilter();
-#endif
-    };
-
-    m_roleIdToFilterValueHash.clear();
-
-    if (!sourceModel()) {
-        return;
-    }
-
-    QHash<QString, FilterValue*> roleNameToValueHash;
-    QList<FilterValue*> filterList = m_filters.list();
-    for (FilterValue* filter : std::as_const(filterList)) {
-        roleNameToValueHash.insert(filter->roleName(), filter);
-    }
-
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    QHash<int, QByteArray>::const_iterator it = roles.constBegin();
-    while (it != roles.constEnd()) {
-        if (roleNameToValueHash.contains(it.value())) {
-            m_roleIdToFilterValueHash.insert(it.key(), roleNameToValueHash[it.value()]);
-        }
-        ++it;
-    }
-}
-
 SorterValue* SortFilterProxyModel::currentSorterValue() const
 {
     QList<SorterValue*> sorterList = m_sorters.list();
@@ -272,4 +245,15 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
     }
 
     return nullptr;
+}
+
+void SortFilterProxyModel::updateRoleIds()
+{
+    m_roleIds.clear();
+
+    const QHash<int, QByteArray> roleNames = this->roleNames();
+    for (const auto& [roleId, roleName] : roleNames.asKeyValueRange()) {
+        const auto [it, didInsert] = m_roleIds.try_emplace(roleName, roleId);
+        DO_ASSERT_X(didInsert, "duplicate role name");
+    }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -28,7 +28,6 @@
 #include <QtVersionChecks>
 
 #include "global/log.h"
-#include "global/types/val.h"
 
 #include "uicomponents/view/modelutils.h"
 
@@ -69,22 +68,24 @@ SortFilterProxyModel::SortFilterProxyModel(QObject* parent)
     });
 
     auto onSortersChanged = [this] {
-        SorterValue* sorter = currentSorterValue();
+        Sorter* sorter = currentSorter();
         invalidate();
 
         if (!sorter) {
+            sort(-1, Qt::AscendingOrder);
             return;
         }
 
-        if (sourceModel()) {
-            sort(0, sorter->sortOrder());
-        }
+        sort(0, sorter->sortOrder());
     };
 
     connect(m_sorters.notifier(), &QmlListPropertyNotifier::appended, this, [this, onSortersChanged](int index) {
-        onSortersChanged();
+        Sorter* sorter = m_sorters.at(index);
+        if (sorter->enabled()) {
+            onSortersChanged();
+        }
 
-        connect(m_sorters.at(index), &SorterValue::dataChanged, this, onSortersChanged);
+        connect(sorter, &Sorter::dataChanged, this, onSortersChanged);
     });
 
     connect(this, &SortFilterProxyModel::sourceModelRoleNamesChanged, this, [this]() {
@@ -97,7 +98,7 @@ QQmlListProperty<Filter> SortFilterProxyModel::filters()
     return m_filters.property();
 }
 
-QQmlListProperty<SorterValue> SortFilterProxyModel::sorters()
+QQmlListProperty<Sorter> SortFilterProxyModel::sorters()
 {
     return m_sorters.property();
 }
@@ -194,23 +195,18 @@ bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& so
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
-    SorterValue* sorter = currentSorterValue();
+    Sorter* sorter = currentSorter();
     if (!sorter) {
-        return false;
+        return left < right;
     }
 
-    int sorterRoleKey = roleIdFromName(sorter->roleName());
-
-    Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
-    Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
-
-    return leftData < rightData;
+    return sorter->lessThan(left, right, *this);
 }
 
-SorterValue* SortFilterProxyModel::currentSorterValue() const
+Sorter* SortFilterProxyModel::currentSorter() const
 {
-    QList<SorterValue*> sorterList = m_sorters.list();
-    for (SorterValue* sorter : std::as_const(sorterList)) {
+    const QList<Sorter*> sorterList = m_sorters.list();
+    for (Sorter* sorter : sorterList) {
         if (sorter->enabled()) {
             return sorter;
         }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.cpp
@@ -19,14 +19,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "sortfilterproxymodel.h"
 
 #include <QTimer>
+#include <QtVersionChecks>
 
-#include "defer.h"
-#include "types/val.h"
+#include "global/defer.h"
+#include "global/types/val.h"
 
-#include "view/modelutils.h"
+#include "uicomponents/view/modelutils.h"
 
 using namespace muse::uicomponents;
 
@@ -136,6 +138,11 @@ void SortFilterProxyModel::setAlwaysExcludeIndices(const QList<int>& indices)
     emit alwaysExcludeIndicesChanged();
 }
 
+int SortFilterProxyModel::roleIdFromName(const QString& roleName) const
+{
+    return roleNames().key(roleName.toUtf8(), INVALID_KEY);
+}
+
 QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
 {
     if (!sourceModel()) {
@@ -159,12 +166,6 @@ void SortFilterProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
         m_subSourceModelConnection = connect(sourceSortFilterModel, &SortFilterProxyModel::sourceModelRoleNamesChanged,
                                              this, &SortFilterProxyModel::sourceModelRoleNamesChanged);
     }
-}
-
-void SortFilterProxyModel::refresh()
-{
-    setFilterFixedString(filterRegularExpression().pattern());
-    setSortCaseSensitivity(sortCaseSensitivity());
 }
 
 bool SortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
@@ -219,19 +220,12 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& left, const QModelIndex& 
         return false;
     }
 
-    int sorterRoleKey = roleKey(sorter->roleName());
+    int sorterRoleKey = roleIdFromName(sorter->roleName());
 
     Val leftData = Val::fromQVariant(sourceModel()->data(left, sorterRoleKey));
     Val rightData = Val::fromQVariant(sourceModel()->data(right, sorterRoleKey));
 
     return leftData < rightData;
-}
-
-void SortFilterProxyModel::reset()
-{
-    beginResetModel();
-    resetInternalData();
-    endResetModel();
 }
 
 void SortFilterProxyModel::fillRoleIds()
@@ -278,16 +272,4 @@ SorterValue* SortFilterProxyModel::currentSorterValue() const
     }
 
     return nullptr;
-}
-
-int SortFilterProxyModel::roleKey(const QString& roleName) const
-{
-    QHash<int, QByteArray> roles = sourceModel()->roleNames();
-    for (auto it = roles.begin(); it != roles.end(); ++it) {
-        if (roleName == QString(it.value())) {
-            return it.key();
-        }
-    }
-
-    return INVALID_KEY;
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -77,6 +77,7 @@ protected:
 private:
     void updateRoleIds();
     Sorter* currentSorter() const;
+    void invalidateFilters();
 
     QHash<QByteArray, int> m_roleIds;
 
@@ -87,5 +88,7 @@ private:
     QList<int> m_alwaysExcludeIndices;
 
     QMetaObject::Connection m_subSourceModelConnection;
+    QMetaObject::Connection m_sourceDataChangedConnection;
+    QMetaObject::Connection m_sourceModelAboutToBeResetConnection;
 };
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -24,6 +24,7 @@
 
 #include <qqmlintegration.h>
 
+#include <QByteArray>
 #include <QHash>
 #include <QList>
 #include <QSortFilterProxyModel>
@@ -74,13 +75,12 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void fillRoleIds();
-
+    void updateRoleIds();
     SorterValue* currentSorterValue() const;
 
-    QmlListProperty<FilterValue> m_filters;
-    QHash<int, FilterValue*> m_roleIdToFilterValueHash;
+    QHash<QByteArray, int> m_roleIds;
 
+    QmlListProperty<FilterValue> m_filters;
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -29,7 +29,7 @@
 #include <QList>
 #include <QSortFilterProxyModel>
 
-#include "filtervalue.h"
+#include "filter.h"
 #include "sortervalue.h"
 #include "qmllistproperty.h"
 
@@ -40,7 +40,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
     QML_ELEMENT
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
@@ -48,7 +48,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
-    QQmlListProperty<FilterValue> filters();
+    QQmlListProperty<Filter> filters();
     QQmlListProperty<SorterValue> sorters();
 
     QList<int> alwaysIncludeIndices() const;
@@ -80,7 +80,7 @@ private:
 
     QHash<QByteArray, int> m_roleIds;
 
-    QmlListProperty<FilterValue> m_filters;
+    QmlListProperty<Filter> m_filters;
     QmlListProperty<SorterValue> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -30,8 +30,8 @@
 #include <QSortFilterProxyModel>
 
 #include "filter.h"
-#include "sortervalue.h"
 #include "qmllistproperty.h"
+#include "sorter.h"
 
 namespace muse::uicomponents {
 class SortFilterProxyModel : public QSortFilterProxyModel
@@ -41,7 +41,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::Filter> filters READ filters CONSTANT)
-    Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
+    Q_PROPERTY(QQmlListProperty<muse::uicomponents::Sorter> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
     Q_PROPERTY(QList<int> alwaysExcludeIndices READ alwaysExcludeIndices WRITE setAlwaysExcludeIndices NOTIFY alwaysExcludeIndicesChanged)
 
@@ -49,7 +49,7 @@ public:
     explicit SortFilterProxyModel(QObject* parent = nullptr);
 
     QQmlListProperty<Filter> filters();
-    QQmlListProperty<SorterValue> sorters();
+    QQmlListProperty<Sorter> sorters();
 
     QList<int> alwaysIncludeIndices() const;
     void setAlwaysIncludeIndices(const QList<int>& indices);
@@ -76,12 +76,12 @@ protected:
 
 private:
     void updateRoleIds();
-    SorterValue* currentSorterValue() const;
+    Sorter* currentSorter() const;
 
     QHash<QByteArray, int> m_roleIds;
 
     QmlListProperty<Filter> m_filters;
-    QmlListProperty<SorterValue> m_sorters;
+    QmlListProperty<Sorter> m_sorters;
 
     QList<int> m_alwaysIncludeIndices;
     QList<int> m_alwaysExcludeIndices;

--- a/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h
@@ -19,10 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include <qqmlintegration.h>
 
+#include <QHash>
+#include <QList>
 #include <QSortFilterProxyModel>
 
 #include "filtervalue.h"
@@ -36,7 +39,6 @@ class SortFilterProxyModel : public QSortFilterProxyModel
     QML_ELEMENT
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
-
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::FilterValue> filters READ filters CONSTANT)
     Q_PROPERTY(QQmlListProperty<muse::uicomponents::SorterValue> sorters READ sorters CONSTANT)
     Q_PROPERTY(QList<int> alwaysIncludeIndices READ alwaysIncludeIndices WRITE setAlwaysIncludeIndices NOTIFY alwaysIncludeIndicesChanged)
@@ -54,16 +56,13 @@ public:
     QList<int> alwaysExcludeIndices() const;
     void setAlwaysExcludeIndices(const QList<int>& indices);
 
+    int roleIdFromName(const QString&) const;
     QHash<int, QByteArray> roleNames() const override;
 
     void setSourceModel(QAbstractItemModel* sourceModel) override;
 
-    Q_INVOKABLE void refresh();
-
 signals:
     void rowCountChanged();
-
-    void filtersChanged(QQmlListProperty<muse::uicomponents::FilterValue> filters);
 
     void alwaysIncludeIndicesChanged();
     void alwaysExcludeIndicesChanged();
@@ -75,11 +74,9 @@ protected:
     bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
-    void reset();
     void fillRoleIds();
 
     SorterValue* currentSorterValue() const;
-    int roleKey(const QString& roleName) const;
 
     QmlListProperty<FilterValue> m_filters;
     QHash<int, FilterValue*> m_roleIdToFilterValueHash;

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_TEST muse_uicomponents_qml_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/doubleinputvalidator_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/intinputvalidator_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sortfilterproxymodel_tests.cpp
     )
 
 set(MODULE_TEST_LINK

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/sortfilterproxymodel_tests.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <QString>
+#include <QStringList>
+#include <QStringListModel>
+
+#include "uicomponents/qml/Muse/UiComponents/filtervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortervalue.h"
+#include "uicomponents/qml/Muse/UiComponents/sortfilterproxymodel.h"
+
+using namespace Qt::StringLiterals;
+
+namespace muse::uicomponents {
+class UiComponents_SortFilterProxyModelTests : public ::testing::Test
+{
+public:
+    UiComponents_SortFilterProxyModelTests()
+    {
+        QStringList modelData;
+        modelData << u"hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay needle hay"_s;
+        modelData << u"needle"_s;
+        modelData << u"hay hay"_s;
+        m_model->setStringList(modelData);
+    }
+
+    QAbstractListModel* listModel() const
+    {
+        return m_model.get();
+    }
+
+private:
+    std::unique_ptr<QStringListModel> m_model = std::make_unique<QStringListModel>();
+};
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* filter = new FilterValue(proxyModel.get());
+    filter->setCompareType(CompareType::Equal);
+    filter->setRoleName(u"display"_s);
+    filter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, filter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 2);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(3));
+
+    filter->setCompareType(CompareType::NotEqual);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(0));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(4));
+
+    filter->setCompareType(CompareType::Contains);
+    EXPECT_EQ(proxyModel->rowCount(), 3);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(1));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(1, 0)), model->index(2));
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(2, 0)), model->index(3));
+
+    filter->setEnabled(false);
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testFilterValueMultiple)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    FilterValue* hayFilter = new FilterValue(proxyModel.get());
+    hayFilter->setCompareType(CompareType::Contains);
+    hayFilter->setRoleName(u"display"_s);
+    hayFilter->setRoleValue(u"hay"_s);
+
+    FilterValue* needleFilter = new FilterValue(proxyModel.get());
+    needleFilter->setCompareType(CompareType::Contains);
+    needleFilter->setRoleName(u"display"_s);
+    needleFilter->setRoleValue(u"needle"_s);
+
+    QQmlListProperty<Filter> filters = proxyModel->filters();
+    ASSERT_TRUE(filters.append);
+    filters.append(&filters, hayFilter);
+    filters.append(&filters, needleFilter);
+
+    EXPECT_EQ(proxyModel->rowCount(), 1);
+    EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(0, 0)), model->index(2));
+}
+
+TEST_F(UiComponents_SortFilterProxyModelTests, testSorterValue)
+{
+    QAbstractListModel* model = this->listModel();
+    auto proxyModel = std::make_unique<SortFilterProxyModel>();
+    proxyModel->setSourceModel(model);
+
+    SorterValue* sorter = new SorterValue(proxyModel.get());
+    sorter->setRoleName(u"display"_s);
+
+    QQmlListProperty<Sorter> sorters = proxyModel->sorters();
+    ASSERT_TRUE(sorters.append);
+    sorters.append(&sorters, sorter);
+
+    EXPECT_EQ(proxyModel->rowCount(), model->rowCount());
+    for (int row = 0; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+        EXPECT_EQ(proxyModel->mapToSource(proxyModel->index(row, 0)), model->index(row));
+    }
+
+    sorter->setEnabled(true);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Less || ordering == QPartialOrdering::Equivalent);
+    }
+
+    sorter->setSortOrder(Qt::DescendingOrder);
+    for (int row = 1; row < proxyModel->rowCount(); ++row) {
+        SCOPED_TRACE(row);
+
+        const QPartialOrdering ordering = QVariant::compare(proxyModel->data(proxyModel->index(row - 1, 0)),
+                                                            proxyModel->data(proxyModel->index(row, 0)));
+        EXPECT_TRUE(ordering == QPartialOrdering::Greater || ordering == QPartialOrdering::Equivalent);
+    }
+}
+}


### PR DESCRIPTION
Part of: musescore/musescore#15983 
Rebased after framework split (previous PR: musescore/musescore#32634)
Requires: #14 

This PR implements a fuzzy filter and score sorter and adds fuzzy search support to the shortcuts list in preferences.

### Overview of the Algorithm
1. Split the user input into words (words are assumed to be separated by whitespace)
2. Try to find a fuzzy match of each individual word within every candidate item. Matches have an error budget of 1 when the searched word is 4 characters or longer. An additional error is added to the budget every 8 characters.
3. The resulting items are then sorted by match similarity (amount of errors between the user input and the item). If the amount of errors is equal they are sorted further by whether the match spans a whole word or starts at a word in the item.
An error can be a missing character, an excess character, different characters, and swapped characters.

The implemented fuzzy search algorithm is an extended version of [Seller's variant for string search of the Wagner-Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm#Seller's_variant_for_string_search) (this is the algorithm that is used in our implementation of `muse::string::levenshteinDistance`). It is extended to also allow transposition errors (Damerau-Levenshtein distance).

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
