### PR TITLE
PolylinePlot - additional options

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.cpp
@@ -44,6 +44,21 @@ void PolylinePointStyle::setCenterRadius(qreal r)
     emit styleChanged();
 }
 
+qreal PolylinePointStyle::centerRadiusHovered() const
+{
+    return m_centerRadiusHovered;
+}
+
+void PolylinePointStyle::setCenterRadiusHovered(qreal r)
+{
+    if (m_centerRadiusHovered == r) {
+        return;
+    }
+
+    m_centerRadiusHovered = r;
+    emit styleChanged();
+}
+
 QColor PolylinePointStyle::centerColor() const
 {
     return m_centerColor;
@@ -59,18 +74,48 @@ void PolylinePointStyle::setCenterColor(const QColor& c)
     emit styleChanged();
 }
 
+QColor PolylinePointStyle::centerColorHovered() const
+{
+    return m_centerColorHovered;
+}
+
+void PolylinePointStyle::setCenterColorHovered(const QColor& c)
+{
+    if (m_centerColorHovered == c) {
+        return;
+    }
+
+    m_centerColorHovered = c;
+    emit styleChanged();
+}
+
 qreal PolylinePointStyle::middleRingWidth() const
 {
     return m_middleRingWidth;
 }
 
-void PolylinePointStyle::setMiddleRingWidth(qreal r)
+void PolylinePointStyle::setMiddleRingWidth(qreal w)
 {
-    if (m_middleRingWidth == r) {
+    if (m_middleRingWidth == w) {
         return;
     }
 
-    m_middleRingWidth = r;
+    m_middleRingWidth = w;
+    emit styleChanged();
+}
+
+qreal PolylinePointStyle::middleRingWidthHovered() const
+{
+    return m_middleRingWidthHovered;
+}
+
+void PolylinePointStyle::setMiddleRingWidthHovered(qreal w)
+{
+    if (m_middleRingWidthHovered == w) {
+        return;
+    }
+
+    m_middleRingWidthHovered = w;
     emit styleChanged();
 }
 
@@ -89,6 +134,21 @@ void PolylinePointStyle::setMiddleRingColor(const QColor& c)
     emit styleChanged();
 }
 
+QColor PolylinePointStyle::middleRingColorHovered() const
+{
+    return m_middleRingColorHovered;
+}
+
+void PolylinePointStyle::setMiddleRingColorHovered(const QColor& c)
+{
+    if (m_middleRingColorHovered == c) {
+        return;
+    }
+
+    m_middleRingColorHovered = c;
+    emit styleChanged();
+}
+
 qreal PolylinePointStyle::outlineWidth() const
 {
     return m_outlineWidth;
@@ -104,6 +164,21 @@ void PolylinePointStyle::setOutlineWidth(qreal w)
     emit styleChanged();
 }
 
+qreal PolylinePointStyle::outlineWidthHovered() const
+{
+    return m_outlineWidthHovered;
+}
+
+void PolylinePointStyle::setOutlineWidthHovered(qreal w)
+{
+    if (m_outlineWidthHovered == w) {
+        return;
+    }
+
+    m_outlineWidthHovered = w;
+    emit styleChanged();
+}
+
 QColor PolylinePointStyle::outlineColor() const
 {
     return m_outlineColor;
@@ -116,5 +191,20 @@ void PolylinePointStyle::setOutlineColor(const QColor& c)
     }
 
     m_outlineColor = c;
