### PR TITLE
added rcommand params

### DIFF
--- a/framework/audio/main/internal/transporteventscontroller.cpp
+++ b/framework/audio/main/internal/transporteventscontroller.cpp
@@ -69,7 +69,7 @@ void TransportEventsController::onEventReceived(const TransportEvent& event)
     case TransportEvent::Type::Seek:
         if (std::holds_alternative<TransportEvent::SeekData>(event.data)) {
             const secs_t pos = std::get<TransportEvent::SeekData>(event.data).position;
-            commandDispatcher()->dispatch(rcommand::make_query("command://playback/rewind", { { "position", Val(pos) } }));
+            commandDispatcher()->dispatch(rcommand::Command("command://playback/rewind"), { { "position", Val(pos) } });
         }
         break;
     case TransportEvent::Type::Unknown:

--- a/framework/diagnostics/diagnosticscommands.h
+++ b/framework/diagnostics/diagnosticscommands.h
@@ -37,7 +37,4 @@ inline static const muse::rcommand::Command DIAGNOSTICS_SHOW_ENGRAVING_UNDOSTACK
 inline static const muse::rcommand::Command DIAGNOSTICS_SHOW_ENGRAVING_STYLE_COMMAND("command://diagnostics/show-engraving-style");
 inline static const muse::rcommand::Command DIAGNOSTICS_SHOW_ACTIONS_COMMAND("command://diagnostics/show-actions");
 inline static const muse::rcommand::Command DIAGNOSTICS_SHOW_RCOMMANDS_COMMAND("command://diagnostics/show-rcommands");
-inline static const muse::rcommand::Command DIAGNOSTICS_ACTIONS_QUERY_COMMAND("command://diagnostics/actions/query");
-inline static const muse::rcommand::Command DIAGNOSTICS_ACTIONS_QUERY_PARAMS1_COMMAND("command://diagnostics/actions/query-params1");
-inline static const muse::rcommand::Command DIAGNOSTICS_ACTIONS_QUERY_PARAMS2_COMMAND("command://diagnostics/actions/query-params2");
 }

--- a/framework/diagnostics/internal/diagnosticsactionscontroller.cpp
+++ b/framework/diagnostics/internal/diagnosticsactionscontroller.cpp
@@ -25,6 +25,7 @@
 
 #include "../diagnosticscommands.h"
 
+#include "rcommand/commandtypes.h"
 #include "types/uri.h"
 
 #include "qml/Muse/Diagnostics/diagnosticaccessiblemodel.h"
@@ -70,9 +71,6 @@ void DiagnosticsActionsController::init()
     });
     cd->onRequest(this, DIAGNOSTICS_SHOW_ACTIONS_COMMAND, [this]() { openUri(ACTIONS_LIST_URI); return muse::make_ok(); });
     cd->onRequest(this, DIAGNOSTICS_SHOW_RCOMMANDS_COMMAND, [this]() { openUri(RCOMMAND_LIST_URI); return muse::make_ok(); });
-    cd->onRequest(this, DIAGNOSTICS_ACTIONS_QUERY_COMMAND, [this](const CommandQuery& q) { return onCommandQuery(q); });
-    cd->onRequest(this, DIAGNOSTICS_ACTIONS_QUERY_PARAMS1_COMMAND, [this](const CommandQuery& q) { return onCommandQuery(q); });
-    cd->onRequest(this, DIAGNOSTICS_ACTIONS_QUERY_PARAMS2_COMMAND, [this](const CommandQuery& q) { return onCommandQuery(q); });
 
     // compat
     {
@@ -92,20 +90,6 @@ void DiagnosticsActionsController::init()
         };
 
         rcommand::registerActionToCommand(this, actionToCommands, commandDispatcher(), dispatcher());
