### PR TITLE
Load font faces from cached bytes instead of re-reading the file per pixel size

### DIFF
--- a/framework/draw/internal/fontfacedu.cpp
+++ b/framework/draw/internal/fontfacedu.cpp
@@ -53,9 +53,9 @@ FontFaceDU::~FontFaceDU()
     delete m_origin;
 }
 
-bool FontFaceDU::load(const FaceKey& key, const io::path_t& path, bool isSymbolMode)
+bool FontFaceDU::load(const FaceKey& key, const FontData& fontData, bool isSymbolMode)
 {
-    return m_origin->load(key, path, isSymbolMode);
+    return m_origin->load(key, fontData, isSymbolMode);
 }
 
 const FaceKey& FontFaceDU::key() const

--- a/framework/draw/internal/fontfacedu.h
+++ b/framework/draw/internal/fontfacedu.h
@@ -30,7 +30,7 @@ public:
     FontFaceDU(IFontFace* origin);
     ~FontFaceDU();
 
-    bool load(const FaceKey& key, const io::path_t& path, bool isSymbolMode) override;
+    bool load(const FaceKey& key, const FontData& fontData, bool isSymbolMode) override;
 
     const FaceKey& key() const override;
     bool isSymbolMode() const override;

--- a/framework/draw/internal/fontfaceft.cpp
+++ b/framework/draw/internal/fontfaceft.cpp
@@ -37,7 +37,6 @@
 #endif
 
 #include "global/types/bytearray.h"
-#include "global/io/file.h"
 
 #include "log.h"
 
@@ -276,7 +275,7 @@ FontFaceFT::~FontFaceFT()
     delete m_data;
 }
 
