### PR TITLE
DockWindow v1. Fix anchoring to hidden dock widgets when adding new ones

### DIFF
--- a/framework/dockwindow/thirdparty/KDDockWidgets/src/private/DropArea.cpp
+++ b/framework/dockwindow/thirdparty/KDDockWidgets/src/private/DropArea.cpp
@@ -111,6 +111,15 @@ void DropArea::addDockWidget(DockWidgetBase *dw, Location location,
 
     Frame *frame = nullptr;
     Frame *relativeToFrame = relativeTo ? relativeTo->d->frame() : nullptr;
+    Layouting::Item *relativeToItem = itemForFrame(relativeToFrame);
+
+    if (relativeTo && !relativeToItem) {
+        // relativeTo is hidden, so it has no frame, anchor to its placeholder item instead
+        if (Layouting::Item *placeholder = relativeTo->d->lastPositions().lastItem()) {
+            if (placeholder->hostWidget() && placeholder->hostWidget()->asQObject() == this)
+                relativeToItem = placeholder;
+        }
+    }
 
     dw->d->saveLastFloatingGeometry();
 
@@ -133,9 +142,9 @@ void DropArea::addDockWidget(DockWidgetBase *dw, Location location,
     }
 
     if (option.startsHidden()) {
-        addWidget(dw, location, relativeToFrame, option);
+        addWidget(dw, location, relativeToItem, option);
     } else {
-        addWidget(frame, location, relativeToFrame, option);
+        addWidget(frame, location, relativeToItem, option);
     }
 
     if (hadSingleFloatingFrame && !hasSingleFloatingFrame()) {
@@ -318,13 +327,13 @@ bool DropArea::drop(QWidgetOrQuick *droppedWindow, KDDockWidgets::Location locat
 
         auto frame = Config::self(m_ctx).frameworkWidgetFactory()->createFrame();
         frame->addWidget(dock);
-        addWidget(frame, location, relativeTo, DefaultSizeMode::FairButFloor);
+        addWidget(frame, location, itemForFrame(relativeTo), DefaultSizeMode::FairButFloor);
     } else if (auto floatingWindow = qobject_cast<FloatingWindow *>(droppedWindow)) {
         if (!validateAffinity(floatingWindow))
             return false;
 
         const bool hadSingleFloatingFrame = hasSingleFloatingFrame();
-        addMultiSplitter(floatingWindow->dropArea(), location, relativeTo,
+        addMultiSplitter(floatingWindow->dropArea(), location, itemForFrame(relativeTo),
                          DefaultSizeMode::FairButFloor);
         if (hadSingleFloatingFrame != hasSingleFloatingFrame())
             updateFloatingActions();

--- a/framework/dockwindow/thirdparty/KDDockWidgets/src/private/MultiSplitter.cpp
+++ b/framework/dockwindow/thirdparty/KDDockWidgets/src/private/MultiSplitter.cpp
@@ -57,7 +57,7 @@ MultiSplitter::~MultiSplitter()
 }
 
 bool MultiSplitter::validateInputs(QWidgetOrQuick *widget, Location location,
-                                   const Frame *relativeToFrame, InitialOption option) const
+                                   const Layouting::Item *relativeTo, InitialOption option) const
 {
     if (!widget) {
         qWarning() << Q_FUNC_INFO << "Widget is null";
@@ -77,7 +77,7 @@ bool MultiSplitter::validateInputs(QWidgetOrQuick *widget, Location location,
         return false;
     }
 
-    if (relativeToFrame && relativeToFrame == widget) {
+    if (relativeTo && relativeTo->guestAsQObject() == widget) {
         qWarning() << "widget can't be relative to itself";
         return false;
     }
@@ -94,13 +94,9 @@ bool MultiSplitter::validateInputs(QWidgetOrQuick *widget, Location location,
         return false;
     }
 
-    const bool relativeToThis = relativeToFrame == nullptr;
-
-    Layouting::Item *relativeToItem = itemForFrame(relativeToFrame);
-    if (!relativeToThis && !containsItem(relativeToItem)) {
+    if (relativeTo && !containsItem(relativeTo)) {
         qWarning() << "MultiSplitter::addWidget: Doesn't contain relativeTo:"
-                   << "; relativeToFrame=" << relativeToFrame
-                   << "; relativeToItem=" << relativeToItem
+                   << "; relativeToItem=" << relativeTo
                    << "; options=" << option;
         return false;
     }
@@ -109,11 +105,18 @@ bool MultiSplitter::validateInputs(QWidgetOrQuick *widget, Location location,
 }
 
 void MultiSplitter::addWidget(QWidgetOrQuick *w, Location location,
-                              Frame *relativeToWidget,
+                              Layouting::Item *relativeTo,
                               InitialOption option)
 {
     auto frame = qobject_cast<Frame *>(w);
-    if (itemForFrame(frame) != nullptr) {
+    Layouting::Item *item = itemForFrame(frame);
+
+    if (relativeTo && relativeTo == item) {
+        qWarning() << "widget can't be relative to itself";
+        return;
+    }
+
+    if (item != nullptr) {
         // Item already exists, remove it.
         // Changing the frame parent will make the item clean itself up. It turns into a placeholder and is removed by unrefOldPlaceholders
         frame->QWidgetAdapter::setParent(nullptr); // so ~Item doesn't delete it
@@ -121,10 +124,9 @@ void MultiSplitter::addWidget(QWidgetOrQuick *w, Location location,
     }
 
     // Make some sanity checks:
-    if (!validateInputs(w, location, relativeToWidget, option))
+    if (!validateInputs(w, location, relativeTo, option))
         return;
 
-    Layouting::Item *relativeTo = itemForFrame(relativeToWidget);
     if (!relativeTo)
         relativeTo = m_rootItem;
 
@@ -166,7 +168,7 @@ void MultiSplitter::addWidget(QWidgetOrQuick *w, Location location,
 }
 
 void MultiSplitter::addMultiSplitter(MultiSplitter *sourceMultiSplitter, Location location,
-                                     Frame *relativeTo,
+                                     Layouting::Item *relativeTo,
                                      InitialOption option)
 {
     qCDebug(addwidget) << Q_FUNC_INFO << sourceMultiSplitter << location << relativeTo;

--- a/framework/dockwindow/thirdparty/KDDockWidgets/src/private/MultiSplitter_p.h
+++ b/framework/dockwindow/thirdparty/KDDockWidgets/src/private/MultiSplitter_p.h
@@ -55,7 +55,7 @@ public:
      * @brief Adds a widget to this MultiSplitter.
      */
     void addWidget(QWidgetOrQuick *widget, KDDockWidgets::Location location,
-                   Frame *relativeTo = nullptr,
+                   Layouting::Item *relativeTo = nullptr,
                    InitialOption option = DefaultSizeMode::Fair);
 
     /**
@@ -65,7 +65,7 @@ public:
      * of widgetBar when the whole splitter is dropped into this one.
      */
     void addMultiSplitter(MultiSplitter *splitter, KDDockWidgets::Location location,
-                          Frame *relativeTo = nullptr,
+                          Layouting::Item *relativeTo = nullptr,
                           InitialOption option = DefaultSizeMode::Fair);
 
     /**
@@ -95,7 +95,7 @@ private:
 
     // For debug/hardening
     bool validateInputs(QWidgetOrQuick *widget, KDDockWidgets::Location location,
-                        const Frame *relativeToFrame, InitialOption option) const;
+                        const Layouting::Item *relativeTo, InitialOption option) const;
 
 
     void setRootItem(Layouting::ItemBoxContainer *);


### PR DESCRIPTION
Fixed the height of Undo/Redo toolbar
<img width="1463" height="831" alt="image" src="https://github.com/user-attachments/assets/cc478fb1-8941-4dd1-8ca8-7637b0060e38" />

Applied the solution from v2 to v1. see https://github.com/musescore/KDDockWidgets/pull/5/changes/8eb97838c36538b9b04860238eac2403d8d8d616

