### PR TITLE
Invalidate plugins if they've crashed the app

### DIFF
--- a/framework/audioplugins/CMakeLists.txt
+++ b/framework/audioplugins/CMakeLists.txt
@@ -32,10 +32,13 @@ target_sources(muse_audioplugins PRIVATE
     iaudiopluginsscannerregister.h
     iaudiopluginmetareader.h
     iaudiopluginmetareaderregister.h
+    iaudiopluginsloadguard.h
     iregisteraudiopluginsscenario.h
 
     internal/audiopluginsconfiguration.cpp
     internal/audiopluginsconfiguration.h
+    internal/audiopluginsloadguard.cpp
+    internal/audiopluginsloadguard.h
     internal/knownaudiopluginsregister.cpp
     internal/knownaudiopluginsregister.h
     internal/knownaudiopluginsmigrationregister.cpp

--- a/framework/audioplugins/audiopluginsmodule.cpp
+++ b/framework/audioplugins/audiopluginsmodule.cpp
@@ -22,6 +22,7 @@
 #include "audiopluginsmodule.h"
 
 #include "internal/audiopluginsconfiguration.h"
+#include "internal/audiopluginsloadguard.h"
 #include "internal/knownaudiopluginsregister.h"
 #include "internal/knownaudiopluginsmigrationregister.h"
 #include "internal/audiopluginsscannerregister.h"
@@ -49,6 +50,7 @@ void AudioPluginsModule::registerExports()
     globalIoc()->registerExport<IKnownAudioPluginsMigrationRegister>(moduleName(), std::make_shared<KnownAudioPluginsMigrationRegister>());
     globalIoc()->registerExport<IKnownAudioPluginsRegister>(moduleName(), std::make_shared<KnownAudioPluginsRegister>());
     globalIoc()->registerExport<IAudioPluginsScannerRegister>(moduleName(), std::make_shared<AudioPluginsScannerRegister>());
+    globalIoc()->registerExport<IAudioPluginsLoadGuard>(moduleName(), std::make_shared<AudioPluginsLoadGuard>());
     globalIoc()->registerExport<IAudioPluginMetaReaderRegister>(moduleName(), std::make_shared<AudioPluginMetaReaderRegister>());
 }
 
@@ -73,7 +75,11 @@ void AudioPluginsContext::registerExports()
     ioc()->registerExport<IRegisterAudioPluginsScenario>(mname, m_registerAudioPluginsScenario);
 }
 
-void AudioPluginsContext::onInit(const IApplication::RunMode&)
+void AudioPluginsContext::onInit(const IApplication::RunMode& mode)
 {
     m_registerAudioPluginsScenario->init();
+
+    if (mode != IApplication::RunMode::AudioPluginRegistration) {
+        m_registerAudioPluginsScenario->markCrashedPluginsAsBroken();
+    }
 }

--- a/framework/audioplugins/iaudiopluginsloadguard.h
+++ b/framework/audioplugins/iaudiopluginsloadguard.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+
+#include "global/types/ret.h"
+
+#include "audiopluginstypes.h"
+
+namespace muse::audioplugins {
+/**
+ * @brief Crash guard for in-process plugin loading.
+ *
+ * @details A plugin that passed validation may still bring the whole application down
+ * when loaded later (e.g. after a licensing state change). Callers bracket
+ * each in-process load with beginLoad()/endLoad(): beginLoad() persists the
+ * plugin id to disk and endLoad() removes it once the load call has returned.
+ * If the application dies in between, the id is still on disk at the next
+ * launch and is reported by danglingLoads(), so the plugin can be marked as
+ * broken instead of crashing the application again.
+ */
+class IAudioPluginsLoadGuard : MODULE_GLOBAL_INTERFACE
+{
+    INTERFACE_ID(IAudioPluginsLoadGuard)
+
+public:
+    virtual ~IAudioPluginsLoadGuard() = default;
+
+    virtual Ret beginLoad(const PluginResourceId& resourceId) = 0;
+    virtual void endLoad(const PluginResourceId& resourceId) = 0;
+
+    //! Ids whose load never completed in a previous run
+    virtual PluginResourceIdList danglingLoads() const = 0;
+    virtual Ret clearDanglingLoads() = 0;
+};
+}