+    emit styleChanged();
+}
+
+QColor PolylinePointStyle::outlineColorHovered() const
+{
+    return m_outlineColorHovered;
+}
+
+void PolylinePointStyle::setOutlineColorHovered(const QColor& c)
+{
+    if (m_outlineColorHovered == c) {
+        return;
+    }
+
+    m_outlineColorHovered = c;
     emit styleChanged();
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/polylinepointstyle.h
@@ -32,33 +32,51 @@ class PolylinePointStyle : public QObject
 
     Q_PROPERTY(qreal centerRadius READ centerRadius WRITE setCenterRadius NOTIFY styleChanged)
     Q_PROPERTY(QColor centerColor READ centerColor WRITE setCenterColor NOTIFY styleChanged)
+    Q_PROPERTY(qreal centerRadiusHovered READ centerRadiusHovered WRITE setCenterRadiusHovered NOTIFY styleChanged)
+    Q_PROPERTY(QColor centerColorHovered READ centerColorHovered WRITE setCenterColorHovered NOTIFY styleChanged)
 
     Q_PROPERTY(qreal middleRingWidth READ middleRingWidth WRITE setMiddleRingWidth NOTIFY styleChanged)
     Q_PROPERTY(QColor middleRingColor READ middleRingColor WRITE setMiddleRingColor NOTIFY styleChanged)
+    Q_PROPERTY(qreal middleRingWidthHovered READ middleRingWidthHovered WRITE setMiddleRingWidthHovered NOTIFY styleChanged)
+    Q_PROPERTY(QColor middleRingColorHovered READ middleRingColorHovered WRITE setMiddleRingColorHovered NOTIFY styleChanged)
 
     Q_PROPERTY(qreal outlineWidth READ outlineWidth WRITE setOutlineWidth NOTIFY styleChanged)
     Q_PROPERTY(QColor outlineColor READ outlineColor WRITE setOutlineColor NOTIFY styleChanged)
+    Q_PROPERTY(qreal outlineWidthHovered READ outlineWidthHovered WRITE setOutlineWidthHovered NOTIFY styleChanged)
+    Q_PROPERTY(QColor outlineColorHovered READ outlineColorHovered WRITE setOutlineColorHovered NOTIFY styleChanged)
 
 public:
     explicit PolylinePointStyle(QObject* parent = nullptr);
 
     qreal centerRadius() const;
     void setCenterRadius(qreal);
+    qreal centerRadiusHovered() const;
+    void setCenterRadiusHovered(qreal);
 
     QColor centerColor() const;
     void setCenterColor(const QColor&);
+    QColor centerColorHovered() const;
+    void setCenterColorHovered(const QColor&);
 
     qreal middleRingWidth() const;
     void setMiddleRingWidth(qreal);
+    qreal middleRingWidthHovered() const;
+    void setMiddleRingWidthHovered(qreal);
 
     QColor middleRingColor() const;
     void setMiddleRingColor(const QColor&);
+    QColor middleRingColorHovered() const;
+    void setMiddleRingColorHovered(const QColor&);
 
     qreal outlineWidth() const;
     void setOutlineWidth(qreal);
+    qreal outlineWidthHovered() const;
+    void setOutlineWidthHovered(qreal);
 
     QColor outlineColor() const;
     void setOutlineColor(const QColor&);
+    QColor outlineColorHovered() const;
+    void setOutlineColorHovered(const QColor&);
 
 signals:
     void styleChanged();
@@ -66,11 +84,17 @@ signals:
 private:
     qreal m_centerRadius = 3.0;
     QColor m_centerColor;
+    qreal m_centerRadiusHovered = 3.0;
+    QColor m_centerColorHovered;
 
     qreal m_middleRingWidth = 0.0;
     QColor m_middleRingColor;
+    qreal m_middleRingWidthHovered = 0.0;
+    QColor m_middleRingColorHovered;
 
     qreal m_outlineWidth = 0.0;
     QColor m_outlineColor;
+    qreal m_outlineWidthHovered = 0.0;
+    QColor m_outlineColorHovered;
 };
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -152,6 +152,11 @@ PolylinePlot::PolylinePlot(QQuickItem* parent)
     QObject::connect(m_ghostPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
         update();
     });
+
+    m_selectedPointStyle = new PolylinePointStyle(this);
+    QObject::connect(m_selectedPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
+        update();
+    });
 }
 
 void PolylinePlot::init()
