### PR TITLE
Fix action icon colour to remain empty when invalid

### DIFF
--- a/framework/ui/internal/uiactionsregister.cpp
+++ b/framework/ui/internal/uiactionsregister.cpp
@@ -154,7 +154,9 @@ const UiAction& UiActionsRegister::action(const ActionCode& code) const
         action.title = info.title;
         action.description = info.description;
         action.iconCode = info.decoration.iconCode;
-        action.iconColor = QString::fromStdString(info.decoration.iconColor.toString());
+        if (info.decoration.iconColor.isValid()) {
+            action.iconColor = QString::fromStdString(info.decoration.iconColor.toString());
+        }
         action.checkable = static_cast<Checkable>(info.decoration.checkable);
 
         it = m_commandActions.emplace(code, action).first;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34442

This fixes the actions icon colour, so that uses like: `color: root.modelData?.iconColor || ui.theme.fontPrimaryColor` - which assume an empty colour string - will remain working (otherwise they were getting a valid `#000000` string instead of empty).