### PR TITLE
FontsEngine - moves font glyph image generation to IFontFace

### DIFF
--- a/framework/draw/internal/fontfacedu.cpp
+++ b/framework/draw/internal/fontfacedu.cpp
@@ -28,9 +28,7 @@ struct DummyGlyph {
     f26dot6_t textAdvance = 0;
     FBBox symBbox;
     f26dot6_t symAdvance = 0;
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-    msdfgen::Shape shape;
-#endif
+    GlyphImage glyphImage;
 };
 
 static const DummyGlyph& dummyGlyph()
@@ -41,51 +39,6 @@ static const DummyGlyph& dummyGlyph()
         g.textAdvance = 4160;
         g.symBbox = FBBox(0, -4011, 2079, 4817);
         g.symAdvance = 2080;
-
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-        using namespace msdfgen;
-
-        g.shape.inverseYAxis = true;
-        g.shape.fillRule = static_cast<msdfgen::FillRule>(msdfgen::FillRule::NonZero);
-
-        Contour c1;
-        {
-            std::vector<Point2> points = {
-                Point2(0, -25), Point2(64, -25),
-                Point2(64, -25), Point2(64, 125),
-                Point2(64, 125), Point2(0, 125),
-                Point2(0, 125), Point2(0, -25)
-            };
-
-            for (size_t i = 0; i < 8;) {
-                EdgeSegment e;
-                e.actualType = EdgeSegment::ActualType::Linear;
-                e.segments.linear.p[0] = points.at(i++);
-                e.segments.linear.p[1] = points.at(i++);
-                c1.edges.push_back(e);
-            }
-        }
-        g.shape.contours.push_back(c1);
-
-        Contour c2;
-        {
-            std::vector<Point2> points = {
-                Point2(9, 115), Point2(54, 115),
-                Point2(54, 115), Point2(54, -15),
-                Point2(54, -15), Point2(9, -15),
-                Point2(9, -15), Point2(9, 115)
-            };
-
-            for (size_t i = 0; i < 8;) {
-                EdgeSegment e;
-                e.actualType = EdgeSegment::ActualType::Linear;
-                e.segments.linear.p[0] = points.at(i++);
-                e.segments.linear.p[1] = points.at(i++);
-                c2.edges.push_back(e);
-            }
-        }
-        g.shape.contours.push_back(c2);
-#endif
     }
 
     return g;
@@ -186,13 +139,11 @@ f26dot6_t FontFaceDU::glyphAdvance(glyph_idx_t idx) const
     return m_origin->glyphAdvance(idx);
 }
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-const msdfgen::Shape& FontFaceDU::glyphShape(glyph_idx_t idx) const
+const GlyphImage& FontFaceDU::glyphImage(glyph_idx_t idx) const
 {
     if (idx == 0) {
-        return dummyGlyph().shape;
+        return dummyGlyph().glyphImage;
     }
-    return m_origin->glyphShape(idx);
-}
 
-#endif
+    return m_origin->glyphImage(idx);
+}

--- a/framework/draw/internal/fontfacedu.cpp
+++ b/framework/draw/internal/fontfacedu.cpp
@@ -28,7 +28,6 @@ struct DummyGlyph {
     f26dot6_t textAdvance = 0;
     FBBox symBbox;
     f26dot6_t symAdvance = 0;
-    GlyphImage glyphImage;
 };
 
 static const DummyGlyph& dummyGlyph()
