### PR TITLE
Implement app event controller

### DIFF
--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(muse_global PRIVATE
 
     globaltypes.h
     iapplication.h
+    iapplicationeventcontroller.h
     iglobalconfiguration.h
     log.h
     logstream.h
@@ -195,6 +196,8 @@ else()
         api/filesystemapi.cpp
         api/filesystemapi.h
 
+        internal/applicationeventcontroller.cpp
+        internal/applicationeventcontroller.h
         internal/baseapplication.cpp
         internal/baseapplication.h
         internal/cmdoptions.h

--- a/framework/global/globalmodule.cpp
+++ b/framework/global/globalmodule.cpp
@@ -36,6 +36,10 @@
 #include "internal/systeminfo.h"
 #include "internal/tickerprovider.h"
 
+#ifndef NO_QT_SUPPORT
+#include "internal/applicationeventcontroller.h"
+#endif
+
 #include "runtime.h"
 #include "async/processevents.h"
 
@@ -90,6 +94,11 @@ void GlobalModule::registerExports()
     globalIoc()->registerExport<IProcess>(moduleName(), new Process());
     globalIoc()->registerExport<ITickerProvider>(moduleName(), m_tickerProvider);
     globalIoc()->registerExport<api::IApiRegister>(moduleName(), new api::ApiRegister());
+
+#ifndef NO_QT_SUPPORT
+    m_eventController = std::make_shared<ApplicationEventController>();
+    globalIoc()->registerExport<IApplicationEventController>(moduleName(), m_eventController);
+#endif
 
 #ifdef Q_OS_WASM
     globalIoc()->registerExport<IFileSystem>(moduleName(), new MemFileSystem());

--- a/framework/global/globalmodule.h
+++ b/framework/global/globalmodule.h
@@ -36,6 +36,7 @@ namespace muse {
 class SystemInfo;
 class GlobalConfiguration;
 class BaseApplication;
+class IApplicationEventController;
 class ITickerProvider;
 class GlobalModule : public modularity::IModuleSetup
 {
@@ -60,6 +61,7 @@ private:
     std::shared_ptr<GlobalConfiguration> m_configuration;
     std::shared_ptr<SystemInfo> m_systemInfo;
     std::shared_ptr<ITickerProvider> m_tickerProvider;
+    std::shared_ptr<IApplicationEventController> m_eventController;
     Ticker m_asyncTicker;
 
     std::optional<muse::logger::Level> m_loggerLevel;

--- a/framework/global/iapplicationeventcontroller.h
+++ b/framework/global/iapplicationeventcontroller.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "modularity/imoduleinterface.h"
+#include "async/channel.h"
+
+#ifndef NO_QT_SUPPORT
+#include <QEvent>
+
+class QObject;
+#endif
+
+namespace muse {
+class IApplicationEventController : MODULE_GLOBAL_INTERFACE
+{
+    INTERFACE_ID(IApplicationEventController)
+public:
+
+    virtual ~IApplicationEventController() = default;
+
+#ifndef NO_QT_SUPPORT
+
+    struct EventData {
+        QObject* watched = nullptr;
+        QEvent* event = nullptr;
+    };
+
+    virtual async::Channel<EventData> eventReceived() const = 0;
+    virtual void setPendingEventTypes(const std::vector<QEvent::Type>& types) = 0;
+
+    //! NOTE The watched object is deliberately not returned.
+    //! By the time the events are taken it may already be destroyed.
+    virtual std::vector<std::unique_ptr<QEvent> > takePendingEvents() = 0;
+#endif
+};
+}

--- a/framework/global/internal/applicationeventcontroller.cpp
+++ b/framework/global/internal/applicationeventcontroller.cpp
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "applicationeventcontroller.h"
+
+#ifndef NO_QT_SUPPORT
+
+#include <QCoreApplication>
+
+#include "containers.h"
+#include "runtime.h"
+
+#include "log.h"
+
+using namespace muse;
+
+ApplicationEventController::ApplicationEventController()
+{
+    DO_ASSERT(std::this_thread::get_id() == runtime::mainThreadId());
+    qApp->installEventFilter(this);
+}
+
+ApplicationEventController::~ApplicationEventController()
+{
+    if (qApp) {
+        qApp->removeEventFilter(this);
+    }
+}
+
+async::Channel<IApplicationEventController::EventData> ApplicationEventController::eventReceived() const
+{
+    return m_eventReceived;
+}
+
+void ApplicationEventController::setPendingEventTypes(const std::vector<QEvent::Type>& types)
+{
+    m_pendingTypes = types;
+}
+
+std::vector< std::unique_ptr<QEvent> > ApplicationEventController::takePendingEvents()
+{
+    DO_ASSERT(std::this_thread::get_id() == runtime::mainThreadId());
+
+    m_pendingTypes.clear();
+    std::vector<std::unique_ptr<QEvent> > events = std::move(m_pendingEvents);
+    m_pendingEvents.clear();
+
+    return events;
+}
+
+bool ApplicationEventController::eventFilter(QObject* watched, QEvent* event)
+{
+    if (contains(m_pendingTypes, event->type())) {
+        m_pendingEvents.emplace_back(event->clone());
+    }
+
+    m_eventReceived.send(EventData { watched, event });
+    return false;
+}
+
+#endif // NO_QT_SUPPORT

--- a/framework/global/internal/applicationeventcontroller.h
+++ b/framework/global/internal/applicationeventcontroller.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#ifndef NO_QT_SUPPORT
+
+#include <memory>
+#include <vector>
+
+#include <QObject>
+
+#include "../iapplicationeventcontroller.h"
+
+namespace muse {
+class ApplicationEventController : public QObject, public IApplicationEventController
+{
+public:
+    ApplicationEventController();
+    ~ApplicationEventController() override;
+
+    async::Channel<EventData> eventReceived() const override;
+
+    void setPendingEventTypes(const std::vector<QEvent::Type>& types) override;
+    std::vector<std::unique_ptr<QEvent> > takePendingEvents() override;
+
+private:
+
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    std::vector<QEvent::Type> m_pendingTypes;
+    std::vector<std::unique_ptr<QEvent> > m_pendingEvents;
+
+    async::Channel<EventData> m_eventReceived = async::Channel<EventData>(async::makeOpt()
+                                                                          .name("muse::ApplicationEventController::m_eventReceived")
+                                                                          .threads(1));
+};
+}
+
+#endif // NO_QT_SUPPORT

--- a/framework/global/tests/CMakeLists.txt
+++ b/framework/global/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/globalconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/systeminfomock.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/applicationeventcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/uri_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/val_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/logremover_tests.cpp

--- a/framework/global/tests/applicationeventcontroller_tests.cpp
+++ b/framework/global/tests/applicationeventcontroller_tests.cpp
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QFileOpenEvent>
+#include <QObject>
+#include <QUrl>
+
+#include "global/internal/applicationeventcontroller.h"
+
+using namespace muse;
+
+class Global_ApplicationEventControllerTests : public ::testing::Test
+{
+public:
+
+    void SetUp() override
+    {
+        m_controller = std::make_unique<ApplicationEventController>();
+    }
+
+    void TearDown() override
+    {
+        m_controller.reset();
+    }
+
+    void send(QEvent* event)
+    {
+        QCoreApplication::sendEvent(&m_target, event);
+    }
+
+    static QUrl urlOf(const std::unique_ptr<QEvent>& event)
+    {
+        return static_cast<QFileOpenEvent*>(event.get())->url();
+    }
+
+    std::unique_ptr<ApplicationEventController> m_controller;
+    QObject m_target;
+};
+
+TEST_F(Global_ApplicationEventControllerTests, ConfiguredTypeIsBuffered)
+{
+    m_controller->setPendingEventTypes({ QEvent::FileOpen });
+
+    const QUrl url("file:///tmp/project.aup4");
+    QFileOpenEvent event(url);
+    send(&event);
+
+    const std::vector<std::unique_ptr<QEvent> > pending = m_controller->takePendingEvents();
+
+    ASSERT_EQ(pending.size(), 1u);
+    EXPECT_EQ(pending.at(0)->type(), QEvent::FileOpen);
+    EXPECT_EQ(urlOf(pending.at(0)), url);
+    EXPECT_NE(pending.at(0).get(), &event);
+}
+
+TEST_F(Global_ApplicationEventControllerTests, UnconfiguredTypeIsNotBuffered)
+{
+    m_controller->setPendingEventTypes({ QEvent::FileOpen });
+
+    QEvent event(QEvent::User);
+    send(&event);
+
+    EXPECT_TRUE(m_controller->takePendingEvents().empty());
+}
+
+TEST_F(Global_ApplicationEventControllerTests, NothingIsBufferedWithoutConfiguredTypes)
+{
+    QFileOpenEvent event(QUrl("file:///tmp/project.aup4"));
+    send(&event);
+
+    EXPECT_TRUE(m_controller->takePendingEvents().empty());
+}
+
+TEST_F(Global_ApplicationEventControllerTests, BufferedEventOutlivesTheOriginal)
+{
+    m_controller->setPendingEventTypes({ QEvent::FileOpen });
+
+    const QUrl url("file:///tmp/project.aup4");
+    {
+        QFileOpenEvent event(url);
+        send(&event);
+    }
+
+    const std::vector<std::unique_ptr<QEvent> > pending = m_controller->takePendingEvents();
+
+    ASSERT_EQ(pending.size(), 1u);
+    EXPECT_EQ(pending.at(0)->type(), QEvent::FileOpen);
+    EXPECT_EQ(urlOf(pending.at(0)), url);
+}
+
+TEST_F(Global_ApplicationEventControllerTests, PendingEventsAreTakenOnlyOnce)
+{
+    m_controller->setPendingEventTypes({ QEvent::FileOpen });
+
+    QFileOpenEvent event(QUrl("file:///tmp/project.aup4"));
+    send(&event);
+
+    EXPECT_EQ(m_controller->takePendingEvents().size(), 1u);
+    EXPECT_TRUE(m_controller->takePendingEvents().empty());
+}
+
+TEST_F(Global_ApplicationEventControllerTests, BufferingStopsAfterTheFirstTake)
+{
+    m_controller->setPendingEventTypes({ QEvent::FileOpen });
+
+    QFileOpenEvent beforeTake(QUrl("file:///tmp/before.aup4"));
+    send(&beforeTake);
+
+    ASSERT_EQ(m_controller->takePendingEvents().size(), 1u);
+
+    QFileOpenEvent afterTake(QUrl("file:///tmp/after.aup4"));
+    send(&afterTake);
+
+    EXPECT_TRUE(m_controller->takePendingEvents().empty());
+}


### PR DESCRIPTION
On macOS the launch url starts the app and a QFileOpenEvent arrives during an early startup before the app install an event filter to handle this events.
This change buffers selected event types to be retrieved later on a ApplicationEventController class.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
