### PR TITLE
Clear the export mix buffer between blocks (fix audio accumulation)

### DIFF
--- a/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -166,6 +166,10 @@ Ret SoundTrackWriter::writeStreaming()
         const samples_t chunk = static_cast<samples_t>(
             std::min<uint64_t>(m_renderStep, audioEnd - framesWritten));
 
+        //! NOTE The mixer mixes additively and relies on the caller to zero the output buffer
+        //! (real time does this via AudioEngine::fillSilent), so clear it before each block.
+        std::fill(m_intermBuffer.begin(), m_intermBuffer.end(), 0.f);
+
         m_source->process(m_intermBuffer.data(), chunk);
 
         const size_t encoded = m_encoderPtr->encode(chunk, m_intermBuffer.data());


### PR DESCRIPTION
Resolves: musescore/MuseScore#34595

## Summary

Exported audio accumulates and saturates over the piece (a droning "echo") while real-time playback is correct. It affects every instrument (SoundFont and VST), because the bug is at the mixer/output-buffer level.

`Mixer::process` mixes additively into the output buffer (`outBuffer[i] += ...`) and relies on the caller to zero the buffer first. The real-time path does this every callback in `AudioEngine::process` via `fillSilent()`. But `SoundTrackWriter::writeStreaming` reuses a persistent `m_intermBuffer` across blocks and only clears it in the leading and trailing silence phases; the audio phase called `m_source->process(m_intermBuffer.data(), chunk)` without clearing first. So each rendered block summed on top of the previous block's samples still in the buffer, and the exported audio accumulated (RMS ramped to clipping), while playback was fine.

## Context

Clears `m_intermBuffer` at the start of each audio-phase iteration, mirroring what the leading/trailing silence phases already do. One `std::fill`, no behavior change elsewhere.

Verified on macOS for both a plain MS Basic SoundFont instrument and a VST instrument.

NOTE: This fix is independent of #220 and can be reviewed and merged on its own. #220 is only needed to reproduce the bug through a real export on current main, since without it the export path does not complete.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves.
- [x] The code in the PR follows the coding rules.
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