-
-        static const std::vector<std::pair<actions::ActionQuery, Command> > actionQueryToCommands = {
-            { actions::ActionQuery("action://diagnostic/actions/query"), DIAGNOSTICS_ACTIONS_QUERY_COMMAND },
-            { actions::ActionQuery("action://diagnostic/actions/query_params1"), DIAGNOSTICS_ACTIONS_QUERY_PARAMS1_COMMAND },
-            { actions::ActionQuery("action://diagnostic/actions/query_params2"), DIAGNOSTICS_ACTIONS_QUERY_PARAMS2_COMMAND },
-        };
-
-        for (const auto& [actionQuery, command] : actionQueryToCommands) {
-            dispatcher()->reg(this, actionQuery, [this, command](const actions::ActionQuery& aquery) {
-                CommandQuery query(command);
-                query.setParams(aquery.params());
-                commandDispatcher()->dispatch(query);
-            });
-        }
     }
 }
 
@@ -124,10 +108,4 @@ void DiagnosticsActionsController::saveDiagnosticFiles()
     if (!ret) {
         LOGE() << ret.toString();
     }
-}
-
-muse::Ret DiagnosticsActionsController::onCommandQuery(const muse::rcommand::CommandQuery& query)
-{
-    interactive()->info("Test query action", query.toString());
-    return muse::make_ok();
 }

--- a/framework/diagnostics/internal/diagnosticsactionscontroller.h
+++ b/framework/diagnostics/internal/diagnosticsactionscontroller.h
@@ -46,7 +46,5 @@ public:
 private:
     void openUri(const muse::UriQuery& uri, bool isSingle = true);
     void saveDiagnosticFiles();
-
-    muse::Ret onCommandQuery(const muse::rcommand::CommandQuery& query);
 };
 }

--- a/framework/diagnostics/internal/diagnosticscommandsregister.cpp
+++ b/framework/diagnostics/internal/diagnosticscommandsregister.cpp
@@ -113,31 +113,6 @@ static const std::vector<CommandInfo> s_commandInfos = {
         InputSchema(),
         Decoration()
     },
-    CommandInfo{
-        DIAGNOSTICS_ACTIONS_QUERY_COMMAND,
-        TranslatableString("diagnostics", "Test query action"),
-        TranslatableString("diagnostics", "Test query action"),
-        InputSchema(),
-        Decoration()
-    },
-    CommandInfo{
-        DIAGNOSTICS_ACTIONS_QUERY_PARAMS1_COMMAND,
-        TranslatableString("diagnostics", "Test query action with params 1"),
-        TranslatableString("diagnostics", "Test query action with params 1"),
-        InputSchema({
-            { "param1", Arg(DataType::String, u"Test parameter 1 (optional)") }
-        }),
-        Decoration()
-    },
-    CommandInfo{
-        DIAGNOSTICS_ACTIONS_QUERY_PARAMS2_COMMAND,
-        TranslatableString("diagnostics", "Test query action with params 2"),
-        TranslatableString("diagnostics", "Test query action with params 2"),
-        InputSchema({
-            { "param1", Arg(DataType::String, u"Test parameter 1 (optional)") }
-        }),
-        Decoration()
-    },
 };
 
 std::string DiagnosticsCommandsRegister::moduleName() const

--- a/framework/dockwindow/internal/dockwindowactionscontroller.cpp
+++ b/framework/dockwindow/internal/dockwindowactionscontroller.cpp
@@ -26,6 +26,7 @@
 
 #include "../idockwindow.h"
 #include "../dockcommands.h"
+#include "rcommand/commandtypes.h"
 
 using namespace muse;
 using namespace muse::dock;