--- a/framework/audioplugins/internal/audiopluginsloadguard.cpp
+++ b/framework/audioplugins/internal/audiopluginsloadguard.cpp
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "audiopluginsloadguard.h"
+
+#include <functional>
+#include <sstream>
+
+#include "log.h"
+
+using namespace muse;
+using namespace muse::audioplugins;
+
+static const std::string SENTINEL_SUFFIX = ".loading";
+
+Ret AudioPluginsLoadGuard::beginLoad(const PluginResourceId& resourceId)
+{
+    IF_ASSERT_FAILED(!resourceId.empty()) {
+        return make_ret(Ret::Code::UnknownError);
+    }
+
+    Ret ret = fileSystem()->makePath(sentinelsDirPath());
+    if (!ret) {
+        LOGE() << "Failed to create plugin load guard dir: " << ret.toString();
+        return ret;
+    }
+
+    ByteArray data(resourceId.data(), resourceId.size());
+    ret = fileSystem()->writeFile(sentinelFilePath(resourceId), data);
+    if (!ret) {
+        LOGE() << "Failed to write plugin load sentinel for " << resourceId << ": " << ret.toString();
+    }
+
+    return ret;
+}
+
+void AudioPluginsLoadGuard::endLoad(const PluginResourceId& resourceId)
+{
+    IF_ASSERT_FAILED(!resourceId.empty()) {
+        return;
+    }
+
+    Ret ret = fileSystem()->remove(sentinelFilePath(resourceId));
+    if (!ret) {
+        LOGE() << "Failed to remove plugin load sentinel for " << resourceId << ": " << ret.toString();
+    }
+}
+
+PluginResourceIdList AudioPluginsLoadGuard::danglingLoads() const
+{
+    const io::path_t dir = sentinelsDirPath();
+    if (!fileSystem()->exists(dir)) {
+        return {};
+    }
+
+    const RetVal<io::paths_t> files = fileSystem()->scanFiles(dir, { "*" + SENTINEL_SUFFIX }, io::ScanMode::FilesInCurrentDir);
+    if (!files.ret) {
+        LOGE() << "Failed to scan plugin load guard dir: " << files.ret.toString();
+        return {};
+    }
+
+    PluginResourceIdList result;
+    result.reserve(files.val.size());
+
+    for (const io::path_t& file : files.val) {
+        RetVal<ByteArray> data = fileSystem()->readFile(file);
+        if (!data.ret) {
+            LOGE() << "Failed to read plugin load sentinel " << file.toStdString() << ": " << data.ret.toString();
+            continue;
+        }
+
+        // the file name is a hash; the content holds the actual id
+        std::string resourceId(reinterpret_cast<const char*>(data.val.constData()), data.val.size());
+        if (!resourceId.empty()) {
+            result.push_back(std::move(resourceId));
+        }
+    }
+
+    return result;
+}
+
+Ret AudioPluginsLoadGuard::clearDanglingLoads()
+{
+    const io::path_t dir = sentinelsDirPath();
+    if (!fileSystem()->exists(dir)) {
+        return make_ok();
+    }
+
+    return fileSystem()->clear(dir);
+}
+
+io::path_t AudioPluginsLoadGuard::sentinelsDirPath() const
+{
+    return globalConfiguration()->userAppDataPath() + "/audio_plugins_loading";
+}
+
+io::path_t AudioPluginsLoadGuard::sentinelFilePath(const PluginResourceId& resourceId) const
+{
+    // ids may contain characters that are not valid in file names; use a hash
+    // for the name and keep the authoritative id in the file content
+    std::ostringstream name;
+    name << std::hex << std::hash<std::string> {}(resourceId);
+    return sentinelsDirPath() + "/" + name.str() + SENTINEL_SUFFIX;
+}