@@ -142,7 +141,8 @@ f26dot6_t FontFaceDU::glyphAdvance(glyph_idx_t idx) const
 const GlyphImage& FontFaceDU::glyphImage(glyph_idx_t idx) const
 {
     if (idx == 0) {
-        return dummyGlyph().glyphImage;
+        static const GlyphImage emptyImage;
+        return emptyImage;
     }
 
     return m_origin->glyphImage(idx);

--- a/framework/draw/internal/fontfacedu.h
+++ b/framework/draw/internal/fontfacedu.h
@@ -49,9 +49,7 @@ public:
     FBBox glyphBbox(glyph_idx_t idx) const override;
     f26dot6_t glyphAdvance(glyph_idx_t idx) const override;
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-    const msdfgen::Shape& glyphShape(glyph_idx_t idx) const override;
-#endif
+    const GlyphImage& glyphImage(glyph_idx_t idx) const override;
 
 private:
     IFontFace* m_origin = nullptr;

--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -109,42 +109,19 @@ struct muse::draw::FData
 #ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
 static const int SDF_DIM = 28; //! default dimension of generated SDF. Real SDF can have another size
 static const int SDF_SHAPE_SIZE = 100; //! effective shape size
+static const double MIN_SDF_OUTLINE_PIXELS = 7.0;
 
-struct SdfGlyphSizeOverride
+static double sdfScaleForShape(const msdfgen::Vector2& shapeDims, double baseScale)
 {
-    std::string family;
-    glyph_idx_t glyphIdx = 0;
-    double scale = 0.;
-};
-
-static const SdfGlyphSizeOverride SDF_GLYPH_SIZE_OVERRIDES[] = {
-    { "bravura", 4, 2.0 },
-    { "leland", 4, 2.0 },
-    { "bravura", 445, 2.5 },
-    { "leland", 445, 2.5 },
-};
-
-static const SdfGlyphSizeOverride* sdfGlyphSizeOverride(const std::string& family, glyph_idx_t glyphIdx)
-{
-    for (const SdfGlyphSizeOverride& item : SDF_GLYPH_SIZE_OVERRIDES) {
-        if (item.glyphIdx == glyphIdx && family == item.family) {
-            return &item;
-        }
-    }
-    return nullptr;
-}
-
-static double sdfScaleOverride(const std::string& fontFamily, glyph_idx_t glyphIdx, double baseScale)
-{
-    const std::string normalizedFamily = muse::strings::toLower(fontFamily);
-    if (const SdfGlyphSizeOverride* gl = sdfGlyphSizeOverride(normalizedFamily, glyphIdx)) {
-        baseScale *= gl->scale;
+    double minDim = std::min(shapeDims.x, shapeDims.y);
+    if (minDim <= 0.0) {
+        return baseScale;
     }
 
-    return baseScale;
+    return std::max(baseScale, MIN_SDF_OUTLINE_PIXELS / minDim);
 }
 
-static void generateSdf(GlyphImage& out, const std::string& fontFamily, glyph_idx_t glyphIdx, msdfgen::Shape& shape)
+static void generateSdf(GlyphImage& out, msdfgen::Shape& shape)
 {
     struct Bounds
     {
@@ -161,7 +138,7 @@ static void generateSdf(GlyphImage& out, const std::string& fontFamily, glyph_id
     int pxRange = 4;
     int pixelFrameWidth = 3;
     double scale = static_cast<double>(SDF_DIM) / SDF_SHAPE_SIZE;
-    scale = sdfScaleOverride(fontFamily, glyphIdx, scale);
+    scale = sdfScaleForShape(shapeDims, scale);
 
     int sdfWidth = static_cast<int>(std::ceil(scale * shapeDims.x));
     int sdfHeight = static_cast<int>(std::ceil(scale * shapeDims.y));
@@ -531,7 +508,7 @@ const GlyphImage& FontFaceFT::glyphImage(glyph_idx_t idx) const
     std::pair<glyph_idx_t, GlyphImage> v;
     v.first = idx;
     shape.inverseYAxis = true;
-    generateSdf(v.second, m_key.dataKey.family().id().toStdString(), idx, shape);
+    generateSdf(v.second, shape);
 
     return m_cache.insert(std::move(v)).first->second;
 #else

--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -21,6 +21,7 @@
  */
 #include "fontfaceft.h"
 
+#include <cmath>
 #include <unordered_map>
 
 #include <ft2build.h>
@@ -31,6 +32,7 @@
 #include <hb-ft.h>
 
 #ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
+#include <msdfgen.h>
 #include <ext/import-font.h>
 #endif
 
@@ -103,6 +105,107 @@ struct muse::draw::FData
     FT_Size_Metrics metrics;
     HeightMetrics heightMetrics;
 };
+
+#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
+static const int SDF_DIM = 28; //! default dimension of generated SDF. Real SDF can have another size
+static const int SDF_SHAPE_SIZE = 100; //! effective shape size
+
+struct SdfGlyphSizeOverride
+{
+    std::string family;
+    glyph_idx_t glyphIdx = 0;
+    double scale = 0.;
+};
+
+static const SdfGlyphSizeOverride SDF_GLYPH_SIZE_OVERRIDES[] = {
+    { "bravura", 4, 2.0 },
+    { "leland", 4, 2.0 },
+    { "bravura", 445, 2.5 },
+    { "leland", 445, 2.5 },
+};
+
+static const SdfGlyphSizeOverride* sdfGlyphSizeOverride(const std::string& family, glyph_idx_t glyphIdx)
+{
+    for (const SdfGlyphSizeOverride& item : SDF_GLYPH_SIZE_OVERRIDES) {
+        if (item.glyphIdx == glyphIdx && family == item.family) {
+            return &item;
+        }
+    }
+    return nullptr;
+}
+
+static double sdfScaleOverride(const std::string& fontFamily, glyph_idx_t glyphIdx, double baseScale)
+{
+    const std::string normalizedFamily = muse::strings::toLower(fontFamily);
+    if (const SdfGlyphSizeOverride* gl = sdfGlyphSizeOverride(normalizedFamily, glyphIdx)) {
+        baseScale *= gl->scale;
+    }
+
+    return baseScale;
+}
+
+static void generateSdf(GlyphImage& out, const std::string& fontFamily, glyph_idx_t glyphIdx, msdfgen::Shape& shape)
+{
+    struct Bounds
+    {
+        double l, b, r, t;
+    };
+    Bounds bounds = { 1e240, 1e240, -1e240, -1e240 };
+
+    shape.normalize();
+    shape.orientContours();
+
+    shape.bound(bounds.l, bounds.b, bounds.r, bounds.t);
+    msdfgen::Vector2 shapeDims(bounds.r - bounds.l, bounds.t - bounds.b);
+
+    int pxRange = 4;
+    int pixelFrameWidth = 3;
+    double scale = static_cast<double>(SDF_DIM) / SDF_SHAPE_SIZE;
+    scale = sdfScaleOverride(fontFamily, glyphIdx, scale);
+
+    int sdfWidth = static_cast<int>(std::ceil(scale * shapeDims.x));
+    int sdfHeight = static_cast<int>(std::ceil(scale * shapeDims.y));
+
+    sdfWidth += 2 * pixelFrameWidth;
+    sdfHeight += 2 * pixelFrameWidth;
+
+    msdfgen::Vector2 translate = { -bounds.l, -bounds.b };
+
+    double pxRangeScaled = pixelFrameWidth / scale;
+
+    double left = bounds.l - pxRangeScaled;
+    double top = -bounds.t - pxRangeScaled;
+    double width = shapeDims.x + pxRangeScaled * 2;
+    double height = shapeDims.y + pxRangeScaled * 2;
+
+    double range = pxRange / scale;
+    translate += pxRangeScaled;
+
+    auto sdf = msdfgen::Bitmap<float, 1>(sdfWidth, sdfHeight);
+    msdfgen::SDFTransformation t(msdfgen::Projection(scale, translate), msdfgen::Range(range));
+    msdfgen::generateSDF(sdf, shape, t);
+    msdfgen::distanceSignCorrection(sdf, shape, t, msdfgen::FILL_NONZERO);
+
+    out.sdf.bitmap.reserve(sdfWidth * sdfHeight);
+    for (int y = 0; y < sdf.height(); ++y) {
+        for (int x = 0; x < sdf.width(); ++x) {
+            uint8_t px = static_cast<uint8_t>(msdfgen::pixelFloatToByte(*sdf(x, y)));
+            out.sdf.bitmap.push_back(px);
+        }
+    }
+    out.sdf.width = sdfWidth;
+    out.sdf.height = sdfHeight;
+    out.range = range;
+
+    out.rect.setTop(top);
+    out.rect.setLeft(left);
+    out.rect.setWidth(width);
+    out.rect.setHeight(height);
+
+    out.sdf.hash = std::hash<std::string_view> {}({ reinterpret_cast<const char*>(out.sdf.bitmap.data()), out.sdf.bitmap.size() });
+}
+
+#endif
 
 static f26dot6_t tableValueToF26Dot6(FT_Face face, long value, int pixelSize)
 {
@@ -400,11 +503,11 @@ f26dot6_t FontFaceFT::glyphAdvance(glyph_idx_t idx) const
     }
 }
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-const msdfgen::Shape& FontFaceFT::glyphShape(glyph_idx_t idx) const
+const GlyphImage& FontFaceFT::glyphImage(glyph_idx_t idx) const
 {
-    static const msdfgen::Shape null;
+    static GlyphImage null;
 
+#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
     FT_UInt index = static_cast<FT_UInt>(idx);
     if (index == 0) {
         return null;
@@ -419,16 +522,23 @@ const msdfgen::Shape& FontFaceFT::glyphShape(glyph_idx_t idx) const
         return null;
     }
 
-    std::pair<glyph_idx_t, msdfgen::Shape> v;
+    msdfgen::Shape shape;
+    msdfgen::readFreetypeOutline(shape, &m_data->face->glyph->outline);
+    if (shape.contours.empty()) {
+        return null;
+    }
+
+    std::pair<glyph_idx_t, GlyphImage> v;
     v.first = idx;
-    v.second = msdfgen::loadGlyphSlot(m_data->face->glyph, nullptr);
-    v.second.normalize();
-    v.second.inverseYAxis = true;
+    shape.inverseYAxis = true;
+    generateSdf(v.second, m_key.dataKey.family().id().toStdString(), idx, shape);
 
     return m_cache.insert(std::move(v)).first->second;
-}
-
+#else
+    UNUSED(idx);
+    return null;
 #endif
+}
 
 f26dot6_t FontFaceFT::leading() const
 {

--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -110,6 +110,7 @@ struct muse::draw::FData
 static const int SDF_DIM = 28; //! default dimension of generated SDF. Real SDF can have another size
 static const int SDF_SHAPE_SIZE = 100; //! effective shape size
 static const double MIN_SDF_OUTLINE_PIXELS = 7.0;
+static const double MAX_SDF_SCALE = 4.0;
 
 static double sdfScaleForShape(const msdfgen::Vector2& shapeDims, double baseScale)
 {
@@ -118,7 +119,7 @@ static double sdfScaleForShape(const msdfgen::Vector2& shapeDims, double baseSca
         return baseScale;
     }
 
-    return std::max(baseScale, MIN_SDF_OUTLINE_PIXELS / minDim);
+    return std::min(std::max(baseScale, MIN_SDF_OUTLINE_PIXELS / minDim), MAX_SDF_SCALE);
 }
 
 static void generateSdf(GlyphImage& out, msdfgen::Shape& shape)
@@ -502,7 +503,7 @@ const GlyphImage& FontFaceFT::glyphImage(glyph_idx_t idx) const
     msdfgen::Shape shape;
     msdfgen::readFreetypeOutline(shape, &m_data->face->glyph->outline);
     if (shape.contours.empty()) {
-        return null;
+        return m_cache.insert({ idx, GlyphImage() }).first->second;
     }
 
     std::pair<glyph_idx_t, GlyphImage> v;

--- a/framework/draw/internal/fontfaceft.h
+++ b/framework/draw/internal/fontfaceft.h
@@ -53,9 +53,7 @@ public:
     FBBox glyphBbox(glyph_idx_t idx) const override;
     f26dot6_t glyphAdvance(glyph_idx_t idx) const override;
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-    const msdfgen::Shape& glyphShape(glyph_idx_t idx) const override;
-#endif
+    const GlyphImage& glyphImage(glyph_idx_t idx) const override;
 
 private:
 
@@ -65,8 +63,6 @@ private:
     FaceKey m_key;
     bool m_isSymbolMode = false;
     FData* m_data = nullptr;
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-    mutable std::unordered_map<glyph_idx_t, msdfgen::Shape> m_cache;
-#endif
+    mutable std::unordered_map<glyph_idx_t, GlyphImage> m_cache;
 };
 }

--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -434,10 +434,10 @@ std::vector<GlyphImage> FontsEngine::render(const Font& f, const std::u32string&
 
         for (const GlyphPos& g : glyphs) {
             if (NOT_RENDER_GLYPHS.find(g.idx) == NOT_RENDER_GLYPHS.end()) {
-                GlyphImage image;// = m_renderCache.load(ffBlock.face->key(), g.idx);
+                GlyphImage image = m_renderCache.load(ffBlock.face->key(), g.idx);
                 if (image.isNull()) {
                     image = ffBlock.face->glyphImage(g.idx);
-                    //m_renderCache.store(ffBlock.face->key(), g.idx, image);
+                    m_renderCache.store(ffBlock.face->key(), g.idx, image);
                 }
 
                 image.rect = scaleRect(image.rect, pixelScale);

--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -21,11 +21,6 @@
  */
 #include "fontsengine.h"
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-#include <msdfgen.h>
-#include <ext/import-font.h>
-#endif
-
 #include "global/io/fileinfo.h"
 
 #include "ifontface.h"
@@ -63,6 +58,11 @@ static inline RectF fromFBBox(const FBBox& bb, double scale)
 {
     return RectF(from_f26d6(bb.left()) * scale, from_f26d6(bb.top()) * scale,
                  from_f26d6(bb.width()) * scale, from_f26d6(bb.height()) * scale);
+}
+
+static inline RectF scaleRect(const RectF& r, double scale)
+{
+    return RectF(r.x() * scale, r.y() * scale, r.width() * scale, r.height() * scale);
 }
 
 static const IFontFace* findSubtitutionFont(char32_t ch, const std::vector<IFontFace*>& subtitutionFaces)
@@ -398,74 +398,6 @@ RectF FontsEngine::tightBoundingRect(const Font& f, const std::u32string& text) 
     return fromFBBox(rect, rf->pixelScale());
 }
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-static void generateSdf(GlyphImage& out, glyph_idx_t glyphIdx, const IFontFace* face)
-{
-    struct Bounds
-    {
-        double l, b, r, t;
-    };
-    Bounds bounds = { 1e240, 1e240, -1e240, -1e240 };
-
-    msdfgen::Shape shape = face->glyphShape(glyphIdx);
-    if (shape.contours.empty()) {
-        //! NOTE Maybe not printable, like ' '
-        return;
-    }
-
-    shape.bounds(bounds.l, bounds.b, bounds.r, bounds.t);
-
-    uint32_t pxRange = std::min(SDF_WIDTH, SDF_HEIGHT) >> 3;
-
-    std::pair<double, double> sdfScale;
-    msdfgen::Vector2 translate;
-    double scale = 0.0;
-    msdfgen::Vector2 frame(SDF_WIDTH, SDF_HEIGHT);
-    frame -= 2 * pxRange;
-    assert(frame.x >= 0 && frame.y >= 0 && bounds.l < bounds.r && bounds.b < bounds.t);
-    msdfgen::Vector2 dims(bounds.r - bounds.l, bounds.t - bounds.b);
-    if (dims.x * frame.y < dims.y * frame.x) { // fit restricted by height
-        translate = { -bounds.l, -bounds.b };
-        scale = frame.y / dims.y;
-        sdfScale = { (frame.x - dims.x * scale) / (dims.x * scale), 0.0f };
-    } else { // fit restricted by width
-        translate = { -bounds.l, -bounds.b };
-        scale = frame.x / dims.x;
-        sdfScale = { 0.0, (frame.y - dims.y * scale) / (dims.y * scale) };
-    }
-
-    double boundsWidth = bounds.r - bounds.l;
-    double boundsHeight = bounds.t - bounds.b;
-    double widthWhitespace = boundsWidth * sdfScale.first;
-    double heightWhitespace = boundsHeight * sdfScale.second;
-    double pxRangeScaled = pxRange / scale;
-
-    double left = bounds.l - pxRangeScaled;
-    double top = -bounds.t - heightWhitespace - pxRangeScaled;
-    double width = boundsWidth + widthWhitespace + pxRangeScaled * 2;
-    double height = boundsHeight + heightWhitespace + pxRangeScaled * 2;
-
-    double range = pxRange / scale;
-    translate += range;
-
-    shape.mergeContours();
-
-    auto sdf = msdfgen::Bitmap<uint8_t>(SDF_WIDTH, SDF_HEIGHT);
-    msdfgen::generateSDF(sdf, shape, bounds.l, range, scale, translate);
-
-    out.sdf.bitmap = mu::ByteArray(sdf.takeMemoryAway(), SDF_WIDTH * SDF_HEIGHT);
-    out.sdf.width = SDF_WIDTH;
-    out.sdf.height = SDF_HEIGHT;
-    out.sdf.hash = std::hash<std::string_view> {}({ reinterpret_cast<const char*>(out.sdf.bitmap.data()), out.sdf.bitmap.size() });
-
-    out.rect.setTop(top);
-    out.rect.setLeft(left);
-    out.rect.setWidth(width);
-    out.rect.setHeight(height);
-}
-
-#endif
-
 std::vector<GlyphImage> FontsEngine::render(const Font& f, const std::u32string& text) const
 {
     //! NOTE for rendering, all fonts, including symbols fonts, are processed as text
@@ -504,7 +436,7 @@ std::vector<GlyphImage> FontsEngine::render(const Font& f, const std::u32string&
             if (NOT_RENDER_GLYPHS.find(g.idx) == NOT_RENDER_GLYPHS.end()) {
                 GlyphImage image;// = m_renderCache.load(ffBlock.face->key(), g.idx);
                 if (image.isNull()) {
-                    generateSdf(image, g.idx, ffBlock.face);
+                    image = ffBlock.face->glyphImage(g.idx);
                     //m_renderCache.store(ffBlock.face->key(), g.idx, image);
                 }
 

--- a/framework/draw/internal/ifontface.h
+++ b/framework/draw/internal/ifontface.h
@@ -21,10 +21,6 @@
  */
 #pragma once
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-#include <msdfgen.h>
-#endif
-
 #include "global/io/path.h"
 #include "types/fontstypes.h"
 
@@ -66,74 +62,6 @@ public:
     virtual FBBox glyphBbox(glyph_idx_t idx) const = 0;
     virtual f26dot6_t glyphAdvance(glyph_idx_t idx) const = 0;
 
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-    virtual const msdfgen::Shape& glyphShape(glyph_idx_t idx) const = 0;
-#endif
+    virtual const GlyphImage& glyphImage(glyph_idx_t idx) const = 0;
 };
 }
-
-#ifndef MUSE_MODULE_DRAW_USE_QTTEXTDRAW
-inline bool operator==(const msdfgen::Shape& s1, const msdfgen::Shape& s2)
-{
-    if (s1.inverseYAxis != s2.inverseYAxis) {
-        return false;
-    }
-
-    if (s1.fillRule != s2.fillRule) {
-        return false;
-    }
-
-    if (s1.contours.size() != s2.contours.size()) {
-        return false;
-    } else {
-        auto pointsIsEqual = [](const msdfgen::Point2* p1, const msdfgen::Point2* p2, int count) {
-            for (int i = 0; i < count; ++i) {
-                if (p1[i] != p2[i]) {
-                    return false;
-                }
-            }
-            return true;
-        };
-
-        for (size_t ci = 0; ci < s1.contours.size(); ++ci) {
-            const msdfgen::Contour& c1 = s1.contours.at(ci);
-            const msdfgen::Contour& c2 = s2.contours.at(ci);
-            if (c1.edges.size() != c2.edges.size()) {
-                return false;
-            } else {
-                for (size_t ei = 0; ei < c1.edges.size(); ++ei) {
-                    const msdfgen::EdgeSegment& e1 = c1.edges.at(ei);
-                    const msdfgen::EdgeSegment& e2 = c2.edges.at(ei);
-                    if (e1.actualType != e2.actualType) {
-                        return false;
-                    } else {
-                        switch (e1.actualType) {
-                        case msdfgen::EdgeSegment::ActualType::Undefined: {
-                            continue;
-                        } break;
-                        case msdfgen::EdgeSegment::ActualType::Linear: {
-                            if (!pointsIsEqual(e1.segments.linear.p, e2.segments.linear.p, 2)) {
-                                return false;
-                            }
-                        } break;
-                        case msdfgen::EdgeSegment::ActualType::Quadratic: {
-                            if (!pointsIsEqual(e1.segments.quadratic.p, e2.segments.quadratic.p, 3)) {
-                                return false;
-                            }
-                        } break;
-                        case msdfgen::EdgeSegment::ActualType::Cubic: {
-                            if (!pointsIsEqual(e1.segments.cubic.p, e2.segments.cubic.p, 4)) {
-                                return false;
-                            }
-                        } break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return true;
-}
-
-#endif

--- a/framework/draw/types/fontstypes.h
+++ b/framework/draw/types/fontstypes.h
@@ -139,6 +139,7 @@ struct Sdf {
 struct GlyphImage {
     muse::RectF rect;
     Sdf sdf;
+    float range = 0.f;
 
     bool isNull() const { return rect.isNull(); }
 };


### PR DESCRIPTION
The font module was originally developed by Igor Korsukov in a separate private Git repository. Later, that work was moved into the Muse repository. Since then, however, the repositories have evolved independently and the implementations have diverged a bit.
For example, Muse Studio builds with the MUSE_MODULE_DRAW_USE_QTTEXTDRAW define enabled. This disables part of the fontsengine code, so that code has not really been tested or actively developed in this repository.
This PR brings together the relevant work from both repositories and ports it here. The main change is in the IFontFace interface. The old approach had MUSE_MODULE_DRAW_USE_QTTEXTDRAW conditionals directly in the .h interface, which could lead to unexpected issues. This PR removes MUSE_MODULE_DRAW_USE_QTTEXTDRAW from the IFontFace interface level and moves the conditional behavior into the .cpp implementation instead.