### PR TITLE
ci: Improve codestyle check diff output

### DIFF
--- a/buildscripts/ci/checkcodestyle/checkcodestyle.cmake
+++ b/buildscripts/ci/checkcodestyle/checkcodestyle.cmake
@@ -48,11 +48,7 @@ if (GIT_DIFF_OUT)
 
     message(${MSG})
 
-    execute_process(
-        COMMAND git diff
-        OUTPUT_VARIABLE GIT_DIFF_OUT
-    )
-
-    message(FATAL_ERROR "${GIT_DIFF_OUT}")
+    execute_process(COMMAND git diff)
+    message(FATAL_ERROR "codestyle check failed")
 endif()
 


### PR DESCRIPTION
Let git diff write its output directly to stdout (inherited from CMake) instead of taking the detour through CMake's message system.

Keep a FATAL_ERROR at the end to exit the CMake process with an error.

[before](https://github.com/musescore/muse_framework/actions/runs/30749873514/job/91501885260#step:4:1644):
```
        The required changes are...
    
CMake Error at buildscripts/ci/checkcodestyle/checkcodestyle.cmake:56 (message):
  diff --git a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
  b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp

  index 515045e..fc3bb9f 100644

  --- a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp

  +++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp

  @@ -176,7 +176,7 @@ void ShortcutsModel::load()

               searchKeyItems << QString::fromStdString(action.code)
                              << action.title.qTranslatedWithoutMnemonic()
                              << action.description.qTranslated()

  - item.searchKey = searchKeyItems.join(u' ');

  + item.searchKey = searchKeyItems.join(u' ');

   
               m_items.append(item);
           }
```

[after](https://github.com/juli27/muse_framework/actions/runs/30751335248/job/91505788648#step:4:1646):
```
        The required changes are...
    
diff --git a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
index 515045e..fc3bb9f 100644
--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/shortcutsmodel.cpp
@@ -176,7 +176,7 @@ void ShortcutsModel::load()
             searchKeyItems << QString::fromStdString(action.code)
                            << action.title.qTranslatedWithoutMnemonic()
                            << action.description.qTranslated()
-            item.searchKey = searchKeyItems.join(u' ');
+                item.searchKey = searchKeyItems.join(u' ');
 
             m_items.append(item);
         }
CMake Error at buildscripts/ci/checkcodestyle/checkcodestyle.cmake:52 (message):
  codestyle check failed


```

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).