### PR TITLE
Don't prevent system from sleeping when no live playback is ongoing

### DIFF
--- a/framework/audio/driver/CMakeLists.txt
+++ b/framework/audio/driver/CMakeLists.txt
@@ -79,11 +79,14 @@ elseif(OS_IS_MAC)
         platform/osx/osxaudiodriver.h
         platform/osx/osxdirectaudiodriver.mm
         platform/osx/osxdirectaudiodriver.h
+        platform/osx/osxidlesleeppolicy.mm
+        platform/osx/osxidlesleeppolicy.h
     )
-        
+
     set_source_files_properties(
         platform/osx/osxaudiodriver.mm
         platform/osx/osxdirectaudiodriver.mm
+        platform/osx/osxidlesleeppolicy.mm
         PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION ON
         SKIP_PRECOMPILE_HEADERS ON

--- a/framework/audio/driver/platform/osx/osxaudiodriver.h
+++ b/framework/audio/driver/platform/osx/osxaudiodriver.h
@@ -51,6 +51,8 @@ public:
     void close() override;
     bool isOpened() const override;
 
+    void setLivePlaybackOngoing(bool ongoing) override;
+
     const Spec& activeSpec() const override;
     async::Channel<Spec> activeSpecChanged() const override;
 
@@ -79,6 +81,7 @@ private:
     std::map<unsigned int, std::string> m_outputDevices = {}, m_inputDevices = {};
     mutable std::mutex m_devicesMutex;
     async::Notification m_availableOutputDevicesChanged;
+    bool m_livePlaybackOngoing = false;
 };
 }
 #endif // MUSE_AUDIO_OSXAUDIODRIVER_H

--- a/framework/audio/driver/platform/osx/osxaudiodriver.mm
+++ b/framework/audio/driver/platform/osx/osxaudiodriver.mm
@@ -26,6 +26,8 @@
 
 #include <AudioToolbox/AudioToolbox.h>
 
+#include "osxidlesleeppolicy.h"
+
 #include "translation.h"
 #include "log.h"
 
@@ -165,6 +167,10 @@ bool OSXAudioDriver::open(const Spec& spec, Spec* activeSpec)
         return false;
     }
 
+    //! NOTE From now on the device is running, so make sure the system knows whether
+    //! it is allowed to go to sleep while that is the case
+    OSXIdleSleepPolicy::setPreventIdleSleep(m_livePlaybackOngoing);
+
     m_activeSpecChanged.send(m_data->format);
 
     LOGI() << "Connected to " << m_data->format.deviceId
@@ -191,6 +197,12 @@ void OSXAudioDriver::doClose()
 bool OSXAudioDriver::isOpened() const
 {
     return m_data->audioQueue != nullptr;
+}
+
+void OSXAudioDriver::setLivePlaybackOngoing(bool ongoing)
+{
+    m_livePlaybackOngoing = ongoing;
+    OSXIdleSleepPolicy::setPreventIdleSleep(ongoing);
 }
 
 const OSXAudioDriver::Spec& OSXAudioDriver::activeSpec() const

--- a/framework/audio/driver/platform/osx/osxdirectaudiodriver.h
+++ b/framework/audio/driver/platform/osx/osxdirectaudiodriver.h
@@ -53,6 +53,8 @@ public:
     void close() override;
     bool isOpened() const override;
 
+    void setLivePlaybackOngoing(bool ongoing) override;
+
     const Spec& activeSpec() const override;
     async::Channel<Spec> activeSpecChanged() const override;
 
@@ -88,6 +90,7 @@ private:
 
     AudioWorkGroup m_audioWorkGroup;
     bool m_deviceMapListenerRegistered = false;
+    bool m_livePlaybackOngoing = false;
 };
 }
 #endif // MUSE_AUDIO_OSXDIRECTAUDIODRIVER_H

--- a/framework/audio/driver/platform/osx/osxdirectaudiodriver.mm
+++ b/framework/audio/driver/platform/osx/osxdirectaudiodriver.mm
@@ -39,6 +39,7 @@
 
 #include "common/audiotypes.h"
 #include "common/audioworkgroup.h"