--- a/framework/audioplugins/internal/audiopluginsloadguard.h
+++ b/framework/audioplugins/internal/audiopluginsloadguard.h
@@ -2,10 +2,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
- * MuseScore Studio
+ * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,20 +21,27 @@
  */
 #pragma once
 
-#include "global/types/ret.h"
+#include "global/modularity/ioc.h"
+#include "global/iglobalconfiguration.h"
+#include "global/io/ifilesystem.h"
+
+#include "../iaudiopluginsloadguard.h"
 
 namespace muse::audioplugins {
-enum class Err {
-    Undefined       = int(Ret::Code::Undefined),
-    NoError         = int(Ret::Code::Ok),
-    UnknownError    = int(Ret::Code::AudioFirst),
-
-    UnknownPluginType = 351,
-    PluginCrashedOnLoad = 352,
-};
-
-inline Ret make_ret(Err e)
+class AudioPluginsLoadGuard : public IAudioPluginsLoadGuard
 {
-    return Ret(static_cast<int>(e));
-}
+public:
+    GlobalInject<IGlobalConfiguration> globalConfiguration;
+    GlobalInject<io::IFileSystem> fileSystem;
+
+    Ret beginLoad(const PluginResourceId& resourceId) override;
+    void endLoad(const PluginResourceId& resourceId) override;
+
+    PluginResourceIdList danglingLoads() const override;
+    Ret clearDanglingLoads() override;
+
+private:
+    io::path_t sentinelsDirPath() const;
+    io::path_t sentinelFilePath(const PluginResourceId& resourceId) const;
+};
 }

--- a/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
+++ b/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
@@ -33,6 +33,7 @@
 #include <thread>
 #include <vector>
 
+#include "global/containers.h"
 #include "global/translation.h"
 
 #include "audiopluginserrors.h"
@@ -89,6 +90,53 @@ void RegisterAudioPluginsScenario::init()
     if (!ret) {
         LOGE() << ret.toString();
     }
+}
+
+Ret RegisterAudioPluginsScenario::markCrashedPluginsAsBroken()
+{
+    TRACEFUNC;
+
+    const PluginResourceIdList crashedIds = loadGuard()->danglingLoads();
+    if (crashedIds.empty()) {
+        return make_ok();
+    }
+
+    AudioPluginInfoList brokenInfos;
+
+    for (const AudioPluginInfo& info : knownPluginsRegister()->pluginInfoList()) {
+        if (!muse::contains(crashedIds, info.meta.id)) {
+            continue;
+        }
+
+        LOGI() << "Plugin crashed the application while loading in a previous run, marking as broken: " << info.meta.id;
+
+        AudioPluginInfo broken = info;
+        broken.state = AudioPluginState::Error;
+        broken.errorCode = static_cast<int>(Err::PluginCrashedOnLoad);
+        brokenInfos.push_back(std::move(broken));
+    }
+
+    Ret ret = make_ok();
+
+    if (!brokenInfos.empty()) {
+        PluginResourceIdList brokenIds;
+        brokenIds.reserve(brokenInfos.size());
+        for (const AudioPluginInfo& info : brokenInfos) {
+            brokenIds.push_back(info.meta.id);
+        }
+
+        ret = knownPluginsRegister()->unregisterPlugins(brokenIds);
+        if (ret) {
+            ret = knownPluginsRegister()->registerPlugins(brokenInfos);
+        }
+
+        if (!ret) {
+            LOGE() << "Failed to mark crashed plugins as broken: " << ret.toString();
+            return ret;
+        }
+    }
+
+    return loadGuard()->clearDanglingLoads();
 }
 
 PluginScanResult RegisterAudioPluginsScenario::scanPlugins(Progress* progress) const