@@ -56,9 +57,9 @@ static CommandQuery toggleConv(const Command& command, const ActionData& args)
 void DockWindowActionsController::init()
 {
     auto cd = commandsDispatcher();
-    cd->onRequest(this, DOCK_SET_OPEN_COMMAND, [this](const CommandQuery& query) { return setDockOpen(query); });
-    cd->onRequest(this, DOCK_TOGGLE_COMMAND, [this](const CommandQuery& query) { return toggleOpened(query); });
-    cd->onRequest(this, DOCK_TOGGLE_FLOATING_COMMAND, [this](const CommandQuery& query) { return toggleFloating(query); });
+    cd->onRequest(this, DOCK_SET_OPEN_COMMAND, [this](const rcommand::Params& params) { return setDockOpen(params); });
+    cd->onRequest(this, DOCK_TOGGLE_COMMAND, [this](const rcommand::Params& params) { return toggleOpened(params); });
+    cd->onRequest(this, DOCK_TOGGLE_FLOATING_COMMAND, [this](const rcommand::Params& params) { return toggleFloating(params); });
     cd->onRequest(this, DOCK_RESTORE_DEFAULT_LAYOUT_COMMAND, [this]() { return restoreDefaultLayout(); });
 
     // compat
@@ -74,37 +75,35 @@ void DockWindowActionsController::init()
     }
 }
 
