### PR TITLE
Place overflowing menus to the left of the cursor

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/menuview.cpp
@@ -220,8 +220,8 @@ void MenuView::updateGeometry()
             setCascadeAlign(Qt::AlignmentFlag::AlignLeft);
             newPopupPos = PopupPosition::Right;
         } else {
-            // move to the left to an area that doesn't fit
-            movePos(m_globalPos.x() - (viewRect.right() - paddedAnchorRect.right()) + padding() * 2, m_globalPos.y());
+            // Place the menu to the left of the cursor instead of pinning it to the screen edge
+            movePos(parentTopLeft.x() - viewRect.width() + padding() * 2, m_globalPos.y());
         }
     }
 

--- a/framework/uicomponents/qml/Muse/UiComponents/menuview.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/menuview.h
@@ -26,6 +26,8 @@
 #include "popupview.h"
 
 namespace muse::uicomponents {
+class MenuViewTestAccess;
+
 class MenuView : public PopupView
 {
     Q_OBJECT
@@ -84,6 +86,8 @@ signals:
     void cascadeAlignChanged(Qt::AlignmentFlag cascadeAlign);
 
 private:
+    friend class MenuViewTestAccess;
+
     void componentComplete() override;
 
     void updateGeometry() override;

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_TEST muse_uicomponents_qml_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/doubleinputvalidator_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/intinputvalidator_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/menuview_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sectionproxymodel_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sortfilterproxymodel_tests.cpp
 
@@ -31,6 +32,7 @@ set(MODULE_TEST_SRC
 
 set(MODULE_TEST_LINK
     Qt::Qml
+    Qt::Quick
     muse_uicomponents_qml
     )
 

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/menuview_tests.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/menuview_tests.cpp
@@ -109,3 +109,35 @@ TEST(MenuViewTests, OverflowingTopLevelMenuOpensLeftOfCursor)
     EXPECT_DOUBLE_EQ(contentRight, cursorX);
     EXPECT_NE(contentRight, availableGeometry.right());
 }
+
+TEST(MenuViewTests, TopLevelMenuUsesScreenBoundaryInsteadOfParentWindow)
+{
+    QScreen* screen = QGuiApplication::primaryScreen();
+    ASSERT_NE(screen, nullptr);
+
+    const QRect availableGeometry = screen->availableGeometry();
+    ASSERT_GT(availableGeometry.width(), 400);
+
+    QQuickWindow parentWindow;
+    parentWindow.setGeometry(availableGeometry.x(), availableGeometry.y(), availableGeometry.width() / 2,
+                             availableGeometry.height());
+
+    QQuickItem anchor(parentWindow.contentItem());
+    anchor.setX(parentWindow.width() - 50);
+    anchor.setY(100);
+    anchor.setSize(QSizeF(1, 1));
+
+    QQuickItem content;
+    TestMenuView menu(&anchor);
+    menu.setMainWindowForTest(std::make_shared<MainWindowStub>());
+    menu.setContentItem(&content);
+    menu.setDesiredWidth(200);
+    menu.setDesiredHeight(100);
+
+    MenuViewTestAccess::updateGeometry(menu);
+
+    const qreal contentRight = menu.globalPosition().x() + menu.padding() + menu.desiredWidth();
+
+    EXPECT_GT(contentRight, parentWindow.geometry().right());
+    EXPECT_LE(contentRight, availableGeometry.right());
+}

--- a/framework/uicomponents/qml/Muse/UiComponents/tests/menuview_tests.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/tests/menuview_tests.cpp
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <QGuiApplication>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QScreen>
+
+#include "../menuview.h"
+
+using namespace muse::uicomponents;
+
+namespace muse::uicomponents {
+class MenuViewTestAccess
+{
+public:
+    static void updateGeometry(MenuView& view)
+    {
+        view.updateGeometry();
+    }
+};
+}
+
+namespace {
+class MainWindowStub final : public muse::ui::IMainWindow
+{
+public:
+    void init(muse::ui::MainWindowBridge*) override {}
+    void deinit() override {}
+
+    QWindow* qWindow() const override { return nullptr; }
+
+    void requestShowOnBack() override {}
+    void requestShowOnFront() override {}
+
+    bool isFullScreen() const override { return false; }
+    muse::async::Notification isFullScreenChanged() const override { return {}; }
+    void toggleFullScreen() override {}
+
+    QScreen* screen() const override { return QGuiApplication::primaryScreen(); }
+};
+
+class TestMenuView final : public MenuView
+{
+public:
+    using MenuView::MenuView;
+
+    QPointF globalPosition() const { return m_globalPos; }
+
+    void setMainWindowForTest(const std::shared_ptr<muse::ui::IMainWindow>& window)
+    {
+        mainWindow.set(window);
+    }
+};
+}
+
+TEST(MenuViewTests, OverflowingTopLevelMenuOpensLeftOfCursor)
+{
+    QScreen* screen = QGuiApplication::primaryScreen();
+    ASSERT_NE(screen, nullptr);
+
+    const QRect availableGeometry = screen->availableGeometry();
+    ASSERT_GT(availableGeometry.width(), 400);
+
+    QQuickWindow parentWindow;
+    parentWindow.setGeometry(availableGeometry);
+
+    QQuickItem anchor(parentWindow.contentItem());
+    anchor.setX(availableGeometry.width() - 100);
+    anchor.setY(100);
+    anchor.setSize(QSizeF(1, 1));
+
+    QQuickItem content;
+    TestMenuView menu(&anchor);
+    menu.setMainWindowForTest(std::make_shared<MainWindowStub>());
+    menu.setContentItem(&content);
+    menu.setDesiredWidth(200);
+    menu.setDesiredHeight(100);
+
+    MenuViewTestAccess::updateGeometry(menu);
+
+    const qreal cursorX = anchor.mapToGlobal(QPointF(0, 0)).x();
+    const qreal contentRight = menu.globalPosition().x() + menu.padding() + menu.desiredWidth();
+
+    EXPECT_LT(menu.globalPosition().x(), cursorX);
+    EXPECT_DOUBLE_EQ(contentRight, cursorX);
+    EXPECT_NE(contentRight, availableGeometry.right());
+}


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/33930

When a top-level context menu did not fit to the right of the cursor, `MenuView::updateGeometry()` only subtracted the screen overlap. This pinned the menu to the screen's right edge and detached it from the cursor.

Use the same left-of-anchor geometry already used for cascading menus. The menu's content now ends at the cursor position when it cannot fit on the right. Screen geometry remains the fit boundary, so the menu may still extend beyond the MuseScore window when the display has room.

Previous related work: musescore/MuseScore#33867 corrected the popup-position state in this branch and exposed the remaining horizontal clamp, but did not change the clamp itself.

Testing:
- `git diff --check` passes.
- The changed file passes the repository's pinned Uncrustify configuration.
- Configured the MuseScore consumer with Qt 6.10.2, MSVC 19.51, and Ninja on Windows.
- Built `muse_uicomponents_qml` and `muse_uicomponents_qml_tests` successfully.
- Ran `MenuViewTests.OverflowingTopLevelMenuOpensLeftOfCursor` with `QT_QPA_PLATFORM=offscreen`; it passed and directly exercised `MenuView::updateGeometry()`.
- Ran the complete offscreen UI-components suite: 21 tests from 6 suites passed.
- The full application sources compiled and `MuseScoreStudio5.exe` linked after a local Windows long-path/debug-symbol workaround. Behavioral verification remained headless, so the combined manual-runtime checklist item below remains unchecked.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [aribradshawaz](https://musescore.org/en/user/6674357):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [ ] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration

audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
