### PR TITLE
fix(dockwindow_v2): add missing include

### DIFF
--- a/framework/dockwindow_v2/internal/dropcontroller.cpp
+++ b/framework/dockwindow_v2/internal/dropcontroller.cpp
@@ -42,6 +42,7 @@
 #include "kddockwidgets/src/core/DragController_p.h"
 #endif
 
+#include "kddockwidgets/src/core/DockWidget.h"
 #include "kddockwidgets/src/qtquick/views/DockWidget.h"
 #include "kddockwidgets/src/qtquick/views/View.h"
 


### PR DESCRIPTION
Otherwise:
```
/Users/casper/Desktop/MuseScore/MuseScoreGB/muse/framework/dockwindow_v2/internal/dropcontroller.cpp:128:13: error: no matching function for call to 'asQQuickItem'
  128 |             KDDockWidgets::QtQuick::asQQuickItem(dw));
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/_deps/kddockwidgets/kddockwidgets/src/qtquick/views/View.h:34:20: note: candidate function not viable: cannot convert argument of incomplete type 'KDDockWidgets::Core::DockWidget *' to 'Core::View *' for 1st argument
   34 | inline QQuickItem *asQQuickItem(Core::View *view)
      |                    ^            ~~~~~~~~~~~~~~~~
/Users/casper/Desktop/MuseScore/MuseScoreGB/build/Qt_6_11_1_for_macOS-DebugNonUnity/_deps/kddockwidgets/kddockwidgets/src/qtquick/views/View.h:42:20: note: candidate function not viable: cannot convert argument of incomplete type 'KDDockWidgets::Core::DockWidget *' to 'Core::Controller *' for 1st argument
   42 | inline QQuickItem *asQQuickItem(Core::Controller *controller)
      |                    ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

```