### PR TITLE
Fix bounding rect font metrics mismatch

### DIFF
--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -291,7 +291,13 @@ std::vector<GlyphPos> FontFaceFT::glyphs(const char32_t* text, int text_length) 
         hb_glyph_position_t* pos = hb_buffer_get_glyph_positions(hb_buffer, NULL);
 
         for (unsigned int i = 0; i < len; i++) {
-            result.push_back({ info[i].codepoint, static_cast<f26dot6_t>(pos[i].x_advance) });
+            f26dot6_t xAdvance = static_cast<f26dot6_t>(pos[i].x_advance);
+            hb_position_t hbAdvance = hb_font_get_glyph_h_advance(m_data->hb_font, info[i].codepoint);
+            if (GlyphMetrics* metrics = glyphMetrics(info[i].codepoint)) {
+                xAdvance += metrics->linearAdvance - hbAdvance;
+            }
+
+            result.push_back({ info[i].codepoint, xAdvance });
         }
 
         hb_buffer_destroy(hb_buffer);

--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -76,6 +76,11 @@ static const IFontFace* findSubtitutionFont(char32_t ch, const std::vector<IFont
     return founded;
 }
 
+static bool fitsQtGlyphCacheMetrics(const FBBox& bbox, f26dot6_t advance)
+{
+    return (bbox.width() >> 6) <= 0xFF && (bbox.height() >> 6) <= 0xFF && advance <= 0x7FFF;
+}
+
 static bool isZeroAdvanceChar(char32_t ch)
 {
     return ch == U'\n' || ch == U'\r';
@@ -123,7 +128,7 @@ void FontsEngine::init()
 
 double FontsEngine::lineSpacing(const Font& f) const
 {
-    RequireFace* rf = fontFace(f, f.type() == Font::Type::MusicSymbol);
+    RequireFace* rf = fontFace(f);
     IF_ASSERT_FAILED(rf && rf->face) {
         return 0.0;
     }
@@ -292,15 +297,19 @@ RectF FontsEngine::boundingRect(const Font& f, const std::u32string& text) const
             f26dot6_t x = xOffset + bbox.x();
             f26dot6_t y = bbox.y();
 
+            bool useCachedGlyphMetrics = fitsQtGlyphCacheMetrics(bbox, fontFace->glyphAdvance(g.idx));
+            f26dot6_t glyphRight = useCachedGlyphMetrics ? ((x + 63) & -64) + bbox.width() : x + bbox.width();
+            f26dot6_t glyphBottom = useCachedGlyphMetrics ? ((y + 63) & -64) + bbox.height() : y + bbox.height();
+
             if (!hasGlyph) {
                 rect.setX(x);
-                xmax = x + bbox.width();
-                ymax = y + bbox.height();
+                xmax = glyphRight;
+                ymax = glyphBottom;
                 hasGlyph = true;
             } else {
                 rect.setX(std::min(rect.x(), x));
-                xmax = std::max(xmax, x + bbox.width());
-                ymax = std::max(ymax, y + bbox.height());
+                xmax = std::max(xmax, glyphRight);
+                ymax = std::max(ymax, glyphBottom);
             }
 
             rect.setY(std::min(rect.y(), y));
@@ -359,17 +368,20 @@ RectF FontsEngine::tightBoundingRect(const Font& f, const std::u32string& text) 
             f26dot6_t x = xOffset + bbox.x();
             f26dot6_t y = bbox.y();
 
+            f26dot6_t glyphRight = ((x + 63) & -64) + bbox.width();
+            f26dot6_t glyphBottom = ((y + 63) & -64) + bbox.height();
+
             if (!hasGlyph) {
                 rect.setX(x);
                 rect.setY(y);
-                xmax = x + bbox.width();
-                ymax = y + bbox.height();
+                xmax = glyphRight;
+                ymax = glyphBottom;
                 hasGlyph = true;
             } else {
                 rect.setX(std::min(rect.x(), x));
                 rect.setY(std::min(rect.y(), y));
-                xmax = std::max(xmax, x + bbox.width());
-                ymax = std::max(ymax, y + bbox.height());
+                xmax = std::max(xmax, glyphRight);
+                ymax = std::max(ymax, glyphBottom);
             }
 
             xOffset += g.x_advance;
@@ -537,11 +549,6 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
         requireKey.pixelSize = DEFAULT_PIXEL_SIZE;
     }
 
-    //! NOTE For symbol mode, a fixed pixelSize is used
-    if (isSymbolMode) {
-        requireKey.pixelSize = SYMBOLS_PIXEL_SIZE;
-    }
-
     //! NOTE At the moment, in some cases, the type may not be specified,
     //! so set as Text
     if (requireKey.type == Font::Type::Undefined || requireKey.type == Font::Type::Unknown) {
@@ -564,10 +571,9 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
     FontDataKey actualDataKey = fontsDatabase()->actualFont(requireKey.dataKey, requireKey.type);
 
     //! NOTE We are looking for the font face we real need among the previously loaded ones
-    //! IMPORTANT We use font faces with a fixed pixelSize, so we need to find the right face only from the data
     IFontFace* face = nullptr;
     for (IFontFace* ff : m_loadedFaces) {
-        if (ff->key().dataKey == actualDataKey && ff->isSymbolMode() == isSymbolMode) {
+        if (ff->key().dataKey == actualDataKey && ff->key().pixelSize == requireKey.pixelSize && ff->isSymbolMode() == isSymbolMode) {
             face = ff;
             break;
         }
@@ -583,7 +589,7 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
         FaceKey loadedKey;
         loadedKey.dataKey = actualDataKey;
         loadedKey.type = requireKey.type;
-        loadedKey.pixelSize = LOADED_PIXEL_SIZE;
+        loadedKey.pixelSize = requireKey.pixelSize;
 
         face = createFontFace(fontPath);
 
@@ -597,7 +603,7 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
     auto subtitutionFontDataKeys = fontsDatabase()->substitutionFonts(requireKey.type);
     for (const FontDataKey& dataKey : subtitutionFontDataKeys) {
         for (IFontFace* ff : m_loadedFaces) {
-            if (ff->key().dataKey == dataKey && ff->isSymbolMode() == isSymbolMode) {
+            if (ff->key().dataKey == dataKey && ff->key().pixelSize == requireKey.pixelSize && ff->isSymbolMode() == isSymbolMode) {
                 subtitutionFace = ff;
                 break;
             }
@@ -612,7 +618,7 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
             FaceKey loadedKey;
             loadedKey.dataKey = dataKey;
             loadedKey.type = requireKey.type;
-            loadedKey.pixelSize = LOADED_PIXEL_SIZE;
+            loadedKey.pixelSize = requireKey.pixelSize;
 
             subtitutionFace = createFontFace(fontPath);
 

--- a/framework/draw/tests/fontsprovider_qt_tests.cpp
+++ b/framework/draw/tests/fontsprovider_qt_tests.cpp
@@ -119,7 +119,7 @@ public:
     };
 };
 
-static const std::vector<double> TEST_POINTSIZES = { 5.62, 24.0, 32.0 };
+static const std::vector<double> TEST_POINTSIZES = { 5.62, 12.0, 18.0, 24.0, 32.0, 48.0 };
 static const std::vector<muse::Char> TEST_CHARS
     = { muse::Char(u'a'), muse::Char(u'x'), muse::Char(u' '), muse::Char(u'"'), muse::Char(u'\''),
         muse::Char(u'*'), muse::Char(u'-'), muse::Char(u':'), muse::Char(u';'),
@@ -160,7 +160,7 @@ static void print(double pointSize, const T& qVal, const T& xVal)
 
 inline bool ValIsEqual(double p1, double p2, double epsilon)
 {
-    return std::abs(std::max(p1, p2) - std::min(p1, p2)) < epsilon;
+    return std::abs(std::max(p1, p2) - std::min(p1, p2)) <= epsilon;
 }
 
 inline bool ValIsEqual(muse::RectF p1, muse::RectF p2, double epsilon)
@@ -262,7 +262,7 @@ TEST_F(Draw_FontsProviderQtTests, horizontalAdvance_Char)
             double xVal = env.xProvider.horizontalAdvance(f, ch);
 
             print(f.pointSizeF(), qVal, xVal);
-            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.06));
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }
@@ -280,7 +280,7 @@ TEST_F(Draw_FontsProviderQtTests, horizontalAdvance_String)
             double xVal = env.xProvider.horizontalAdvance(f, str);
 
             print(f.pointSizeF(), qVal, xVal);
-            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.2));
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }
@@ -299,7 +299,7 @@ TEST_F(Draw_FontsProviderQtTests, boundingRect_Char)
             muse::RectF xVal = env.xProvider.boundingRect(f, ucs4);
 
             print(f.pointSizeF(), qVal, xVal);
