### PR TITLE
Fix vst checkable unity ambiguity

### DIFF
--- a/framework/rcommand/commandtypes.h
+++ b/framework/rcommand/commandtypes.h
@@ -71,6 +71,10 @@ struct Arg {
 };
 
 struct InputSchema {
+    InputSchema() {}
+    InputSchema(std::map<std::string, Arg> _args)
+        : args(std::move(_args)) {}
+
     std::map<std::string, Arg> args;
 };
 

--- a/framework/vst/internal/vstuiactions.cpp
+++ b/framework/vst/internal/vstuiactions.cpp
@@ -36,13 +36,13 @@ const UiActionList VstUiActions::m_actions = {
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_DISABLED,
              TranslatableString("action", "Use old view"),
-             Checkable::Yes
+             muse::ui::Checkable::Yes
              ),
     UiAction("vst-use-newview",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_DISABLED,
              TranslatableString("action", "Use new view"),
-             Checkable::Yes
+             muse::ui::Checkable::Yes
              )
 };
 


### PR DESCRIPTION
Fixes Audacity build

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