--- a/framework/audioplugins/internal/registeraudiopluginsscenario.h
+++ b/framework/audioplugins/internal/registeraudiopluginsscenario.h
@@ -35,6 +35,7 @@
 #include "../iknownaudiopluginsregister.h"
 #include "../iaudiopluginsscannerregister.h"
 #include "../iaudiopluginmetareaderregister.h"
+#include "../iaudiopluginsloadguard.h"
 
 namespace muse::audioplugins {
 class RegisterAudioPluginsScenario : public IRegisterAudioPluginsScenario, public Contextable, public async::Asyncable
@@ -46,6 +47,7 @@ public:
     GlobalInject<IKnownAudioPluginsRegister> knownPluginsRegister;
     GlobalInject<IAudioPluginsScannerRegister> scannerRegister;
     GlobalInject<IAudioPluginMetaReaderRegister> metaReaderRegister;
+    GlobalInject<IAudioPluginsLoadGuard> loadGuard;
     ContextInject<IInteractive> interactive = { this };
 
 public:
@@ -53,6 +55,8 @@ public:
         : Contextable(iocCtx) {}
 
     void init();
+
+    Ret markCrashedPluginsAsBroken();
 
     PluginScanResult scanPlugins(Progress* progress = nullptr) const override;
 

--- a/framework/audioplugins/tests/CMakeLists.txt
+++ b/framework/audioplugins/tests/CMakeLists.txt
@@ -28,7 +28,9 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audiopluginsscannermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audiopluginmetareaderregistermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audiopluginmetareadermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/audiopluginsloadguardmock.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/audiopluginsloadguardtest.cpp
     ${CMAKE_CURRENT_LIST_DIR}/knownaudiopluginsregistertest.cpp
     ${CMAKE_CURRENT_LIST_DIR}/knownaudiopluginsmigrationregistertest.cpp
     ${CMAKE_CURRENT_LIST_DIR}/registeraudiopluginsscenariotest.cpp

--- a/framework/audioplugins/tests/audiopluginsloadguardtest.cpp
+++ b/framework/audioplugins/tests/audiopluginsloadguardtest.cpp
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gmock/gmock.h>
+
+#include "audioplugins/internal/audiopluginsloadguard.h"
+
+#include "global/tests/mocks/globalconfigurationmock.h"
+#include "global/tests/mocks/filesystemmock.h"
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SaveArg;
+
+using namespace muse;
+using namespace muse::audioplugins;
+
+namespace muse::audioplugins {
+class AudioPlugins_AudioPluginsLoadGuardTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_guard = std::make_shared<AudioPluginsLoadGuard>();
+        m_globalConfiguration = std::make_shared<NiceMock<GlobalConfigurationMock> >();
+        m_fileSystem = std::make_shared<NiceMock<io::FileSystemMock> >();
+
+        m_guard->globalConfiguration.set(m_globalConfiguration);
+        m_guard->fileSystem.set(m_fileSystem);
+
+        ON_CALL(*m_globalConfiguration, userAppDataPath())
+        .WillByDefault(Return(io::path_t("/appdata")));
+
+        ON_CALL(*m_fileSystem, makePath(_))
+        .WillByDefault(Return(make_ok()));
+
+        ON_CALL(*m_fileSystem, writeFile(_, _))
+        .WillByDefault(Return(make_ok()));
+
+        ON_CALL(*m_fileSystem, remove(_, _))
+        .WillByDefault(Return(make_ok()));
+    }
+
+    std::shared_ptr<AudioPluginsLoadGuard> m_guard;
+    std::shared_ptr<GlobalConfigurationMock> m_globalConfiguration;
+    std::shared_ptr<io::FileSystemMock> m_fileSystem;
+};
+}
+
+TEST_F(AudioPlugins_AudioPluginsLoadGuardTest, BeginLoadWritesSentinelWithIdAsContent)
+{
+    // [GIVEN] Some plugin id (may contain characters not valid in file names)
+    const PluginResourceId resourceId = "Effect/VST3: Weird\\Id";
+
+    // [THEN] A sentinel file is written; its content is the exact id
+    io::path_t writtenPath;
+    ByteArray writtenData;
+    EXPECT_CALL(*m_fileSystem, writeFile(_, _))
+    .WillOnce(DoAll(SaveArg<0>(&writtenPath), SaveArg<1>(&writtenData), Return(make_ok())));
+
+    // [WHEN] Begin the load
+    EXPECT_TRUE(m_guard->beginLoad(resourceId));
+
+    EXPECT_EQ(std::string(writtenData.constChar(), writtenData.size()), resourceId);
+
+    // [THEN] Ending the load removes the very same file
+    EXPECT_CALL(*m_fileSystem, remove(writtenPath, _))
+    .WillOnce(Return(make_ok()));
+
+    // [WHEN] End the load
+    m_guard->endLoad(resourceId);
+}
+
+TEST_F(AudioPlugins_AudioPluginsLoadGuardTest, DanglingLoadsReturnsSentinelContents)
+{
+    // [GIVEN] Two sentinel files left over from a crashed run
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(make_ok()));
+
+    const io::paths_t sentinelFiles { "/appdata/audio_plugins_loading/aaa.loading",
+                                      "/appdata/audio_plugins_loading/bbb.loading" };
+    ON_CALL(*m_fileSystem, scanFiles(_, _, _))
+    .WillByDefault(Return(RetVal<io::paths_t>::make_ok(sentinelFiles)));
+
+    ON_CALL(*m_fileSystem, readFile(sentinelFiles[0]))
+    .WillByDefault(Return(RetVal<ByteArray>::make_ok(ByteArray("PluginA", 7))));
+    ON_CALL(*m_fileSystem, readFile(sentinelFiles[1]))
+    .WillByDefault(Return(RetVal<ByteArray>::make_ok(ByteArray("PluginB", 7))));
+
+    // [WHEN] Query the dangling loads
+    const PluginResourceIdList dangling = m_guard->danglingLoads();
+
+    // [THEN] The ids stored in the sentinels are returned
+    EXPECT_EQ(dangling, (PluginResourceIdList { "PluginA", "PluginB" }));
+}
+
+TEST_F(AudioPlugins_AudioPluginsLoadGuardTest, DanglingLoadsEmptyWhenNoSentinelDir)
+{
+    // [GIVEN] The sentinel dir does not exist (nothing ever crashed)
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+
+    // [THEN] No scan is even attempted
+    EXPECT_CALL(*m_fileSystem, scanFiles(_, _, _))
+    .Times(0);
+
+    // [WHEN] Query the dangling loads
+    EXPECT_TRUE(m_guard->danglingLoads().empty());
+}