+#include "osxidlesleeppolicy.h"
 #include "translation.h"
 #include "log.h"
 
@@ -668,6 +669,10 @@ bool OSXDirectAudioDriver::open(const Spec& spec, Spec* activeSpec)
         return false;
     }
 
+    //! NOTE From now on the device is running, so make sure the system knows whether
+    //! it is allowed to go to sleep while that is the case
+    OSXIdleSleepPolicy::setPreventIdleSleep(m_livePlaybackOngoing);
+
     m_audioWorkGroup = createAudioWorkgroup(*deviceId);
     m_currentWorkgroupChanged.notify();
 
@@ -715,6 +720,12 @@ void OSXDirectAudioDriver::doClose()
 bool OSXDirectAudioDriver::isOpened() const
 {
     return m_data->procId != nullptr;
+}
+
+void OSXDirectAudioDriver::setLivePlaybackOngoing(bool ongoing)
+{
+    m_livePlaybackOngoing = ongoing;
+    OSXIdleSleepPolicy::setPreventIdleSleep(ongoing);
 }
 
 const OSXDirectAudioDriver::Spec& OSXDirectAudioDriver::activeSpec() const

--- a/framework/audio/driver/platform/osx/osxidlesleeppolicy.h
+++ b/framework/audio/driver/platform/osx/osxidlesleeppolicy.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace muse::audio {
+//! NOTE macOS prevents the system from going to idle sleep for as long as a process has
+//! audio IO running, no matter whether that IO is audible. Since we keep the audio device
+//! open for the whole session, that would keep the Mac awake permanently, also when idle.
+//! So we tell CoreAudio that idle sleep is fine, and only opt out of it while something
+//! is actually being played back.
+//!
+//! The policy applies to the process as a whole, so it is shared by all drivers.
+class OSXIdleSleepPolicy
+{
+public:
+    static void setPreventIdleSleep(bool prevent);
+};
+}

--- a/framework/audio/driver/platform/osx/osxidlesleeppolicy.mm
+++ b/framework/audio/driver/platform/osx/osxidlesleeppolicy.mm
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "osxidlesleeppolicy.h"
+
+#include <mutex>
+
+#include <CoreAudio/AudioHardware.h>
+
+#include "log.h"
+
+using namespace muse::audio;
+
+//! NOTE The policy is set from the thread that starts and stops playback, but reapplied
+//! from a CoreAudio owned thread, so reading it and applying it has to be serialized
+static std::mutex s_mutex;
+static bool s_preventIdleSleep = false;
+
+static void applyPolicy()
+{
+    std::lock_guard lock(s_mutex);
+
+    //! NOTE 1 means: allow the CPU to idle sleep even if there is audio IO in progress
+    UInt32 sleepingIsAllowed = s_preventIdleSleep ? 0 : 1;
+
+    AudioObjectPropertyAddress address = {
+        .mSelector = kAudioHardwarePropertySleepingIsAllowed,
+        .mScope = kAudioObjectPropertyScopeGlobal,
+        .mElement = kAudioObjectPropertyElementMain
+    };
+
+    OSStatus result = AudioObjectSetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr,
+                                                 sizeof(sleepingIsAllowed), &sleepingIsAllowed);
+    if (result != noErr) {
+        LOGE() << "Failed to set idle sleep policy, err: " << result;
+    }
+}
+
+static OSStatus onServiceRestarted(AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void*)
+{
+    //! NOTE The policy belongs to our HAL client, which is recreated when coreaudiod restarts
+    applyPolicy();
+    return noErr;
+}
+
+static void initServiceRestartListener()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, []() {
+        AudioObjectPropertyAddress address = {
+            .mSelector = kAudioHardwarePropertyServiceRestarted,
+            .mScope = kAudioObjectPropertyScopeGlobal,
+            .mElement = kAudioObjectPropertyElementMain
+        };
+
+        OSStatus result = AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address, &onServiceRestarted, nullptr);
+        if (result != noErr) {
+            LOGE() << "Failed to add service restart listener, err: " << result;
+        }
+    });
+}
+
+void OSXIdleSleepPolicy::setPreventIdleSleep(bool prevent)
+{
+    initServiceRestartListener();
+
+    {
+        std::lock_guard lock(s_mutex);
+        s_preventIdleSleep = prevent;
+    }
+
+    applyPolicy();
+}