@@ -175,6 +180,45 @@ PolylinePointStyle* PolylinePlot::standardPointStyle()
 PolylinePointStyle* PolylinePlot::ghostPointStyle()
 {
     return m_ghostPointStyle;
+}
+
+PolylinePointStyle* PolylinePlot::selectedPointStyle()
+{
+    return m_selectedPointStyle;
+}
+
+bool PolylinePlot::ghostPointsEnabled() const
+{
+    return m_ghostPointsEnabled;
+}
+
+void PolylinePlot::setGhostPointsEnabled(bool v)
+{
+    if (m_ghostPointsEnabled == v) {
+        return;
+    }
+
+    m_ghostPointsEnabled = v;
+    emit ghostPointsEnabledChanged();
+
+    update();
+}
+
+bool PolylinePlot::selectedPointsEnabled() const
+{
+    return m_selectedPointsEnabled;
+}
+
+void PolylinePlot::setSelectedPointsEnabled(bool v)
+{
+    if (m_selectedPointsEnabled == v) {
+        return;
+    }
+
+    m_selectedPointsEnabled = v;
+    emit selectedPointsEnabledChanged();
+
+    update();
 }
 
 QColor PolylinePlot::lineColor() const
@@ -630,6 +674,15 @@ void PolylinePlot::updateActivePoint()
                 bestScore = score;
                 draggedDisplayDomainIdx = i;
             }
+        }
+    }
+
+    // m_pressedPointIndex must stay at the original model index (so consumed neighbors can be restored), but selection indices
+    // need to shift when other indices are deleted...
+    if (m_selectedPointsEnabled && draggedDisplayDomainIdx >= 0) {
+        if (m_selectedPointsIndices.size() != 1 || !muse::contains(m_selectedPointsIndices, draggedDisplayDomainIdx)) {
+            m_selectedPointsIndices.clear();
+            m_selectedPointsIndices.insert(draggedDisplayDomainIdx);
         }
     }
 
@@ -1097,7 +1150,7 @@ void PolylinePlot::paint(QPainter* painter)
     }
 
     // draw points
-    IF_ASSERT_FAILED(m_standardPointStyle && m_ghostPointStyle) {
+    IF_ASSERT_FAILED(m_standardPointStyle && m_ghostPointStyle && m_selectedPointStyle) {
         return;
     }
 
@@ -1107,22 +1160,20 @@ void PolylinePlot::paint(QPainter* painter)
         QPointF pN = m_pointsNVisible[i];
         const QPointF centre(toPxX(this, pN.x()), toPxY(this, pN.y()));
 
-        const int domainIdx
-            =(i < m_visibleToDomainIndex.size()) ? m_visibleToDomainIndex[i] : INVALID_POINT_IDX;
-        const bool isHovered = (domainIdx >= 0 && domainIdx == hoveredIndex);
-        paintPoint(painter, m_standardPointStyle, centre, /*useHoveredStyle*/ isHovered);
+        const int domainIdx = (i < m_visibleToDomainIndex.size()) ? m_visibleToDomainIndex[i] : INVALID_POINT_IDX;
+        const bool isSelected = m_selectedPointsEnabled && domainIdx >= 0 && muse::contains(m_selectedPointsIndices, domainIdx);
+        const bool isHovered = !(m_pressed && isSelected) && domainIdx >= 0 && domainIdx == hoveredIndex;
+
+        const PolylinePointStyle* style = isSelected ? m_selectedPointStyle : m_standardPointStyle;
+        paintPoint(painter, style, centre, /*useHoveredStyle*/ isHovered);
     }
 
     // draw hover ghost point