-muse::Ret DockWindowActionsController::setDockOpen(const CommandQuery& query)
+muse::Ret DockWindowActionsController::setDockOpen(const rcommand::Params& params)
 {
-    if (!(query.contains("dock_name") && query.contains("open"))) {
+    if (!(params.contains("dock_name") && params.contains("open"))) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
-
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
-    bool open = query.param("open").toBool();
-
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
+    bool open = params.at("open").toBool();
     window()->setDockOpen(dockName, open);
     return muse::make_ok();
 }
 
-muse::Ret DockWindowActionsController::toggleOpened(const CommandQuery& query)
+muse::Ret DockWindowActionsController::toggleOpened(const rcommand::Params& params)
 {
-    if (!query.contains("dock_name")) {
+    if (!params.contains("dock_name")) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
 
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
     window()->toggleDock(dockName);
     return muse::make_ok();
 }
 
-muse::Ret DockWindowActionsController::toggleFloating(const CommandQuery& query)
+muse::Ret DockWindowActionsController::toggleFloating(const rcommand::Params& params)
 {
-    if (!query.contains("dock_name")) {
+    if (!params.contains("dock_name")) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
 
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
     window()->toggleDockFloating(dockName);
     return muse::make_ok();
 }

--- a/framework/dockwindow/internal/dockwindowactionscontroller.h
+++ b/framework/dockwindow/internal/dockwindowactionscontroller.h
@@ -46,9 +46,9 @@ public:
     void init();
 
 private:
-    muse::Ret setDockOpen(const rcommand::CommandQuery& query);
-    muse::Ret toggleOpened(const rcommand::CommandQuery& query);
-    muse::Ret toggleFloating(const rcommand::CommandQuery& query);
+    muse::Ret setDockOpen(const rcommand::Params& params);
+    muse::Ret toggleOpened(const rcommand::Params& params);
+    muse::Ret toggleFloating(const rcommand::Params& params);
 
     muse::Ret restoreDefaultLayout();
 

--- a/framework/dockwindow_v2/internal/dockwindowactionscontroller.cpp
+++ b/framework/dockwindow_v2/internal/dockwindowactionscontroller.cpp
@@ -56,9 +56,9 @@ static CommandQuery toggleConv(const Command& command, const ActionData& args)
 void DockWindowActionsController::init()
 {
     auto cd = commandsDispatcher();
-    cd->onRequest(this, DOCK_SET_OPEN_COMMAND, [this](const CommandQuery& query) { return setDockOpen(query); });
-    cd->onRequest(this, DOCK_TOGGLE_COMMAND, [this](const CommandQuery& query) { return toggleOpened(query); });
-    cd->onRequest(this, DOCK_TOGGLE_FLOATING_COMMAND, [this](const CommandQuery& query) { return toggleFloating(query); });
+    cd->onRequest(this, DOCK_SET_OPEN_COMMAND, [this](const rcommand::Params& params) { return setDockOpen(params); });
+    cd->onRequest(this, DOCK_TOGGLE_COMMAND, [this](const rcommand::Params& params) { return toggleOpened(params); });
+    cd->onRequest(this, DOCK_TOGGLE_FLOATING_COMMAND, [this](const rcommand::Params& params) { return toggleFloating(params); });
     cd->onRequest(this, DOCK_RESTORE_DEFAULT_LAYOUT_COMMAND, [this]() { return restoreDefaultLayout(); });
 
     // compat
@@ -74,37 +74,37 @@ void DockWindowActionsController::init()
     }
 }
 
-muse::Ret DockWindowActionsController::setDockOpen(const CommandQuery& query)
+muse::Ret DockWindowActionsController::setDockOpen(const rcommand::Params& params)
 {
-    if (!(query.contains("dock_name") && query.contains("open"))) {
+    if (!(params.contains("dock_name") && params.contains("open"))) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
 
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
-    bool open = query.param("open").toBool();
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
+    bool open = params.at("open").toBool();
 
     window()->setDockOpen(dockName, open);
     return muse::make_ok();
 }
 
-muse::Ret DockWindowActionsController::toggleOpened(const CommandQuery& query)
+muse::Ret DockWindowActionsController::toggleOpened(const rcommand::Params& params)
 {
-    if (!query.contains("dock_name")) {
+    if (!params.contains("dock_name")) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
 
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
     window()->toggleDock(dockName);
     return muse::make_ok();
 }
 
-muse::Ret DockWindowActionsController::toggleFloating(const CommandQuery& query)
+muse::Ret DockWindowActionsController::toggleFloating(const rcommand::Params& params)
 {
-    if (!query.contains("dock_name")) {
+    if (!params.contains("dock_name")) {
         return muse::make_ret(Ret::Code::BadArgs);
     }
 
-    QString dockName = QString::fromStdString(query.param("dock_name").toString());
+    QString dockName = QString::fromStdString(params.at("dock_name").toString());
     window()->toggleDockFloating(dockName);
     return muse::make_ok();
 }

--- a/framework/dockwindow_v2/internal/dockwindowactionscontroller.h
+++ b/framework/dockwindow_v2/internal/dockwindowactionscontroller.h
@@ -46,9 +46,9 @@ public:
     void init();
 
 private:
-    muse::Ret setDockOpen(const rcommand::CommandQuery& query);
-    muse::Ret toggleOpened(const rcommand::CommandQuery& query);
-    muse::Ret toggleFloating(const rcommand::CommandQuery& query);
+    muse::Ret setDockOpen(const rcommand::Params& params);
+    muse::Ret toggleOpened(const rcommand::Params& params);
+    muse::Ret toggleFloating(const rcommand::Params& params);
 
     muse::Ret restoreDefaultLayout();
 

--- a/framework/midiremote/internal/midiremote.cpp
+++ b/framework/midiremote/internal/midiremote.cpp
@@ -304,7 +304,7 @@ void MidiRemote::processMMC(const MMCMessage& msg)
     case MMCCommand::Locate: {
         const std::optional<double> pos = m_mmcDecoder->locateToSeconds(msg);
         if (pos.has_value()) {
-            commandDispatcher()->dispatch(rcommand::make_query("command://playback/rewind", { { "position", Val(pos.value()) } }));
+            commandDispatcher()->dispatch(rcommand::Command("command://playback/rewind"), { { "position", Val(pos.value()) } });
         }
     } break;
     default: break;

--- a/framework/rcommand/commandtypes.h
+++ b/framework/rcommand/commandtypes.h
@@ -37,16 +37,31 @@ constexpr std::string_view COMMAND_SCHEME = "command";
 using Command = Uri;
 using CommandQuery = UriQuery;
 
-inline CommandQuery make_query(const Command& command, const std::vector<std::pair<std::string, Val> >& params)
+struct Params : public std::map<std::string, Val>
+{
+    Params() = default;
+    Params(const std::map<std::string, Val>& params)
+        : std::map<std::string, Val>(params) {}
+
+    Params(std::initializer_list<value_type> params)
+        : std::map<std::string, Val>(params) {}
+
+    // hides the std::map implementation of at()
+    Val at(const std::string& key, const Val& def = Val()) const
+    {
+        auto it = find(key);
+        return it != end() ? it->second : def;
+    }
+};
+
+inline CommandQuery make_query(const Command& command, const Params& params)
 {
     CommandQuery query(command);
-    for (const auto& param : params) {
-        query.addParam(param.first, param.second);
-    }
+    query.setParams(params);
     return query;
 }
 
-inline CommandQuery make_query(const std::string& command, const std::vector<std::pair<std::string, Val> >& params)
+inline CommandQuery make_query(const std::string& command, const Params& params)
 {
     return make_query(Command(command), params);
 }
@@ -145,7 +160,8 @@ using CallId = uint64_t;
 struct Request
 {
     CallId callId = 0;
-    CommandQuery query;
+    Command command;
+    Params params;
 };
 
 struct Response
@@ -168,11 +184,12 @@ inline CallId new_call_id()
     return lastId;
 }
 
-inline Request make_request(const CommandQuery& query)
+inline Request make_request(const Command& command, const Params& params)
 {
     Request request;
     request.callId = new_call_id();
-    request.query = query;
+    request.command = command;
+    request.params = params;
     return request;
 }
 

--- a/framework/rcommand/icommanddispatcher.h
+++ b/framework/rcommand/icommanddispatcher.h
@@ -36,22 +36,26 @@ public:
 
     using CallBack = std::function<Response (const Request& request)>;
     using CallBackRet = std::function<Ret ()>;
-    using CallBackQueryRet = std::function<Ret (const CommandQuery& query)>;
+    using CallBackParamsRet = std::function<Ret (const Params& params)>;
 
     virtual async::Promise<Response> dispatch(const Request& request) = 0;
     virtual void onRequest(Commandable* client, const Command& command, const CallBack& callback) = 0;
     virtual void unreg(Commandable* client) = 0;
 
     // Helpers for convenience
+    async::Promise<Response> dispatch(const Command& command)
+    {
+        return dispatch(make_request(command, {}));
+    }
+
+    async::Promise<Response> dispatch(const Command& command, const Params& params)
+    {
+        return dispatch(make_request(command, params));
+    }
 
     async::Promise<Response> dispatch(const CommandQuery& query)
     {
-        return dispatch(make_request(query));
-    }
-
-    async::Promise<Response> dispatch(const Command& query)
-    {
-        return dispatch(CommandQuery(query));
+        return dispatch(make_request(query.uri(), query.params()));
     }
 
     void onRequest(Commandable* client, const Command& command, const CallBackRet& callback)
@@ -61,10 +65,10 @@ public:
         });
     }
 
-    void onRequest(Commandable* client, const Command& command, const CallBackQueryRet& callback)
+    void onRequest(Commandable* client, const Command& command, const CallBackParamsRet& callback)
     {
         onRequest(client, command, [callback](const Request& request) {
-            return make_response(request, callback(request.query));
+            return make_response(request, callback(request.params));
         });
     }
 };