--- a/framework/audio/iaudiodriver.h
+++ b/framework/audio/iaudiodriver.h
@@ -61,6 +61,12 @@ public:
     virtual void close() = 0;
     virtual bool isOpened() const = 0;
 
+    //! NOTE Tells the driver whether audio is currently being played back in real time.
+    //! The driver is kept open for the whole session and simply receives silence when
+    //! nothing is playing, so it cannot tell the difference on its own.
+    //! Drivers may use this to adjust platform specific behaviour; ignored by default.
+    virtual void setLivePlaybackOngoing(bool ongoing) { (void)ongoing; }
+
     virtual const Spec& activeSpec() const = 0;
     virtual async::Channel<Spec> activeSpecChanged() const = 0;
 

--- a/framework/audio/iaudiodrivercontroller.h
+++ b/framework/audio/iaudiodrivercontroller.h
@@ -48,6 +48,9 @@ public:
     virtual void close() = 0;
     virtual bool isOpened() const = 0;
 
+    //! NOTE See IAudioDriver::setLivePlaybackOngoing
+    virtual void setLivePlaybackOngoing(bool ongoing) = 0;
+
     virtual const IAudioDriver::Spec& activeSpec() const = 0;
     virtual async::Channel<IAudioDriver::Spec> activeSpecChanged() const = 0;
 

