### PR TITLE
PopupView: fix top and bottom overflow

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/popupview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/popupview.cpp
@@ -424,6 +424,16 @@ void PopupView::updateGeometry()
         movePos(m_globalPos.x() - (viewRect.right() - anchorRect.right()), m_globalPos.y());
     }
 
+    if (viewRect.bottom() > anchorRect.bottom()) {
+        // move to the top to an area that doesn't fit
+        movePos(m_globalPos.x(), m_globalPos.y() + anchorRect.bottom() - viewRect.bottom());
+    }
+
+    if (viewRect.top() < anchorRect.top()) {
+        // move to the bottom to an area that doesn't fit
+        movePos(m_globalPos.x(), m_globalPos.y() - (viewRect.top() - anchorRect.top()));
+    }
+
     if (!showArrow()) {
         if (popupPosition() == PopupPosition::Bottom || popupPosition() == PopupPosition::Top) {
             movePos(m_globalPos.x() - padding(), m_globalPos.y());


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10660 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Fix PopupView top and bottom overflow. Lower the popup if it's position overflows the window's height (and viceversa for bottom).

Previous attempts:
- https://github.com/audacity/audacity/pull/10871
- https://github.com/audacity/audacity/pull/10875
- https://github.com/musescore/muse_framework/pull/85

<img width="825" height="541" alt="image" src="https://github.com/user-attachments/assets/68dd4d1c-f3d0-4c5d-8a49-dd4018f27b23" />



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [camporcr](https://musescore.com/user/122142653): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