--- a/framework/rcommand/internal/commanddispatcher.cpp
+++ b/framework/rcommand/internal/commanddispatcher.cpp
@@ -43,34 +43,34 @@ CommandDispatcher::~CommandDispatcher()
 async::Promise<Response> CommandDispatcher::dispatch(const Request& request)
 {
     return async::make_promise<Response>([this, request](auto resolve) {
-        auto it = m_clients.find(Command(request.query.uri()));
+        auto it = m_clients.find(request.command);
         if (it != m_clients.end()) {
-            LOGI() << "try call command query: " << request.query.toString();
+            LOGI() << "try call command: " << request.command;
             Response response = it->second.callback(request);
             return resolve(response);
         } else {
-            LOGW() << "command not registered: " << request.query.toString();
+            LOGW() << "command not registered: " << request.command;
             return resolve(make_response(request, make_ret(Ret::Code::UnknownError)));
         }
     });
 }
 
-Response CommandDispatcher::dispatch(const Command& command)
+Response CommandDispatcher::dispatch(const Command& command, const Params& params)
 {
-    return dispatch(CommandQuery(command));
-}
-
-Response CommandDispatcher::dispatch(const CommandQuery& query)
-{
-    Request request = make_request(query);
-    auto it = m_clients.find(Command(query.uri()));
+    Request request = make_request(command, params);
+    auto it = m_clients.find(command);
     if (it != m_clients.end()) {
-        LOGI() << "try call command query: " << query.toString();
-        Response response = it->second.callback(make_request(query));
+        LOGI() << "try call command: " << command;
+        Response response = it->second.callback(request);
         return response;
     } else {
         return make_response(request, make_ret(Ret::Code::UnknownError));
     }
+}
+
+Response CommandDispatcher::dispatch(const CommandQuery& query)
+{
+    return dispatch(query.uri(), query.params());
 }
 
 void CommandDispatcher::onRequest(Commandable* client, const Command& command, const CallBack& callback)

