### PR TITLE
fontsengine added clearLoadedFaces api to clean cache

### DIFF
--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -130,13 +130,7 @@ double FontsEngine::RequireFace::pixelScaleFor(const IFontFace* loadedFace) cons
 
 FontsEngine::~FontsEngine()
 {
-    for (RequireFace* f : m_requiredFaces) {
-        delete f;
-    }
-
-    for (IFontFace* f : m_loadedFaces) {
-        delete f;
-    }
+    clearLoadedFaces();
 }
 
 void FontsEngine::init()
@@ -147,6 +141,19 @@ void FontsEngine::init()
 void FontsEngine::setRenderCacheDirPath(const io::path_t& path, const std::string& revision)
 {
     m_renderCache.setCacheDirPath(path, revision);
+}
+
+void FontsEngine::clearLoadedFaces()
+{
+    for (RequireFace* f : m_requiredFaces) {
+        delete f;
+    }
+    m_requiredFaces.clear();
+
+    for (IFontFace* f : m_loadedFaces) {
+        delete f;
+    }
+    m_loadedFaces.clear();
 }
 
 double FontsEngine::lineSpacing(const Font& f) const

--- a/framework/draw/internal/fontsengine.h
+++ b/framework/draw/internal/fontsengine.h
@@ -44,6 +44,7 @@ public:
 
     void init();
     void setRenderCacheDirPath(const io::path_t& path, const std::string& revision = std::string()) override;
+    void clearLoadedFaces() override;
 
     double lineSpacing(const Font& f) const override;
     double xHeight(const Font& f) const override;

--- a/framework/draw/internal/ifontsengine.h
+++ b/framework/draw/internal/ifontsengine.h
@@ -37,6 +37,7 @@ public:
     virtual ~IFontsEngine() = default;
 
     virtual void setRenderCacheDirPath(const io::path_t& path, const std::string& revision = std::string()) = 0;
+    virtual void clearLoadedFaces() = 0;
 
     virtual double lineSpacing(const Font& f) const = 0;
     virtual double xHeight(const Font& f) const = 0;


### PR DESCRIPTION
This PR is fixing this comment https://github.com/musescore/muse_framework/pull/230#discussion_r3801958522

> m_loadedFaces keeps one entry per unique (dataKey, type, pixelSize, isSymbolMode) for the process lifetime, and the lookup is a linear scan. fontMetricsPixelSize derives pixel size from pointSizeF * FONT_METRICS_DPI / PPI, so non-FTX fonts can produce many distinct pixel sizes during a session. Add a map-based index keyed by FaceKey plus symbol mode, and add an eviction or reuse policy if measurements show growth.