-            EXPECT_TRUE(ValIsEqual(qVal, xVal, 3));
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }
@@ -317,7 +317,7 @@ TEST_F(Draw_FontsProviderQtTests, boundingRect_String)
             muse::RectF xVal = env.xProvider.boundingRect(f, str);
 
             print(f.pointSizeF(), qVal, xVal);
-            EXPECT_TRUE(ValIsEqual(qVal, xVal, 3));
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }
@@ -335,7 +335,7 @@ TEST_F(Draw_FontsProviderQtTests, tightBoundingRect_String)
             muse::RectF xVal = env.xProvider.tightBoundingRect(f, str);
 
             print(f.pointSizeF(), qVal, xVal);
-            EXPECT_TRUE(ValIsEqual(qVal, xVal, 3));
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }
@@ -391,6 +391,46 @@ TEST_F(Draw_FontsProviderQtTests, boundingRect_Symbol_Bravura)
 
             print(f.pointSizeF(), qVal, xVal);
             EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.7));
+        }
+    }
+}
+
+TEST_F(Draw_FontsProviderQtTests, tightBoundingRect_Symbol)
+{
+    Env env;
+    Font f(u"Leland", Font::Type::MusicSymbol);
+    std::vector<double> points = { 12.0 };
+
+    for (double pointSize : points) {
+        f.setPointSizeF(pointSize);
+
+        for (const char16_t ch : TEST_SYMBOLS) {
+            const char16_t text[] = { ch, 0 };
+            muse::RectF qVal = env.qProvider.tightBoundingRect(f, muse::String(text));
+            muse::RectF xVal = env.xProvider.tightBoundingRect(f, muse::String(text));
+
+            print(f.pointSizeF(), qVal, xVal);
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
+        }
+    }
+}
+
+TEST_F(Draw_FontsProviderQtTests, tightBoundingRect_Symbol_Bravura)
+{
+    Env env;
+    Font f(u"Bravura", Font::Type::MusicSymbol);
+    std::vector<double> points = { 12.0 };
+
+    for (double pointSize : points) {
+        f.setPointSizeF(pointSize);
+
+        for (const char16_t ch : TEST_SYMBOLS) {
+            const char16_t text[] = { ch, 0 };
+            muse::RectF qVal = env.qProvider.tightBoundingRect(f, muse::String(text));
+            muse::RectF xVal = env.xProvider.tightBoundingRect(f, muse::String(text));
+
+            print(f.pointSizeF(), qVal, xVal);
+            EXPECT_TRUE(ValIsEqual(qVal, xVal, 0.0));
         }
     }
 }


### PR DESCRIPTION
The main result of this work is that the allowed epsilon between FontProvider and QFontProvider is now 0.0. In other words, the current state is that FontProvider returns the same metrics as Qt.
To achieve this, the implementation was aligned with Qt’s source code. The code was not copied verbatim, but the same approach was used to avoid metric mismatches.
This PR contains two main changes:
FontProvider now loads FontFace with the real requested pixel size instead of using the fixed LOADED_PIXEL_SIZE constant. This provided the main improvement, because FreeType metrics are not equivalent to simply scaling one loaded font size to every requested pixel size.

The remaining mismatch was fixed by rounding fractional values at the same stage as Qt does. This made the metrics match Qt exactly.

However, the epsilon for the `boundingRect` metric of music symbols is not `0.0`.

This is because `QFontProvider::boundingRect()` for music symbols uses `QPainterPath` instead of `QFontMetrics`. Reusing the `QPainterPath` behavior is much more complicated than aligning with `QFontMetrics`, which on Linux is based on the same FreeType/HarfBuzz stack as our `FontProvider`.

