### PR TITLE
Return extension from file dialog and use it on file save

### DIFF
--- a/framework/interactive/qml/Muse/Interactive/FileDialog.qml
+++ b/framework/interactive/qml/Muse/Interactive/FileDialog.qml
@@ -28,11 +28,33 @@ QtPlatform.FileDialog {
     property string objectId: ""
     property var ret: null
 
+    readonly property string allFilesExtension: "*"
+
     signal opened()
     signal closed()
 
     function show() {
+        //! NOTE `selectedNameFilter` is created on first access
+        root.selectedNameFilter.index = 0
         root.open()
+    }
+
+    function appendSuffixIfNeeded(filePath) {
+        const extensions = root.selectedNameFilter.extensions || []
+        let defaultExtension = ""
+        for (let i = 0; i < extensions.length; ++i) {
+            const extension = extensions[i]
+            if (extension === "" || extension === root.allFilesExtension) {
+                continue
+            }
+            if (defaultExtension === "") {
+                defaultExtension = extension
+            }
+            if (filePath.endsWith("." + extension)) {
+                return filePath
+            }
+        }
+        return defaultExtension === "" ? filePath : filePath + "." + defaultExtension
     }
 
     onVisibleChanged: {
@@ -45,6 +67,8 @@ QtPlatform.FileDialog {
         if (root.fileMode === FileDialog.OpenFiles) {
             const selectedUrls = root.fileUrls || []
             root.ret = { "errcode": 0, "value": selectedUrls }
+        } else if (root.fileMode === FileDialog.SaveFile) {
+            root.ret = { "errcode": 0, "value": root.appendSuffixIfNeeded(root.currentFile.toString()) }
         } else {
             root.ret = { "errcode": 0, "value": root.currentFile.toString() }
         }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8166

<!-- Add a short description of and motivation for the changes here -->

Linux file picker on save does not add the selected extension to the filename.
This PR returns the extension from the dialog and append it to the filename.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
