### PR TITLE
Reduce dock separator's oversized hit-margin

### DIFF
--- a/framework/dockwindow/qml/Muse/Dock/DockSeparator.qml
+++ b/framework/dockwindow/qml/Muse/Dock/DockSeparator.qml
@@ -37,7 +37,7 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
-        anchors.margins: -5 //! NOTE: extra space for user convenience
+        anchors.margins: -2 //! NOTE: extra space for user convenience
 
         cursorShape: (root.separatorCpp && separatorCpp.showResizeCursor)
                      ? (root.separatorCpp.isVertical ? Qt.SizeVerCursor : Qt.SizeHorCursor)

--- a/framework/dockwindow_v2/qml/Muse/Dock/DockSeparator.qml
+++ b/framework/dockwindow_v2/qml/Muse/Dock/DockSeparator.qml
@@ -37,7 +37,7 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
-        anchors.margins: -5 //! NOTE: extra space for user convenience
+        anchors.margins: -2 //! NOTE: extra space for user convenience
 
         cursorShape: (root.separatorCpp && separatorCpp.showResizeCursor)
                      ? (root.separatorCpp.isVertical ? Qt.SizeVerCursor : Qt.SizeHorCursor)


### PR DESCRIPTION
## Summary
- `DockSeparator.qml`'s resize-handle `MouseArea` extends 5px beyond the separator's own ~1px-thin visual bounds, for easier grabbing when resizing docks.
- That invisible catch-zone can silently overlap adjacent interactive content in a neighboring dock — e.g. the last few pixels of a toolbar button sitting right above a separator — and wins the Qt Quick hit-test there, swallowing clicks meant for that control before they ever reach its own `MouseArea`.
- Shrinking the margin from `-5` to `-2` keeps the separator comfortably grabbable while greatly reducing the chance of overlapping neighboring controls. Validated manually: the original click-loss is very hard to reproduce anymore, and the resize-grab ergonomics (getting the resize cursor, dragging) feel unchanged from stock 4.7.4.

Fixes musescore/MuseScore#34603

## Note on scope / trade-off
This is a minimal, low-risk mitigation (one-line diff), not a structural fix — an even smaller invisible catch-zone still has some residual chance of overlapping content in an unusually tight layout. A more thorough fix would have the separator's hit-region conditionally yield only where it actually overlaps interactive content (rather than shrinking the margin universally), but that requires new runtime hit-testing logic in a widely-shared component. Happy to discuss if maintainers would prefer that direction instead.

## Test plan
- [x] Manually reproduced the original bug pre-fix (click silently ignored near a toolbar button's bottom edge while its tooltip is shown)
- [x] Manually verified the fix resolves it (click reliably registers in the same spot)
- [x] Manually verified no regression in separator resize behavior (drag-to-resize, cursor feedback, double-click-to-reset) across multiple dock boundaries (toolbar/score, and the Mixer panel specifically, which was checked against an earlier over-broad attempt that did regress)
- [ ] Automated test coverage — not attempted; this is an interactive mouse/hit-testing behavior not easily covered by existing headless test infrastructure