-    if (m_hoveredOnLine && m_pressedPointIndex < 0) {
+    if (m_ghostPointsEnabled && m_hoveredOnLine && m_pressedPointIndex < 0) {
         QPointF hp = m_hoverGhostPx;
 
         if (m_pointsNVisible.size() < 2) {
-            const qreal yN
-                =(m_pointsNVisible.size() == 1)
-                  ? m_pointsNVisible[0].y()
-                  : m_baselineN;
-
+            const qreal yN = (m_pointsNVisible.size() == 1) ? m_pointsNVisible[0].y() : m_baselineN;
             hp.setY(toPxY(this, yN));
         }
 
@@ -1146,17 +1197,24 @@ void PolylinePlot::hoverMoveEvent(QHoverEvent* e)
 
     const bool nearPoint = (pointIndexAtPx(m_hoverPx) >= 0);
 
-    auto proj = ghostPointToPolylinePx(m_hoverPx);
-    const bool nearLine = (proj.distToSegment <= m_hitRadius);
+    bool nearLine = false;
+    if (m_ghostPointsEnabled) {
+        const auto proj = ghostPointToPolylinePx(m_hoverPx);
+        nearLine = (proj.distToSegment <= m_hitRadius);
+
+        if (m_pointsNVisible.size() >= 2) {
+            m_hoverGhostPx = proj.point;
+        } else {
+            m_hoverGhostPx = m_hoverPx;
+        }
+    } else {
+        // nearLine is still required for updateCursor (m_hoveredOnLine) and to accept events, but
+        // if ghost points are disabled we can skip the m_hoverGhostPx logic...
+        nearLine = isNearLinePx(m_hoverPx);
+    }
 
     m_hoveredOnLine = (nearPoint || nearLine);
     updateCursor();
-
-    if (m_pointsNVisible.size() >= 2) {
-        m_hoverGhostPx = proj.point;
-    } else {
-        m_hoverGhostPx = m_hoverPx;
-    }
 
     updateActivePoint();
     update();
@@ -1187,6 +1245,10 @@ void PolylinePlot::mousePressEvent(QMouseEvent* e)
         return;
     }
 
+    if (!m_selectedPointsIndices.empty()) {
+        m_selectedPointsIndices.clear();
+    }
+
     const int pointIndex = pointIndexAtPx(e->position());
     const bool onPoint = pointIndex >= 0;
     const bool onLine  = isNearLinePx(e->position());
@@ -1209,6 +1271,9 @@ void PolylinePlot::mousePressEvent(QMouseEvent* e)
         m_pressedOnPoint = true;
         m_pressedPointIndex = pointIndex;
         if (m_pressedPointIndex >= 0 && m_pressedPointIndex < m_points.size()) {
+            if (m_selectedPointsEnabled) {
+                m_selectedPointsIndices.insert(m_pressedPointIndex);
+            }
             m_draggedPointDomain = m_points[m_pressedPointIndex];
             m_hasDraggedPointDomain = true;
         }

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -148,11 +148,6 @@ PolylinePlot::PolylinePlot(QQuickItem* parent)
         update();
     });
 
-    m_hoveredPointStyle = new PolylinePointStyle(this);
-    QObject::connect(m_hoveredPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
-        update();
-    });
-
     m_ghostPointStyle = new PolylinePointStyle(this);
     QObject::connect(m_ghostPointStyle, &PolylinePointStyle::styleChanged, this, [this]() {
         update();
@@ -175,11 +170,6 @@ void PolylinePlot::init()
 PolylinePointStyle* PolylinePlot::standardPointStyle()
 {
     return m_standardPointStyle;
-}
-
-PolylinePointStyle* PolylinePlot::hoveredPointStyle()
-{
-    return m_hoveredPointStyle;
 }
 
 PolylinePointStyle* PolylinePlot::ghostPointStyle()
@@ -1027,15 +1017,20 @@ void PolylinePlot::geometryChange(const QRectF& newG, const QRectF& oldG)
     }
 }
 
