### PR TITLE
Fix CommandListDialog / fix CommandListModel QML registration

### DIFF
--- a/framework/rcommand/qml/Muse/RCommand/commandlistmodel.h
+++ b/framework/rcommand/qml/Muse/RCommand/commandlistmodel.h
@@ -21,6 +21,7 @@
 
 #include <QAbstractListModel>
 #include <QQmlParserStatus>
+#include <qqmlintegration.h>
 
 #include "global/async/asyncable.h"
 


### PR DESCRIPTION
The QML_ELEMENT macro is ignored when the `<qqmlintegration.h>` header is not included; that is reported by the following build warning:

```
[757/2232] Automatic MOC and UIC for target muse_rcommand_qml
AutoMoc: /home/runner/work/MuseScore/MuseScore/muse/framework/rcommand/qml/Muse/RCommand/commandlistmodel.h:39:1: warning: Potential QML registration macro was found, but no header containing it was included.
This might cause runtime errors in QML applications
Include <QtQmlIntegration/qqmlintegration.h> or <QtQml/qqmlregistration.h> to fix this.

```