--- a/framework/audioplugins/tests/mocks/audiopluginsloadguardmock.h
+++ b/framework/audioplugins/tests/mocks/audiopluginsloadguardmock.h
@@ -2,10 +2,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
- * MuseScore Studio
+ * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited and others
+ * Copyright (C) 2026 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,20 +21,17 @@
  */
 #pragma once
 
-#include "global/types/ret.h"
+#include <gmock/gmock.h>
+
+#include "audioplugins/iaudiopluginsloadguard.h"
 
 namespace muse::audioplugins {
-enum class Err {
-    Undefined       = int(Ret::Code::Undefined),
-    NoError         = int(Ret::Code::Ok),
-    UnknownError    = int(Ret::Code::AudioFirst),
-
-    UnknownPluginType = 351,
-    PluginCrashedOnLoad = 352,
-};
-
-inline Ret make_ret(Err e)
+class AudioPluginsLoadGuardMock : public IAudioPluginsLoadGuard
 {
-    return Ret(static_cast<int>(e));
-}
+public:
+    MOCK_METHOD(Ret, beginLoad, (const PluginResourceId&), (override));
+    MOCK_METHOD(void, endLoad, (const PluginResourceId&), (override));
+    MOCK_METHOD(PluginResourceIdList, danglingLoads, (), (const, override));
+    MOCK_METHOD(Ret, clearDanglingLoads, (), (override));
+};
 }