-bool FontFaceFT::load(const FaceKey& key, const io::path_t& path, bool isSymbolMode)
+bool FontFaceFT::load(const FaceKey& key, const FontData& fontData, bool isSymbolMode)
 {
     if (!_init_ft()) {
         return false;
@@ -285,14 +284,12 @@ bool FontFaceFT::load(const FaceKey& key, const io::path_t& path, bool isSymbolM
     m_key = key;
     m_isSymbolMode = isSymbolMode;
 
-    {
-        io::File file(path);
-        if (!file.open(io::IODevice::ReadOnly)) {
-            return false;
-        }
-
-        m_data->fontData = file.readAll();
+    if (!fontData.valid()) {
+        LOGE() << "empty font data: " << m_key.dataKey.family().id();
+        return false;
     }
+
+    m_data->fontData = fontData.data;
 
     int rval = FT_New_Memory_Face(ftlib, (FT_Byte*)m_data->fontData.constData(),
                                   (FT_Long)m_data->fontData.size(), 0, &m_data->face);

--- a/framework/draw/internal/fontfaceft.h
+++ b/framework/draw/internal/fontfaceft.h
@@ -34,7 +34,7 @@ public:
     FontFaceFT();
     ~FontFaceFT();
 
-    bool load(const FaceKey& key, const io::path_t& path, bool isSymbolMode) override;
+    bool load(const FaceKey& key, const FontData& fontData, bool isSymbolMode) override;
 
     const FaceKey& key() const override;
     bool isSymbolMode() const override;

--- a/framework/draw/internal/fontfacext.cpp
+++ b/framework/draw/internal/fontfacext.cpp
@@ -54,18 +54,20 @@ FontFaceXT::~FontFaceXT()
 {
 }
 
-bool FontFaceXT::load(const FaceKey& key, const muse::io::path_t& path, bool isSymbolMode)
+bool FontFaceXT::load(const FaceKey& key, const FontData& fontData, bool isSymbolMode)
 {
     m_key = key;
     m_isSymbolMode = isSymbolMode;
 
-    std::unique_ptr<muse::ZipReader> zip = std::make_unique<muse::ZipReader>(path);
-    if (!zip->exists()) {
-        LOGE() << "not exists: " << path;
+    if (!fontData.valid()) {
+        LOGE() << "empty font data: " << key.dataKey.family().id();
         return false;
     }
 
-    m_zip = std::move(zip);
+    m_fileBuffer = std::make_unique<muse::io::Buffer>(muse::ByteArray(fontData.data));
+    m_fileBuffer->open(muse::io::IODevice::ReadOnly);
+
+    m_zip = std::make_unique<muse::ZipReader>(m_fileBuffer.get());
 
     // meta
     {
@@ -110,7 +112,7 @@ bool FontFaceXT::load(const FaceKey& key, const muse::io::path_t& path, bool isS
             }
         }
 
-        LOGI() << "fxt version: " << ver << ", glyphs: " << glyphs << ", path: " << path;
+        LOGI() << "fxt version: " << ver << ", glyphs: " << glyphs << ", family: " << key.dataKey.family().id();
     }
 
     // ligatures

--- a/framework/draw/internal/fontfacext.h
+++ b/framework/draw/internal/fontfacext.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "global/io/iodevice.h"
+#include "global/io/buffer.h"
 
 #include "ifontface.h"
 
@@ -78,7 +79,7 @@ public:
         void read(muse::io::IODevice* d);
     };
 
-    bool load(const FaceKey& key, const muse::io::path_t& path, bool isSymbolMode) override;
+    bool load(const FaceKey& key, const FontData& fontData, bool isSymbolMode) override;
 
     const FaceKey& key() const override;
     bool isSymbolMode() const override;
@@ -113,6 +114,7 @@ private:
     FaceKey m_key;
     bool m_isSymbolMode = false;
 
+    std::unique_ptr<muse::io::Buffer> m_fileBuffer;
     std::unique_ptr<muse::ZipReader> m_zip;
     f26dot6_t m_leading = -1;
     f26dot6_t m_ascent = -1;

--- a/framework/draw/internal/fontsdatabase.cpp
+++ b/framework/draw/internal/fontsdatabase.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "global/io/file.h"
+#include "global/io/fileinfo.h"
 
 #include "log.h"
 
@@ -111,28 +112,27 @@ FontData FontsDatabase::fontData(const FontDataKey& requireKey, Font::Type type)
         return FontData();
     }
 
-    io::File file(path);
-    if (!file.open()) {
-        LOGE() << "failed open font file: " << path;
+    std::string pathStr = path.toStdString();
+    auto it = m_fileDataCache.find(pathStr);
+    if (it != m_fileDataCache.end()) {
+        return FontData { key, it->second };
+    }
+
+    ByteArray data;
+    if (!io::File::readFile(path, data)) {
+        LOGE() << "failed read font file: " << path;
         return FontData();
     }
 
-    FontData fd;
-    fd.key = key;
-    fd.data = file.readAll();
-    return fd;
+    m_fileDataCache.insert({ pathStr, data });
+    return FontData { key, data };
 }
 
-io::path_t FontsDatabase::fontPath(const FontDataKey& requireKey, Font::Type type) const
+bool FontsDatabase::isFtxFont(const FontDataKey& requireKey, Font::Type type) const
 {
     FontDataKey key = actualFont(requireKey, type);
     io::path_t path = fontInfo(key).path;
-    if (!io::File::exists(path)) {
-        LOGE() << "not exists font: " << path;
-        DO_ASSERT(io::File::exists(path));
-        return io::path_t();
-    }
-    return path;
+    return io::FileInfo::suffix(path).toLower() == u"ftx";
 }
 
 const FontsDatabase::FontInfo& FontsDatabase::fontInfo(const FontDataKey& key) const

--- a/framework/draw/internal/fontsdatabase.h
+++ b/framework/draw/internal/fontsdatabase.h
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <map>
+#include <unordered_map>
 
 #include "ifontsdatabase.h"
 
@@ -40,7 +41,7 @@ public:
     FontDataKey actualFont(const FontDataKey& requireKey, Font::Type type) const override;
     std::vector<FontDataKey> substitutionFonts(const FontDataKey& requireKey) const override;
     FontData fontData(const FontDataKey& requireKey, Font::Type type) const override;
-    io::path_t fontPath(const FontDataKey& requireKey, Font::Type type) const override;
+    bool isFtxFont(const FontDataKey& requireKey, Font::Type type) const override;
 
 private:
 
@@ -58,5 +59,6 @@ private:
     std::map<Font::Type, FontDataKey> m_defaults;
     std::map<FontDataKey, std::vector<FontDataKey> > m_familySubstitutions;
     std::vector<FontInfo> m_fonts;
+    mutable std::unordered_map<std::string, ByteArray> m_fileDataCache;
 };
 }

--- a/framework/draw/internal/fontsengine.cpp
+++ b/framework/draw/internal/fontsengine.cpp
@@ -21,8 +21,6 @@
  */
 #include "fontsengine.h"
 
-#include "global/io/fileinfo.h"
-
 #include "ifontface.h"
 #ifdef MUSE_MODULE_DRAW_USE_FONTFACE_FT
 #include "fontfaceft.h"
@@ -55,16 +53,6 @@ static int fontMetricsPixelSize(const Font& f)
 static FaceKey faceKeyForMetricsFont(const Font& f)
 {
     return FaceKey(dataKeyForFont(f), f.type(), fontMetricsPixelSize(f));
-}
-
-static int loadedPixelSizeForFontPath(const io::path_t& path, int requirePixelSize)
-{
-    // FTX fonts store glyph metrics and images baked at LOADED_PIXEL_SIZE.
-    if (io::FileInfo::suffix(path).toLower() == u"ftx") {
-        return static_cast<int>(LOADED_PIXEL_SIZE);
-    }
-
-    return requirePixelSize;
 }
 
 static inline RectF fromFBBox(const FBBox& bb, double scale)
@@ -502,25 +490,25 @@ void FontsEngine::setFontFaceFactory(const FontFaceFactory& f)
     m_fontFaceFactory = f;
 }
 
