### PR TITLE
Shortcuts. Replacing Shortcut Deletes all Keybinds

### DIFF
--- a/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -22,6 +22,7 @@
 
 #include "shortcutsmodel.h"
 
+#include "containers.h"
 #include "translation.h"
 #include "types/mnemonicstring.h"
 #include "types/translatablestring.h"
@@ -226,7 +227,17 @@ void ShortcutsModel::applySequenceToCurrentShortcut(const QString& newSequence, 
     m_shortcuts[row].sequences = Shortcut::sequencesFromString(newSequence.toStdString());
 
     if (conflictShortcutIndex >= 0 && conflictShortcutIndex < m_shortcuts.size()) {
-        m_shortcuts[conflictShortcutIndex].clear();
+        const std::vector<std::string>& newSequences = m_shortcuts[row].sequences;
+        Shortcut& conflictShortcut = m_shortcuts[conflictShortcutIndex];
+
+        muse::remove_if(conflictShortcut.sequences, [&newSequences](const std::string& sequence) {
+            return muse::contains(newSequences, sequence);
+        });
+
+        if (conflictShortcut.sequences.empty()) {
+            conflictShortcut.clear();
+        }
+
         notifyAboutShortcutChanged(index(conflictShortcutIndex));
     }
 

--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -22,6 +22,7 @@
 
 #include "shortcutsmodel.h"
 
+#include "containers.h"
 #include "translation.h"
 #include "types/mnemonicstring.h"
 #include "types/translatablestring.h"
@@ -298,9 +299,19 @@ void ShortcutsModel::applySequenceToCurrentShortcut(const QString& newSequence, 
     LOGD() << "apply sequence to command: " << m_items[row].shortcut.command << " new sequence: " << newSequence.toStdString();
 
     if (conflictShortcutIndex >= 0 && conflictShortcutIndex < m_items.size()) {
-        m_items[conflictShortcutIndex].shortcut.clear();
-        m_items[conflictShortcutIndex].sequence = "";
-        LOGD() << "clear sequence for command: " << m_items[conflictShortcutIndex].shortcut.command;
+        const std::vector<std::string>& newSequences = m_items[row].shortcut.sequences;
+        Item& conflictItem = m_items[conflictShortcutIndex];
+
+        muse::remove_if(conflictItem.shortcut.sequences, [&newSequences](const std::string& sequence) {
+            return muse::contains(newSequences, sequence);
+        });
+
+        if (conflictItem.shortcut.sequences.empty()) {
+            conflictItem.shortcut.clear();
+        }
+
+        conflictItem.sequence = sequencesToNativeText(conflictItem.shortcut.sequences);
+        LOGD() << "clear sequence for command: " << conflictItem.shortcut.command;
         notifyAboutShortcutChanged(index(conflictShortcutIndex));
     }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9676

The conflicting shortcut may have other sequences assigned to it, so take away only those that have just been reassigned