-void PolylinePlot::paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre) const
+void PolylinePlot::paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre, bool useHoveredStyle) const
 {
     IF_ASSERT_FAILED(painter && style) {
         return;
     }
 
-    const qreal centerRadius = style->centerRadius();
-    const qreal middleRingWidth = style->middleRingWidth();
-    const qreal outlineWidth = style->outlineWidth();
+    const qreal centerRadius = useHoveredStyle ? style->centerRadiusHovered() : style->centerRadius();
+    const QColor centerColor = useHoveredStyle ? style->centerColorHovered() : style->centerColor();
+
+    const qreal middleRingWidth = useHoveredStyle ? style->middleRingWidthHovered() : style->middleRingWidth();
+    const QColor middleRingColor = useHoveredStyle ? style->middleRingColorHovered() : style->middleRingColor();
+
+    const qreal outlineWidth = useHoveredStyle ? style->outlineWidthHovered() : style->outlineWidth();
+    const QColor outlineColor = useHoveredStyle ? style->outlineColorHovered() : style->outlineColor();
 
     if (middleRingWidth > 0.0) {
         const qreal middleRadius = centerRadius + middleRingWidth;
@@ -1043,23 +1038,23 @@ void PolylinePlot::paintPoint(QPainter* painter, const PolylinePointStyle* style
 
         painter->setPen(Qt::NoPen);
 
-        painter->setBrush(style->outlineColor());
+        painter->setBrush(outlineColor);
         painter->drawEllipse(centre, outerRadius, outerRadius);
 
-        painter->setBrush(style->middleRingColor());
+        painter->setBrush(middleRingColor);
         painter->drawEllipse(centre, middleRadius, middleRadius);
 
-        painter->setBrush(style->centerColor());
+        painter->setBrush(centerColor);
         painter->drawEllipse(centre, centerRadius, centerRadius);
         return;
     }
 
     painter->setPen(Qt::NoPen);
-    painter->setBrush(style->centerColor());
+    painter->setBrush(centerColor);
     painter->drawEllipse(centre, centerRadius, centerRadius);
 
     if (outlineWidth > 0.0) {
-        QPen pen(style->outlineColor());
+        QPen pen(outlineColor);
         pen.setWidthF(outlineWidth);
         painter->setPen(pen);
         painter->setBrush(Qt::NoBrush);
@@ -1102,7 +1097,7 @@ void PolylinePlot::paint(QPainter* painter)
     }
 
     // draw points
-    IF_ASSERT_FAILED(m_standardPointStyle && m_hoveredPointStyle && m_ghostPointStyle) {
+    IF_ASSERT_FAILED(m_standardPointStyle && m_ghostPointStyle) {
         return;
     }
 
@@ -1115,8 +1110,7 @@ void PolylinePlot::paint(QPainter* painter)
         const int domainIdx
             =(i < m_visibleToDomainIndex.size()) ? m_visibleToDomainIndex[i] : INVALID_POINT_IDX;
         const bool isHovered = (domainIdx >= 0 && domainIdx == hoveredIndex);
-        const PolylinePointStyle* style = isHovered ? m_hoveredPointStyle : m_standardPointStyle;
-        paintPoint(painter, style, centre);
+        paintPoint(painter, m_standardPointStyle, centre, /*useHoveredStyle*/ isHovered);
     }
 
     // draw hover ghost point
@@ -1133,7 +1127,7 @@ void PolylinePlot::paint(QPainter* painter)
         }
 
         if (pointIndexAtPx(hp) < 0 && isNearLinePx(hp)) {
-            paintPoint(painter, m_ghostPointStyle, hp);
+            paintPoint(painter, m_ghostPointStyle, hp, /*useHoveredStyle*/ false);
         }
     }
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
@@ -50,7 +50,6 @@ class PolylinePlot : public QQuickPaintedItem, public muse::async::Asyncable, pu
     Q_OBJECT
 
     Q_PROPERTY(PolylinePointStyle * standardPointStyle READ standardPointStyle CONSTANT)
-    Q_PROPERTY(PolylinePointStyle * hoveredPointStyle READ hoveredPointStyle CONSTANT)
     Q_PROPERTY(PolylinePointStyle * ghostPointStyle READ ghostPointStyle CONSTANT)
 
     Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor NOTIFY lineColorChanged)
@@ -96,7 +95,6 @@ public:
     Q_INVOKABLE void init();
 
     PolylinePointStyle* standardPointStyle();
-    PolylinePointStyle* hoveredPointStyle();
     PolylinePointStyle* ghostPointStyle();
 
     QColor lineColor() const;