--- a/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
+++ b/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
@@ -22,6 +22,7 @@
 #include <gmock/gmock.h>
 
 #include "audioplugins/internal/registeraudiopluginsscenario.h"
+#include "audioplugins/audiopluginserrors.h"
 
 #include "global/tests/mocks/globalconfigurationmock.h"
 #include "global/tests/mocks/processmock.h"
@@ -33,6 +34,7 @@
 #include "mocks/audiopluginsscannermock.h"
 #include "mocks/audiopluginmetareaderregistermock.h"
 #include "mocks/audiopluginmetareadermock.h"
+#include "mocks/audiopluginsloadguardmock.h"
 
 #include "translation.h"
 
@@ -62,6 +64,7 @@ protected:
         m_knownPlugins = std::make_shared<NiceMock<KnownAudioPluginsRegisterMock> >();
         m_scanners = { std::make_shared<NiceMock<AudioPluginsScannerMock> >() };
         m_metaReaderRegister = std::make_shared<NiceMock<AudioPluginMetaReaderRegisterMock> >();
+        m_loadGuard = std::make_shared<NiceMock<AudioPluginsLoadGuardMock> >();
 
         const auto metaReaderMock = std::make_shared<NiceMock<AudioPluginMetaReaderMock> >();
         m_metaReaders = { metaReaderMock };
@@ -73,6 +76,7 @@ protected:
         m_scenario->knownPluginsRegister.set(m_knownPlugins);
         m_scenario->scannerRegister.set(m_scannerRegister);
         m_scenario->metaReaderRegister.set(m_metaReaderRegister);
+        m_scenario->loadGuard.set(m_loadGuard);
 
         ON_CALL(*m_globalConfiguration, appBinPath())
         .WillByDefault(Return(m_appPath));
@@ -123,6 +127,7 @@ protected:
     std::shared_ptr<AudioPluginsScannerRegisterMock> m_scannerRegister;
     std::vector<IAudioPluginsScannerPtr> m_scanners;
     std::shared_ptr<AudioPluginMetaReaderRegisterMock> m_metaReaderRegister;
+    std::shared_ptr<AudioPluginsLoadGuardMock> m_loadGuard;
     std::vector<IAudioPluginMetaReaderPtr> m_metaReaders;
 
     std::string m_appPath = "/some/path/to/MuseScore";
@@ -653,6 +658,65 @@ TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, FailedValidationRecordsErr
 
     // [WHEN] Register the new plugin with validation enabled
     EXPECT_TRUE(m_scenario->registerNewPlugins(paths, /*validate*/ true));
