### PR TITLE
Defer toast dismissal to avoid destroying Progress during callback

### DIFF
--- a/framework/toast/internal/toastprovider.cpp
+++ b/framework/toast/internal/toastprovider.cpp
@@ -21,6 +21,8 @@
  */
 #include "toastprovider.h"
 
+#include "async/async.h"
+
 using namespace muse::toast;
 
 ToastProvider::~ToastProvider()
@@ -122,13 +124,13 @@ void ToastProvider::checkProgress(int id)
                 item->setCurrentProgress(newProgress);
 
                 if (newProgress >= 100.0) {
-                    dismissToast(item->id());
+                    async::Async::call(this, [this, item]() { dismissToast(item->id()); });
                 }
             }
         });
 
         progress->finished().onReceive(this, [this, item](const muse::ProgressResult&) {
-            dismissToast(item->id());
+            async::Async::call(this, [this, item]() { dismissToast(item->id()); });
         });
     }
 }


### PR DESCRIPTION
Dismissing a toast from inside a Progress channel callback erased the ToastItem.
If this item is the last owner of the Progress it would destroying the channel during the callback.
Post the dismissal via Async::call

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