--- a/framework/audio/main/internal/audiodrivercontroller.cpp
+++ b/framework/audio/main/internal/audiodrivercontroller.cpp
@@ -178,6 +178,9 @@ void AudioDriverController::setNewDriver(IAudioDriverPtr newDriver)
     m_audioDriver = newDriver;
 
     if (m_audioDriver) {
+        //! NOTE The new driver doesn't know yet what is going on
+        m_audioDriver->setLivePlaybackOngoing(m_livePlaybackOngoing);
+
         // subscribe
         m_audioDriver->availableOutputDevicesChanged().onNotify(this, [this]() {
             async::Async::call(this, [this]() {
@@ -315,6 +318,19 @@ bool AudioDriverController::isOpened() const
         return false;
     }
     return m_audioDriver->isOpened();
+}
+
+void AudioDriverController::setLivePlaybackOngoing(bool ongoing)
+{
+    if (m_livePlaybackOngoing == ongoing) {
+        return;
+    }
+
+    m_livePlaybackOngoing = ongoing;
+
+    if (m_audioDriver) {
+        m_audioDriver->setLivePlaybackOngoing(ongoing);
+    }
 }
 
 const IAudioDriver::Spec& AudioDriverController::activeSpec() const

--- a/framework/audio/main/internal/audiodrivercontroller.h
+++ b/framework/audio/main/internal/audiodrivercontroller.h
@@ -54,6 +54,8 @@ public:
     void close() override;
     bool isOpened() const override;
 
+    void setLivePlaybackOngoing(bool ongoing) override;
+
     const IAudioDriver::Spec& activeSpec() const override;
     async::Channel<IAudioDriver::Spec> activeSpecChanged() const override;
 
@@ -91,5 +93,6 @@ private:
     async::Notification m_outputDeviceSampleRateChanged;
 
     bool m_retryOpenDevice = false;
+    bool m_livePlaybackOngoing = false;
 };
 }

--- a/framework/audio/main/internal/player.cpp
+++ b/framework/audio/main/internal/player.cpp
@@ -21,6 +21,8 @@
  */
 #include "player.h"
 
+#include <set>
+
 #include "audio/common/rpc/rpcpacker.h"
 #include "audio/common/audiosanitizer.h"
 
@@ -31,9 +33,35 @@ using namespace muse::async;
 using namespace muse::audio;
 using namespace muse::audio::rpc;
 
+//! NOTE Playback is contextual (each window has its own), and every context can hand out
+//! more than one player, so live playback is ongoing as long as any of them is running.
+static std::set<const Player*>& runningPlayers()
+{
+    static std::set<const Player*> s_runningPlayers;
+    return s_runningPlayers;
+}
+
+Player::~Player()
+{
+    if (runningPlayers().erase(this) != 0) {
+        updateLivePlaybackOngoing();
+    }
+}
+
 rpc::CtxId Player::ctxId() const
 {
     return rpc::ctxId(iocContext());
+}
+
+void Player::updateLivePlaybackOngoing()
+{
+    ONLY_AUDIO_MAIN_THREAD;
+
+    //! NOTE Can already be gone on shutdown
+    const std::shared_ptr<IAudioDriverController>& controller = audioDriverController.get();
+    if (controller) {
+        controller->setLivePlaybackOngoing(!runningPlayers().empty());
+    }
 }
 
 void Player::init()
@@ -45,6 +73,16 @@ void Player::init()
     {
         m_playbackStatusChanged.onReceive(this, [this](PlaybackStatus st) {
             m_playbackStatus = st;
+
+            //! NOTE Only while running is audio actually being produced;
+            //! when paused or stopped there is nothing to keep the system awake for
+            if (m_playbackStatus == PlaybackStatus::Running) {
+                runningPlayers().insert(this);
+            } else {
+                runningPlayers().erase(this);
+            }
+
+            updateLivePlaybackOngoing();
         });
 
         Msg msg = rpc::make_request(ctxId(), MsgCode::GetPlaybackStatus);

--- a/framework/audio/main/internal/player.h
+++ b/framework/audio/main/internal/player.h
@@ -29,15 +29,19 @@
 
 #include "modularity/ioc.h"
 #include "audio/common/rpc/irpcchannel.h"
+#include "audio/iaudiodrivercontroller.h"
 
 namespace muse::audio {
 class Player : public IPlayer, public Contextable, public async::Asyncable
 {
     GlobalInject<rpc::IRpcChannel> channel;
+    GlobalInject<IAudioDriverController> audioDriverController;
 
 public:
     Player(const muse::modularity::ContextPtr& ctx)
         : Contextable(ctx) {}
+
+    ~Player() override;
 
     void init();
 
@@ -62,6 +66,8 @@ public:
 private:
 
     rpc::CtxId ctxId() const;
+
+    void updateLivePlaybackOngoing();
 
     PlaybackStatus m_playbackStatus = PlaybackStatus::Stopped;
     async::Channel<PlaybackStatus> m_playbackStatusChanged;

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(muse_global PRIVATE
     timer.cpp
     timer.h
     progress.h
+    idlesleepblocker.h
     utils.cpp
     utils.h
     interpolation.h
@@ -241,6 +242,34 @@ else()
             Winmm # needed for timeBeginPeriod
         )
     endif()
+endif()
+
+#! NOTE IdleSleepBlocker is always declared, so it always needs an implementation
+include(GetPlatformInfo)
+
+if (GLOBAL_NO_INTERNAL)
+    target_sources(muse_global PRIVATE
+        internal/platform/stub/idlesleepblocker.cpp
+    )
+elseif (OS_IS_MAC)
+    target_sources(muse_global PRIVATE
+        internal/platform/macos/idlesleepblocker.cpp
+    )
+    find_library(IOKit NAMES IOKit)
+    target_link_libraries(muse_global PRIVATE ${IOKit})
+elseif (OS_IS_WIN)
+    target_sources(muse_global PRIVATE
+        internal/platform/windows/idlesleepblocker.cpp
+    )
+elseif ((OS_IS_LIN OR OS_IS_FBSD) AND MUSE_QT_SUPPORT)
+    target_sources(muse_global PRIVATE
+        internal/platform/linux/idlesleepblocker.cpp
+    )
+    target_link_libraries(muse_global PRIVATE Qt::DBus)
+else()
+    target_sources(muse_global PRIVATE
+        internal/platform/stub/idlesleepblocker.cpp
+    )
 endif()
 
 include(GetCompilerInfo)

--- a/framework/global/idlesleepblocker.h
+++ b/framework/global/idlesleepblocker.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace muse {
+//! NOTE Prevents the system from going to idle sleep for as long as this object exists.
+//! Meant for tasks that can take a long time while the user is not interacting with the
+//! application and nothing is audible, like exporting an audio file: without this, the
+//! system can suspend halfway through such a task.
+//!
+//! It does not prevent the display from sleeping, and it does not prevent sleep that the
+//! user or the system asks for explicitly (closing the lid, low battery, etc.).
+//!
+//! Blocking is best effort: if the platform refuses, or has no way to express this, the
+//! failure is logged and the object simply does nothing.
+class IdleSleepBlocker
+{
+public:
+    //! NOTE `reason` is shown to the user by some systems, so it should describe the task
+    //! being performed, and be translated
+    explicit IdleSleepBlocker(const std::string& reason);
+    ~IdleSleepBlocker();
+
+    IdleSleepBlocker(const IdleSleepBlocker&) = delete;
+    IdleSleepBlocker& operator=(const IdleSleepBlocker&) = delete;
+
+private:
+    struct Data;
+    std::unique_ptr<Data> m_data;
+};
+
+using IdleSleepBlockerPtr = std::shared_ptr<IdleSleepBlocker>;
+}

--- a/framework/global/internal/platform/linux/idlesleepblocker.cpp
+++ b/framework/global/internal/platform/linux/idlesleepblocker.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../../../idlesleepblocker.h"
+
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusUnixFileDescriptor>
+
+#include "log.h"
+
+using namespace muse;
+
+struct IdleSleepBlocker::Data {
+    //! NOTE Holding the descriptor is what holds the inhibitor; closing it releases it
+    QDBusUnixFileDescriptor descriptor;
+};
+
+IdleSleepBlocker::IdleSleepBlocker(const std::string& reason)
+    : m_data(std::make_unique<Data>())
+{
+    QDBusInterface manager("org.freedesktop.login1",
+                           "/org/freedesktop/login1",
+                           "org.freedesktop.login1.Manager",
+                           QDBusConnection::systemBus());
+
+    if (!manager.isValid()) {
+        LOGW() << "Failed to connect to login1, the system may go to sleep";
+        return;
+    }
+
+    QDBusReply<QDBusUnixFileDescriptor> reply = manager.call("Inhibit",
+                                                             QStringLiteral("idle"),
+                                                             QCoreApplication::applicationName(),
+                                                             QString::fromStdString(reason),
+                                                             QStringLiteral("block"));
+
+    if (!reply.isValid()) {
+        LOGW() << "Failed to inhibit idle sleep: " << reply.error().message().toStdString()
+               << ", the system may go to sleep";
+        return;
+    }
+
+    m_data->descriptor = reply.value();
+}
+
+IdleSleepBlocker::~IdleSleepBlocker() = default;

--- a/framework/global/internal/platform/macos/idlesleepblocker.cpp
+++ b/framework/global/internal/platform/macos/idlesleepblocker.cpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../../../idlesleepblocker.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
+
+#include "log.h"
+
+using namespace muse;
+
+struct IdleSleepBlocker::Data {
+    IOPMAssertionID assertionId = kIOPMNullAssertionID;
+};
+
+IdleSleepBlocker::IdleSleepBlocker(const std::string& reason)
+    : m_data(std::make_unique<Data>())
+{
+    CFStringRef reasonRef = CFStringCreateWithCString(kCFAllocatorDefault, reason.c_str(), kCFStringEncodingUTF8);
+    if (!reasonRef) {
+        LOGW() << "Failed to create reason string, the system may go to sleep";
+        return;
+    }
+
+    IOPMAssertionID assertionId = kIOPMNullAssertionID;
+    IOReturn result = IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleSystemSleep,
+                                                  kIOPMAssertionLevelOn, reasonRef, &assertionId);
+    CFRelease(reasonRef);
+
+    if (result != kIOReturnSuccess) {
+        LOGW() << "Failed to create power assertion, err: " << result << ", the system may go to sleep";
+        return;
+    }
+
+    m_data->assertionId = assertionId;
+}
+
+IdleSleepBlocker::~IdleSleepBlocker()
+{
+    if (m_data->assertionId != kIOPMNullAssertionID) {
+        IOPMAssertionRelease(m_data->assertionId);
+    }
+}

--- a/framework/global/internal/platform/stub/idlesleepblocker.cpp
+++ b/framework/global/internal/platform/stub/idlesleepblocker.cpp
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../../../idlesleepblocker.h"
+
+using namespace muse;
+
+struct IdleSleepBlocker::Data {
+};
+
+IdleSleepBlocker::IdleSleepBlocker(const std::string&)
+    : m_data(std::make_unique<Data>())
+{
+}
+
+IdleSleepBlocker::~IdleSleepBlocker() = default;

--- a/framework/global/internal/platform/windows/idlesleepblocker.cpp
+++ b/framework/global/internal/platform/windows/idlesleepblocker.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../../../idlesleepblocker.h"
+
+#include <windows.h>
+
+#include "log.h"
+
+using namespace muse;
+
+struct IdleSleepBlocker::Data {
+    //! NOTE Kept alive because the reason string is referenced by the request, not copied
+    std::wstring reason;
+    HANDLE request = INVALID_HANDLE_VALUE;
+};
+
+IdleSleepBlocker::IdleSleepBlocker(const std::string& reason)
+    : m_data(std::make_unique<Data>())
+{
+    int size = MultiByteToWideChar(CP_UTF8, 0, reason.c_str(), static_cast<int>(reason.size()), nullptr, 0);
+    m_data->reason.resize(static_cast<size_t>(size));
+    MultiByteToWideChar(CP_UTF8, 0, reason.c_str(), static_cast<int>(reason.size()), m_data->reason.data(), size);
+
+    REASON_CONTEXT context = {};
+    context.Version = POWER_REQUEST_CONTEXT_VERSION;
+    context.Flags = POWER_REQUEST_CONTEXT_SIMPLE_STRING;
+    context.Reason.SimpleReasonString = m_data->reason.data();
+
+    HANDLE request = PowerCreateRequest(&context);
+    if (request == INVALID_HANDLE_VALUE) {
+        LOGW() << "Failed to create power request, err: " << GetLastError() << ", the system may go to sleep";
+        return;
+    }
+
+    if (!PowerSetRequest(request, PowerRequestSystemRequired)) {
+        LOGW() << "Failed to set power request, err: " << GetLastError() << ", the system may go to sleep";
+        CloseHandle(request);
+        return;
+    }
+
+    m_data->request = request;
+}
+
+IdleSleepBlocker::~IdleSleepBlocker()
+{
+    if (m_data->request == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    PowerClearRequest(m_data->request, PowerRequestSystemRequired);
+    CloseHandle(m_data->request);
+}

--- a/framework/stubs/audio/audiodrivercontrollerstub.cpp
+++ b/framework/stubs/audio/audiodrivercontrollerstub.cpp
@@ -69,6 +69,10 @@ bool AudioDriverControllerStub::isOpened() const
     return false;
 }
 
+void AudioDriverControllerStub::setLivePlaybackOngoing(bool)
+{
+}
+
 const IAudioDriver::Spec& AudioDriverControllerStub::activeSpec() const
 {
     static IAudioDriver::Spec spec;

--- a/framework/stubs/audio/audiodrivercontrollerstub.h
+++ b/framework/stubs/audio/audiodrivercontrollerstub.h
@@ -43,6 +43,8 @@ public:
     void close()  override;
     bool isOpened() const override;
 
+    void setLivePlaybackOngoing(bool ongoing) override;
+
     const IAudioDriver::Spec& activeSpec() const override;
     async::Channel<IAudioDriver::Spec> activeSpecChanged() const override;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34594

* By default, CoreAudio prevents the Mac from sleeping when the driver is opened. Opt out from this behaviour, except when playback is actually running.
    * Off-stream events (note input) don't count as live playback and thus don't prevent sleep; that's actually fine, because those are always the result of user input events, which prevent the system from sleeping anyway.
* Now that CoreAudio does not prevent sleep anymore, the system could go to sleep while (audio) export is ongoing, which is probably not desirable. Add an `IdleSleepBlocker` RAII utility that allows preventing that; that will be used by `AbstractAudioWriter` in the MuseScore repo in a future PR.

These changes were generated by Claude Code; I've checked that the macOS parts look plausible and indeed work (you can check in Activity Monitor > Energy, as shown in the issue description). Not sure about the Linux and Windows parts.