-IFontFace* FontsEngine::createFontFace(const io::path_t& path) const
+IFontFace* FontsEngine::createFontFace(const FontDataKey& dataKey, Font::Type type) const
 {
     if (m_fontFaceFactory) {
-        return m_fontFaceFactory(path);
+        return m_fontFaceFactory(dataKey, type);
     }
 
     IFontFace* origin = nullptr;
-    if (io::FileInfo::suffix(path).toLower() == u"ftx") {
+    if (fontsDatabase()->isFtxFont(dataKey, type)) {
 #ifdef MUSE_MODULE_DRAW_USE_FONTFACE_XT
         origin = new FontFaceXT();
 #else
-        LOGE() << "XT font face backend is disabled: " << path;
+        LOGE() << "XT font face backend is disabled: " << dataKey.family().id();
         return nullptr;
 #endif
     } else {
 #ifdef MUSE_MODULE_DRAW_USE_FONTFACE_FT
         origin = new FontFaceFT();
 #else
-        LOGE() << "FreeType font face backend is disabled: " << path;
+        LOGE() << "FreeType font face backend is disabled: " << dataKey.family().id();
         return nullptr;
 #endif
     }
@@ -528,35 +516,34 @@ IFontFace* FontsEngine::createFontFace(const io::path_t& path) const
     return new FontFaceDU(origin);
 }
 
-IFontFace* FontsEngine::fontFace(const FontDataKey& dataKey, Font::Type type, int pixelSize, bool isSymbolMode) const
+IFontFace* FontsEngine::fontFaceByActualDataKey(const FontDataKey& actualDataKey, Font::Type type, int loadedPixelSize,
+                                                bool isSymbolMode) const
 {
-    io::path_t fontPath = fontsDatabase()->fontPath(dataKey, type);
-    if (fontPath.empty()) {
-        LOGE() << "font path is empty: " << dataKey.family().id();
-        return nullptr;
-    }
-
-    const int loadedPixelSize = loadedPixelSizeForFontPath(fontPath, pixelSize);
-
     for (IFontFace* face : m_loadedFaces) {
-        if (face->key().dataKey == dataKey && face->key().type == type && face->key().pixelSize == loadedPixelSize
+        if (face->key().dataKey == actualDataKey && face->key().type == type && face->key().pixelSize == loadedPixelSize
             && face->isSymbolMode() == isSymbolMode) {
             return face;
         }
     }
 
+    FontData fontData = fontsDatabase()->fontData(actualDataKey, type);
+    if (!fontData.valid()) {
+        LOGE() << "font data is empty: " << actualDataKey.family().id();
+        return nullptr;
+    }
+
     FaceKey loadedKey;
-    loadedKey.dataKey = dataKey;
+    loadedKey.dataKey = fontData.key;
     loadedKey.type = type;
     loadedKey.pixelSize = loadedPixelSize;
 
-    IFontFace* face = createFontFace(fontPath);
+    IFontFace* face = createFontFace(fontData.key, type);
     IF_ASSERT_FAILED(face) {
         return nullptr;
     }
 
-    if (!face->load(loadedKey, fontPath, isSymbolMode)) {
-        LOGE() << "failed load font face: " << fontPath;
+    if (!face->load(loadedKey, fontData, isSymbolMode)) {
+        LOGE() << "failed load font face: " << fontData.key.family().id();
         delete face;
         return nullptr;
     }
@@ -571,7 +558,8 @@ IFontFace* FontsEngine::sdfFontFaceFor(const IFontFace* layoutFace) const
         return nullptr;
     }
 
-    return fontFace(layoutFace->key().dataKey, layoutFace->key().type, static_cast<int>(LOADED_PIXEL_SIZE), layoutFace->isSymbolMode());
+    return fontFaceByActualDataKey(layoutFace->key().dataKey, layoutFace->key().type, static_cast<int>(LOADED_PIXEL_SIZE),
+                                   layoutFace->isSymbolMode());
 }
 
 FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode) const
@@ -602,7 +590,9 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
     //! (for example, if there is no required one)
     FontDataKey actualDataKey = fontsDatabase()->actualFont(requireKey.dataKey, requireKey.type);
 
-    IFontFace* face = fontFace(actualDataKey, requireKey.type, requireKey.pixelSize, isSymbolMode);
+    const int loadedPixelSize = fontsDatabase()->isFtxFont(actualDataKey, requireKey.type) ? static_cast<int>(LOADED_PIXEL_SIZE)
+                                : requireKey.pixelSize;
+    IFontFace* face = fontFaceByActualDataKey(actualDataKey, requireKey.type, loadedPixelSize, isSymbolMode);
     if (!face) {
         return nullptr;
     }
@@ -610,11 +600,16 @@ FontsEngine::RequireFace* FontsEngine::fontFace(const Font& f, bool isSymbolMode
     //! If we didn't find it, we create a new require font
     RequireFace* newFont = new RequireFace();
     newFont->requireKey = requireKey;
+    newFont->actualDataKey = actualDataKey;
     newFont->face = face;
 
     auto subtitutionFontDataKeys = fontsDatabase()->substitutionFonts(requireKey.dataKey);
     for (const FontDataKey& dataKey : subtitutionFontDataKeys) {
-        IFontFace* subtitutionFace = fontFace(dataKey, requireKey.type, requireKey.pixelSize, isSymbolMode);
+        const FontDataKey actualSubtitutionDataKey = fontsDatabase()->actualFont(dataKey, requireKey.type);
+        const int subtitutionLoadedPixelSize = fontsDatabase()->isFtxFont(actualSubtitutionDataKey, requireKey.type)
+                                               ? static_cast<int>(LOADED_PIXEL_SIZE) : requireKey.pixelSize;
+        IFontFace* subtitutionFace = fontFaceByActualDataKey(actualSubtitutionDataKey, requireKey.type, subtitutionLoadedPixelSize,
+                                                             isSymbolMode);
         if (subtitutionFace) {
             newFont->subtitutionFaces.push_back(subtitutionFace);
         }

--- a/framework/draw/internal/fontsengine.h
+++ b/framework/draw/internal/fontsengine.h
@@ -66,7 +66,7 @@ public:
     std::vector<GlyphImage> render(const Font& f, const std::u32string& text) const override;
 
     // For dev
-    using FontFaceFactory = std::function<IFontFace* (const io::path_t&)>;
+    using FontFaceFactory = std::function<IFontFace* (const FontDataKey& dataKey, Font::Type type)>;
     void setFontFaceFactory(const FontFaceFactory& f);
 
 private:
@@ -85,15 +85,16 @@ private:
         IFontFace* face = nullptr;   // real loaded face
         std::vector<IFontFace*> subtitutionFaces;
         FaceKey requireKey;          // require face
+        FontDataKey actualDataKey;   // resolved face
 
         bool isSymbolMode() const;
         double pixelScale() const;
         double pixelScaleFor(const IFontFace* loadedFace) const;
     };
 
-    IFontFace* createFontFace(const io::path_t& path) const;
+    IFontFace* createFontFace(const FontDataKey& dataKey, Font::Type type) const;
     RequireFace* fontFace(const Font& f, bool isSymbolMode = false) const;
-    IFontFace* fontFace(const FontDataKey& dataKey, Font::Type type, int pixelSize, bool isSymbolMode) const;
+    IFontFace* fontFaceByActualDataKey(const FontDataKey& actualDataKey, Font::Type type, int loadedPixelSize, bool isSymbolMode) const;
     IFontFace* sdfFontFaceFor(const IFontFace* layoutFace) const;
 
     std::vector<FontFaceTextBlock> splitTextByFontFaces(const RequireFace* rf, const TextBlock& text) const;

--- a/framework/draw/internal/ifontface.h
+++ b/framework/draw/internal/ifontface.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "global/io/path.h"
+#include "global/types/bytearray.h"
 #include "types/fontstypes.h"
 
 namespace muse::draw {
@@ -43,7 +43,7 @@ public:
 
     virtual ~IFontFace() = default;
 
-    virtual bool load(const FaceKey& key, const io::path_t& path, bool isSymbolMode) = 0;
+    virtual bool load(const FaceKey& key, const FontData& fontData, bool isSymbolMode) = 0;
 
     virtual const FaceKey& key() const = 0;
     virtual bool isSymbolMode() const = 0;

--- a/framework/draw/internal/ifontsdatabase.h
+++ b/framework/draw/internal/ifontsdatabase.h
@@ -41,6 +41,6 @@ public:
     virtual FontDataKey actualFont(const FontDataKey& requireKey, Font::Type type) const = 0;
     virtual std::vector<FontDataKey> substitutionFonts(const FontDataKey& requireKey) const = 0;
     virtual FontData fontData(const FontDataKey& requireKey, Font::Type type) const = 0;
-    virtual io::path_t fontPath(const FontDataKey& requireKey, Font::Type type) const = 0;
+    virtual bool isFtxFont(const FontDataKey& requireKey, Font::Type type) const = 0;
 };
 }

--- a/framework/draw/tests/fontfacext_tests.cpp
+++ b/framework/draw/tests/fontfacext_tests.cpp
@@ -28,6 +28,8 @@
 
 #include "draw/internal/fontfaceft.h"
 #include "draw/internal/fontfacext.h"
+#include "global/io/file.h"
+#include "global/io/path.h"
 
 using namespace muse;
 using namespace muse::draw;
@@ -73,6 +75,14 @@ static io::path_t edwinXtPath()
 static FaceKey edwinFaceKey()
 {
     return FaceKey(FontDataKey(u"Edwin"), Font::Type::Text, TEST_PIXEL_SIZE);
+}
+
+static ByteArray readFontData(const io::path_t& path)
+{
+    ByteArray data;
+    EXPECT_TRUE(io::File::readFile(path, data)) << path.toStdString();
+    EXPECT_FALSE(data.empty()) << path.toStdString();
+    return data;
 }
 
 static bool valueIsNear(f26dot6_t v1, f26dot6_t v2, f26dot6_t epsilon)
@@ -157,8 +167,8 @@ static std::unique_ptr<FontFaces> loadEdwinFaces()
     std::unique_ptr<FontFaces> faces = std::make_unique<FontFaces>();
     const FaceKey key = edwinFaceKey();
 
-    EXPECT_TRUE(faces->ft.load(key, edwinFtPath(), false));
-    EXPECT_TRUE(faces->xt.load(key, edwinXtPath(), false));
+    EXPECT_TRUE(faces->ft.load(key, FontData { key.dataKey, readFontData(edwinFtPath()) }, false));
+    EXPECT_TRUE(faces->xt.load(key, FontData { key.dataKey, readFontData(edwinXtPath()) }, false));
 
     return faces;
 }


### PR DESCRIPTION
FontsEngine is not used in Musescore, so I tested in standalone application.
After last PR https://github.com/musescore/muse_framework/pull/231 profiling showed clearLoadedFaces() taking ~20% of total score-open time. 
FontsEngine's face cache is keyed by (family, type, pixelSize, isSymbolMode), so every distinct pixel size used in a document creates a brand-new IFontFace, which re-opens and re-reads the same font file from disk again. FT_New_Memory_Face itself is fast; the actual cost is (a) the repeated disk reads and (b) destroying all those per-pixel-size ByteArray buffers later in clearLoadedFaces().

So FontsDatabase now caches the font file's bytes once per path (fontData()), and IFontFace::load() takes those bytes directly instead of a path, so a new pixel size no longer triggers a new disk read.

The reading of font file was changing from code
```
io::File file(path);
if (!file.open(io::IODevice::ReadOnly)) {
  return false;
}
m_data->fontData = file.readAll();
```
to
```
ByteArray data;
io::File::readFile(path, data)
```
because sequence of `file.open` `file.readAll()` malloc memory twice. For 5mb otf file it is a problem.