@@ -223,7 +221,7 @@ private:
     QPointF snapToNeighbor(qreal dragPxX, QPointF pDomain) const;
     void updateActivePoint();
 
-    void paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre) const;
+    void paintPoint(QPainter* painter, const PolylinePointStyle* style, const QPointF& centre, bool useHoveredStyle) const;
 
 private:
     QColor m_lineColor;
@@ -231,7 +229,6 @@ private:
     qreal m_baselineN = 0.5;
 
     PolylinePointStyle* m_standardPointStyle = nullptr;
-    PolylinePointStyle* m_hoveredPointStyle = nullptr;
     PolylinePointStyle* m_ghostPointStyle = nullptr;
 
     qreal m_hitRadius = 9.0;

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.h
@@ -50,7 +50,12 @@ class PolylinePlot : public QQuickPaintedItem, public muse::async::Asyncable, pu
     Q_OBJECT
 
     Q_PROPERTY(PolylinePointStyle * standardPointStyle READ standardPointStyle CONSTANT)
+
+    Q_PROPERTY(bool ghostPointsEnabled READ ghostPointsEnabled WRITE setGhostPointsEnabled NOTIFY ghostPointsEnabledChanged)
     Q_PROPERTY(PolylinePointStyle * ghostPointStyle READ ghostPointStyle CONSTANT)
+
+    Q_PROPERTY(bool selectedPointsEnabled READ selectedPointsEnabled WRITE setSelectedPointsEnabled NOTIFY selectedPointsEnabledChanged)
+    Q_PROPERTY(PolylinePointStyle * selectedPointStyle READ selectedPointStyle CONSTANT)
 
     Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor NOTIFY lineColorChanged)
     Q_PROPERTY(qreal lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged)
@@ -96,6 +101,13 @@ public:
 
     PolylinePointStyle* standardPointStyle();
     PolylinePointStyle* ghostPointStyle();
+    PolylinePointStyle* selectedPointStyle();
+
+    bool ghostPointsEnabled() const;
+    void setGhostPointsEnabled(bool);
+
+    bool selectedPointsEnabled() const;
+    void setSelectedPointsEnabled(bool);
 
     QColor lineColor() const;
     void setLineColor(const QColor&);
@@ -154,6 +166,9 @@ public:
     void paint(QPainter* painter) override;
 
 signals:
+    void ghostPointsEnabledChanged();
+    void selectedPointsEnabledChanged();
+
     void lineColorChanged();
     void lineWidthChanged();
     void drawBackgroundChanged();
@@ -229,7 +244,12 @@ private:
     qreal m_baselineN = 0.5;
 
     PolylinePointStyle* m_standardPointStyle = nullptr;
+
+    bool m_ghostPointsEnabled = true;
     PolylinePointStyle* m_ghostPointStyle = nullptr;
+
+    bool m_selectedPointsEnabled = false;
+    PolylinePointStyle* m_selectedPointStyle = nullptr;
 
     qreal m_hitRadius = 9.0;
     bool m_isSnapEnabled = true;
@@ -256,6 +276,8 @@ private:
     bool m_hoveredOnLine = false;
     QPointF m_hoverPx;
     QPointF m_hoverGhostPx;
+
+    std::unordered_set<int> m_selectedPointsIndices;
 
     bool m_pressedOnLine = false;
     bool m_pressed = false;


### PR DESCRIPTION
This PR tweaks and adds some additional options to our `PolylinePlot` component:

1. Some basic "selected point" logic has been implemented. Eventually this will play a part in keyboard accessibility for polylines (amongst other things). Selected points are disabled by default.
2. A flag has been introduced to disable ghost points. Ghost points are enabled by default.
3. "Hovered" is no longer its own style. Instead `PolylinePointStyle` now contains both the "normal" and "hovered" styles for a given point type. The idea is that, with the introduction of selected points, we should try and keep the number of `PolylinePointStyles` to a minimum. This means we can simply declare _standard_, _selected_, and _ghost_ point styles instead of having to declare _standard normal_, _standard hovered_, _selected normal_, _selected hovered_, etc.

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