--- a/framework/rcommand/internal/commanddispatcher.h
+++ b/framework/rcommand/internal/commanddispatcher.h
@@ -32,7 +32,7 @@ public:
     void unreg(Commandable* client) override;
 
     // for utests
-    Response dispatch(const Command& command);
+    Response dispatch(const Command& command, const Params& params = {});
     Response dispatch(const CommandQuery& query);
 
 private:

--- a/framework/workspace/internal/workspaceactioncontroller.cpp
+++ b/framework/workspace/internal/workspaceactioncontroller.cpp
@@ -33,7 +33,9 @@ using namespace muse::rcommand;
 
 void WorkspaceActionController::init()
 {
-    commandDispatcher()->onRequest(this, WORKSPACE_SELECT_COMMAND, [this](const CommandQuery& query) { return selectWorkspace(query); });
+    commandDispatcher()->onRequest(this, WORKSPACE_SELECT_COMMAND, [this](const rcommand::Params& params) {
+        return selectWorkspace(params);
+    });
     commandDispatcher()->onRequest(this, WORKSPACES_CONFIGURE_COMMAND, [this]() { openWorkspacesConfigure(); return muse::make_ok(); });
     commandDispatcher()->onRequest(this, WORKSPACE_CREATE_COMMAND, [this]() { createNewWorkspace(); return muse::make_ok(); });
 
@@ -49,9 +51,9 @@ void WorkspaceActionController::init()
     }
 }
 
-muse::Ret WorkspaceActionController::selectWorkspace(const muse::rcommand::CommandQuery& query)
+muse::Ret WorkspaceActionController::selectWorkspace(const muse::rcommand::Params& params)
 {
-    std::string selectedWorkspace = query.param("name").toString();
+    std::string selectedWorkspace = params.at("name").toString();
     manager()->changeCurrentWorkspace(selectedWorkspace);
     return muse::make_ok();
 }

--- a/framework/workspace/internal/workspaceactioncontroller.h
+++ b/framework/workspace/internal/workspaceactioncontroller.h
@@ -48,7 +48,7 @@ public:
     void init();
 
 private:
-    muse::Ret selectWorkspace(const muse::rcommand::CommandQuery& query);
+    muse::Ret selectWorkspace(const muse::rcommand::Params& params);
     void openWorkspacesConfigure();
     void createNewWorkspace();
 };


### PR DESCRIPTION
Previously, the dispatcher was essentially a query-first approach, now it's command+params
see also: https://github.com/musescore/muse_framework/blob/main/docs/adr/00104-Command-first.md 