### PR TITLE
Ignore SetupBuildEnvironment.user.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ compile_commands.json
 
 # QML language server
 **/.qmlls.ini
+
+# User overrides of SetupBuildEnvironment
+/buildscripts/cmake/SetupBuildEnvironment.user.cmake
+


### PR DESCRIPTION
At the very end `SetupBuildEnvironment.cmake` includes `SetupBuildEnvironment.user.cmake` (if exists). This file can be used by users to customize their build environment as they like. We had it ignored when there were no submodules, let's ignore it again now that the build scripts are part of the `muse_framework`.

- [X] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [X] The title of the PR describes the problem it addresses.
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [X] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [X] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [X] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [X] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
