### PR TITLE
Let the application own the MUSE_COMPILE_USE_PCH option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,14 @@ set(MUSE_APP_BUILD_MODE "dev" CACHE STRING "Build mode")
 # - testing - for testing versions (alpha, beta, RC)
 # - release - for stable release builds
 
+# Consumer applications own these options and must declare them on their side.
+# The standalone framework build is the application here, and deliberately
+# builds with PCH and unity OFF: every source stays self-contained (see #256),
+# so CI catches missing includes and Qt module links that PCH or unity batches
+# would mask.
+option(MUSE_COMPILE_USE_PCH "Use precompiled headers." OFF)
+option(MUSE_COMPILE_USE_UNITY "Use unity build." OFF)
+
 include(${MUSE_FRAMEWORK_SRC_PATH}/cmake/MuseDeclareOptions.cmake)
 
 ###########################################

--- a/framework/cmake/MuseDeclareOptions.cmake
+++ b/framework/cmake/MuseDeclareOptions.cmake
@@ -7,7 +7,6 @@ option(MUSE_CONFIGURATION_IS_WEB "Configuration is web" OFF)
 
 # === Build options ===
 option(MUSE_COMPILE_ASAN "Enable Address Sanitizer" OFF)
-option(MUSE_COMPILE_USE_PCH "Use precompiled headers." ON)
 
 # === Debug options ===
 option(MUSE_COMPILE_STRING_DEBUG_HACK "Enable string debug hack (only clang)" ON)


### PR DESCRIPTION
Resolves: audacity/audacity#11898

Removes the `MUSE_COMPILE_USE_PCH` declaration from `MuseDeclareOptions.cmake` so the application owns the option, matching how `MUSE_COMPILE_USE_UNITY` already works (declared app-side, consumed by `DeclareModuleSetup.cmake` / `MuseCreateModule.cmake`).

Motivation: with the framework declaring it, an application wanting visibility/control of the default has to rely on `option()` first-declaration-wins ordering (see review discussion in audacity/audacity#11795).

The standalone build declares both `MUSE_COMPILE_USE_PCH` and `MUSE_COMPILE_USE_UNITY` explicitly OFF: with #256 merged, every source is self-contained, and the strict configuration in CI keeps missing includes and Qt module links from regressing (the follow-up suggested in #256, without a dedicated CI job).

Note for consumers: an application that does not declare `MUSE_COMPILE_USE_PCH` now builds without PCH (undefined → falsy in the gating checks). Both consumer apps have PRs declaring it app-side, safe to merge before or after this one: audacity/audacity#11900 (tracked by audacity/audacity#11898) and musescore/MuseScore#34791.


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