+}
+
+TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, MarkCrashedPluginsAsBroken)
+{
+    // [GIVEN] Two validated plugins; loading the first one crashed the
+    // application in a previous run, leaving a dangling load sentinel
+    AudioPluginInfo crashedPlugin;
+    crashedPlugin.meta.id = "CrashingPlugin";
+    crashedPlugin.meta.type = "VstPlugin";
+    crashedPlugin.path = "/some/path/AAA.vst3";
+    crashedPlugin.state = AudioPluginState::Validated;
+
+    AudioPluginInfo healthyPlugin;
+    healthyPlugin.meta.id = "HealthyPlugin";
+    healthyPlugin.meta.type = "VstPlugin";
+    healthyPlugin.path = "/some/path/BBB.vst3";
+    healthyPlugin.state = AudioPluginState::Validated;
+
+    ON_CALL(*m_knownPlugins, pluginInfoList(_))
+    .WillByDefault(Return(AudioPluginInfoList { crashedPlugin, healthyPlugin }));
+
+    ON_CALL(*m_loadGuard, danglingLoads())
+    .WillByDefault(Return(PluginResourceIdList { crashedPlugin.meta.id }));
+
+    // [THEN] Only the crashed plugin is re-registered, as broken
+    AudioPluginInfo expectedBroken = crashedPlugin;
+    expectedBroken.state = AudioPluginState::Error;
+    expectedBroken.errorCode = static_cast<int>(Err::PluginCrashedOnLoad);
+
+    ::testing::InSequence seq;
+    EXPECT_CALL(*m_knownPlugins, unregisterPlugins(PluginResourceIdList { crashedPlugin.meta.id }))
+    .WillOnce(Return(make_ok()));
+    EXPECT_CALL(*m_knownPlugins, registerPlugins(AudioPluginInfoList { expectedBroken }))
+    .WillOnce(Return(make_ok()));
+
+    // [THEN] The sentinels are cleared
+    EXPECT_CALL(*m_loadGuard, clearDanglingLoads())
+    .WillOnce(Return(make_ok()));
+
+    // [WHEN] Handle crashed plugins
+    EXPECT_TRUE(m_scenario->markCrashedPluginsAsBroken());
+}
+
+TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, MarkCrashedPluginsAsBroken_NoDanglingLoads)
+{
+    // [GIVEN] No dangling load sentinels
+    ON_CALL(*m_loadGuard, danglingLoads())
+    .WillByDefault(Return(PluginResourceIdList {}));
+
+    // [THEN] The register is left untouched
+    EXPECT_CALL(*m_knownPlugins, unregisterPlugins(_))
+    .Times(0);
+    EXPECT_CALL(*m_knownPlugins, registerPlugins(_))
+    .Times(0);
+    EXPECT_CALL(*m_loadGuard, clearDanglingLoads())
+    .Times(0);
+
+    // [WHEN] Handle crashed plugins
+    EXPECT_TRUE(m_scenario->markCrashedPluginsAsBroken());
 }
 
 TEST_F(AudioPlugins_RegisterAudioPluginsScenarioTest, TimedOutValidationRecordsErrorEntry)

--- a/framework/vst/internal/vstmodulesrepository.cpp
+++ b/framework/vst/internal/vstmodulesrepository.cpp
@@ -76,7 +76,10 @@ void VstModulesRepository::addPluginModule(const muse::audio::AudioResourceId& r
         return;
     }
 
+    loadGuard()->beginLoad(resourceId);
     PluginModulePtr module = createModule(knownPlugins()->pluginPath(resourceId));
+    loadGuard()->endLoad(resourceId);
+
     if (!module) {
         return;
     }

--- a/framework/vst/internal/vstmodulesrepository.h
+++ b/framework/vst/internal/vstmodulesrepository.h
@@ -29,6 +29,7 @@
 
 #include "modularity/ioc.h"
 #include "audioplugins/iknownaudiopluginsregister.h"
+#include "audioplugins/iaudiopluginsloadguard.h"
 #include "audio/common/iaudiothreadsecurer.h"
 
 #include "vsttypes.h"
@@ -38,6 +39,7 @@ class VstModulesRepository : public IVstModulesRepository
 {
     muse::GlobalInject<muse::audio::IAudioThreadSecurer> threadSecurer;
     muse::GlobalInject<audioplugins::IKnownAudioPluginsRegister> knownPlugins;
+    muse::GlobalInject<audioplugins::IAudioPluginsLoadGuard> loadGuard;
 
 public:
     VstModulesRepository() = default;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11604

It can be that a once validated plugin later crashes the application, like MuseHub-distributed plugins did in the recent past, when their license expired.

With this PR, this can happen only once per offending plugin (rather than every time): next time, at startup, it'll be marked as invalid and won't be available in the app anymore.

MSS will benefit from this PR without further work.
Audacity will need to use the lock guard in its plugin-loading code - a small change, and not one needed for successful compilation.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
