### PR TITLE
Don't restore stale navigation control when a dialog closes

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/windowview.cpp
@@ -59,6 +59,8 @@ void WindowView::init()
     });
 
     navigationController()->navigationChanged().onNotify(this, [this]() {
+        updateNavigationParentControl();
+
         if (!(m_focusPolicies & FocusPolicy::TabFocus)) {
             return;
         }
@@ -528,23 +530,44 @@ void WindowView::setNavigationParentControl(ui::INavigationControl* navigationPa
         return;
     }
 
+    QObject* oldCtrl = dynamic_cast<QObject*>(m_navigationParentControl);
+
+    if (oldCtrl) {
+        disconnect(oldCtrl, &QObject::destroyed, this, nullptr);
+    }
+
     m_navigationParentControl = navigationParentControl;
+
+    //! NOTE At the moment we have only qml navigation controls
+    QObject* qmlCtrl = dynamic_cast<QObject*>(navigationParentControl);
+
+    if (qmlCtrl) {
+        connect(qmlCtrl, &QObject::destroyed, this, [this]() {
+            m_navigationParentControl = nullptr;
+            emit navigationParentControlChanged(nullptr);
+        });
+    }
+
     emit navigationParentControlChanged(m_navigationParentControl);
 }
 
 void WindowView::resolveNavigationParentControl()
 {
-    ui::INavigationControl* ctrl = navigationController()->activeControl();
-    setNavigationParentControl(ctrl);
+    setNavigationParentControl(navigationController()->activeControl());
+}
 
-    //! NOTE At the moment we have only qml navigation controls
-    QObject* qmlCtrl = dynamic_cast<QObject*>(ctrl);
-
-    if (qmlCtrl) {
-        connect(qmlCtrl, &QObject::destroyed, this, [this]() {
-            setNavigationParentControl(nullptr);
-        });
+void WindowView::updateNavigationParentControl()
+{
+    if (!isOpened() || !m_parentWindow) {
+        return;
     }
+
+    ui::INavigationControl* activeControl = navigationController()->activeControl();
+    if (!activeControl || activeControl->window() != m_parentWindow) {
+        return;
+    }
+
+    setNavigationParentControl(activeControl);
 }
 
 void WindowView::activateNavigationParentControl()

--- a/framework/uicomponents/qml/Muse/UiComponents/windowview.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/windowview.h
@@ -194,6 +194,7 @@ protected:
     void updateSize(const QSize& newSize);
 
     void resolveNavigationParentControl();
+    void updateNavigationParentControl();
     void activateNavigationParentControl();
 
     QQmlEngine* m_engine = nullptr;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11659

ProgressBar saves the active navigation control on open and re-activates it on close. If focus in the parent window changed while the dialog is opened (eg a track created), the close restores the incorrect control.

We need to update which control should be activated on close.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
