### PR TITLE
Fix crash caused by deleting dialog inside its own finished handler

### DIFF
--- a/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
+++ b/framework/dockwindow/qml/Muse/Dock/dockwindow.cpp
@@ -574,10 +574,6 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
 
     loadPageContent(newPage);
     restorePageState(newPage);
-
-    // Calls such as clearRegistry lead to deferred deletes of docks. Ensure these
-    // have been fully processed before attempting to re-init (see issue #31997)
-    qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete);
     initDocks(newPage);
 
     newPage->setParams(params);

--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -43,6 +43,7 @@
 
 #include "muse_framework_config.h"
 
+#include "defer.h"
 #include "log.h"
 
 using namespace muse;
@@ -359,7 +360,10 @@ async::Promise<io::path_t> Interactive::selectOpeningFile(const std::string& tit
         dlg->setFileMode(QFileDialog::ExistingFile);
 
         QObject::connect(dlg, &QFileDialog::finished, [dlg, resolve, reject](int result) {
-            dlg->deleteLater();
+            DEFER {
+                //! Must be called AFTER resolve/reject, as they may process posted events
+                dlg->deleteLater();
+            };
 
             QStringList files = dlg->selectedFiles();
 
@@ -549,7 +553,10 @@ async::Promise<Color> Interactive::selectColor(const Color& color, const std::st
         dlg->setOption(QColorDialog::ShowAlphaChannel, allowAlpha);
 
         QObject::connect(dlg, &QColorDialog::finished, [this, dlg, resolve, reject](int result) {
-            dlg->deleteLater();
+            DEFER {
+                //! Must be called AFTER resolve/reject, as they may process posted events
+                dlg->deleteLater();
+            };
 
             uiConfiguration()->setColorDialogCustomColors(getCustomColors());
 


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/33951

+ additional protection in Interactive
+ dock v2 doesn't require the same revert (never had the sendPostedEvents fix)