### PR TITLE
Make sources self-contained without PCH and unity builds

### DIFF
--- a/framework/audio/engine/internal/iexecoperation.h
+++ b/framework/audio/engine/internal/iexecoperation.h
@@ -22,6 +22,8 @@
 
  #pragma once
 
+#include <functional>
+
 namespace muse::audio::engine {
 //! NOTE When commands arrive at the engine, it exec them.
 //! These can be quick commands like changing the volume,

--- a/framework/cloud/internal/abstractcloudservice.cpp
+++ b/framework/cloud/internal/abstractcloudservice.cpp
@@ -29,6 +29,8 @@
 #include <QUrlQuery>
 #include <QHttpMultiPart>
 #include <QRandomGenerator>
+#include <QEventLoop>
+#include <QTimer>
 
 #include "clouderrors.h"
 #include "multiwindows/resourcelockguard.h"

--- a/framework/cloud/musescorecom/musescorecomservice.cpp
+++ b/framework/cloud/musescorecom/musescorecomservice.cpp
@@ -23,12 +23,12 @@
 #include "musescorecomservice.h"
 
 #include <QBuffer>
+#include <QEventLoop>
 #include <QHttpMultiPart>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
-#include <QEventLoop>
 
 #include "clouderrors.h"
 

--- a/framework/cloud/musescorecom/musescorecomservice.cpp
+++ b/framework/cloud/musescorecom/musescorecomservice.cpp
@@ -28,6 +28,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
+#include <QEventLoop>
 
 #include "clouderrors.h"
 

--- a/framework/dockwindow/internal/dockseparator.cpp
+++ b/framework/dockwindow/internal/dockseparator.cpp
@@ -22,14 +22,14 @@
 
 #include "dockseparator.h"
 
+#include <QTimer>
+
 #include "log.h"
 #include "../docktypes.h"
 
 #include "thirdparty/KDDockWidgets/src/private/multisplitter/Rubberband_quick.h"
 #include "thirdparty/KDDockWidgets/src/DockWidgetBase.h"
 #include "thirdparty/KDDockWidgets/src/private/DockRegistry_p.h"
-
-#include <QTimer>
 
 using namespace muse::dock;
 

--- a/framework/dockwindow/qml/Muse/Dock/docktoolbarview.h
+++ b/framework/dockwindow/qml/Muse/Dock/docktoolbarview.h
@@ -22,9 +22,9 @@
 
 #pragma once
 
-#include "internal/dockbase.h"
-
 #include <QtGlobal>
+
+#include "internal/dockbase.h"
 
 namespace muse::dock {
 namespace DockToolBarAlignment {

--- a/framework/dockwindow_v2/qml/Muse/Dock/docktoolbarview.h
+++ b/framework/dockwindow_v2/qml/Muse/Dock/docktoolbarview.h
@@ -22,9 +22,9 @@
 
 #pragma once
 
-#include "internal/dockbase.h"
-
 #include <QtGlobal>
+
+#include "internal/dockbase.h"
 
 namespace muse::dock {
 namespace DockToolBarAlignment {

--- a/framework/extensions/qml/Muse/Extensions/CMakeLists.txt
+++ b/framework/extensions/qml/Muse/Extensions/CMakeLists.txt
@@ -19,6 +19,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 muse_create_qml_module(muse_extensions_qml ALIAS muse::extensions_qml FOR muse_extensions)
+target_link_libraries(muse_extensions_qml PRIVATE Qt::Quick)
+
 
 qt_add_qml_module(muse_extensions_qml
     URI Muse.Extensions

--- a/framework/global/CMakeLists.txt
+++ b/framework/global/CMakeLists.txt
@@ -254,7 +254,7 @@ target_include_directories(muse_global PRIVATE ${_picojson}/picojson)
 if (MUSE_QT_SUPPORT)
     # These are needed by so many modules, that we make them public here,
     # so that other modules get them transitively.
-    target_link_libraries(muse_global PUBLIC Qt::Core Qt::Gui)
+    target_link_libraries(muse_global PUBLIC Qt::Core Qt::Gui Qt::Qml)
 
     target_link_libraries(muse_global PRIVATE Qt::Quick Qt::Widgets)
 endif()

--- a/framework/global/api/apiutils.h
+++ b/framework/global/api/apiutils.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <QString>
 #include <QJSValue>
+#include <QMetaEnum>
 
 #include "apitypes.h"
 #include "iapiengine.h"

--- a/framework/global/io/internal/filesystem.h
+++ b/framework/global/io/internal/filesystem.h
@@ -26,9 +26,9 @@
 #include <memory>
 #include <mutex>
 
-#include "../ifilesystem.h"
+#include <QFile>
 
-class QFile;
+#include "../ifilesystem.h"
 
 namespace muse::io {
 class FileSystem : public IFileSystem

--- a/framework/interactive/api/interactiveapi.cpp
+++ b/framework/interactive/api/interactiveapi.cpp
@@ -23,6 +23,7 @@
 #include "interactiveapi.h"
 
 #include <QUrl>
+#include <QMetaEnum>
 
 using namespace muse::interactive;
 

--- a/framework/interactive/internal/iinteractiveprovider.h
+++ b/framework/interactive/internal/iinteractiveprovider.h
@@ -28,6 +28,7 @@
 #include "global/async/channel.h"
 
 #include "global/modularity/imoduleinterface.h"
+#include <QWindow>
 
 namespace muse::interactive {
 class QmlLaunchData : public QObject

--- a/framework/interactive/internal/iinteractiveprovider.h
+++ b/framework/interactive/internal/iinteractiveprovider.h
@@ -24,11 +24,11 @@
 
 #include <QObject>
 #include <QVariant>
+#include <QWindow>
 
 #include "global/async/channel.h"
 
 #include "global/modularity/imoduleinterface.h"
-#include <QWindow>
 
 namespace muse::interactive {
 class QmlLaunchData : public QObject

--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -31,6 +31,7 @@
 #include <QUrl>
 #include <QWidget>
 #include <QWindow>
+#include <QQmlEngine>
 
 #include "async/async.h"
 #include "io/path.h"

--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -28,10 +28,10 @@
 #include <QGuiApplication>
 #include <QMetaProperty>
 #include <QMetaType>
+#include <QQmlEngine>
 #include <QUrl>
 #include <QWidget>
 #include <QWindow>
-#include <QQmlEngine>
 
 #include "async/async.h"
 #include "io/path.h"

--- a/framework/interactive/qml/Muse/Interactive/interactiveprovidermodel.h
+++ b/framework/interactive/qml/Muse/Interactive/interactiveprovidermodel.h
@@ -24,6 +24,7 @@
 
 #include <QObject>
 #include <QQmlParserStatus>
+#include <QWindow>
 #include <qqmlintegration.h>
 
 #include "global/async/asyncable.h"

--- a/framework/multiwindows/CMakeLists.txt
+++ b/framework/multiwindows/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 muse_create_module(muse_multiwindows ALIAS muse::multiwindows)
 
+target_link_libraries(muse_multiwindows PRIVATE Qt::Network)
+
 target_sources(muse_multiwindows PRIVATE
     multiwindowsmodule.cpp
     multiwindowsmodule.h

--- a/framework/multiwindows/internal/singleprocess/singleprocessprovider.cpp
+++ b/framework/multiwindows/internal/singleprocess/singleprocessprovider.cpp
@@ -21,6 +21,7 @@
  */
 
  #include "singleprocessprovider.h"
+ #include <QCoreApplication>
 
  #include "../../iprojectprovider.h"
  #include "ui/imainwindow.h"

--- a/framework/multiwindows/internal/singleprocess/singleprocessprovider.cpp
+++ b/framework/multiwindows/internal/singleprocess/singleprocessprovider.cpp
@@ -21,6 +21,7 @@
  */
 
  #include "singleprocessprovider.h"
+
  #include <QCoreApplication>
 
  #include "../../iprojectprovider.h"

--- a/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.cpp
+++ b/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "multiinstancesdevmodel.h"
+
 #include <QVariant>
 
 using namespace muse::mi;

--- a/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.cpp
+++ b/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "multiinstancesdevmodel.h"
+#include <QVariant>
 
 using namespace muse::mi;
 

--- a/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.h
+++ b/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.h
@@ -29,6 +29,7 @@
 #include "internal/multiprocess/imultiprocessprovider.h"
 
 #include "async/asyncable.h"
+#include <QVariant>
 
 namespace muse::mi {
 class MultiInstancesDevModel : public QObject, public Contextable, public async::Asyncable

--- a/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.h
+++ b/framework/multiwindows/qml/Muse/MultiWindows/multiinstancesdevmodel.h
@@ -23,13 +23,13 @@
 #pragma once
 
 #include <QObject>
+#include <QVariant>
 #include <qqmlintegration.h>
 
 #include "modularity/ioc.h"
 #include "internal/multiprocess/imultiprocessprovider.h"
 
 #include "async/asyncable.h"
-#include <QVariant>
 
 namespace muse::mi {
 class MultiInstancesDevModel : public QObject, public Contextable, public async::Asyncable

--- a/framework/rcontrol/CMakeLists.txt
+++ b/framework/rcontrol/CMakeLists.txt
@@ -18,6 +18,8 @@
 # NOTE This is the remote control module
 muse_create_module(muse_rcontrol ALIAS muse::rcontrol)
 
+target_link_libraries(muse_rcontrol PRIVATE Qt::Network)
+
 target_sources(muse_rcontrol PRIVATE
     rcontrolmodule.cpp
     rcontrolmodule.h

--- a/framework/tours/CMakeLists.txt
+++ b/framework/tours/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 muse_create_module(muse_tours ALIAS muse::tours)
 
+target_link_libraries(muse_tours PRIVATE Qt::Quick)
+
 target_sources(muse_tours PRIVATE
     toursmodule.cpp
     toursmodule.h

--- a/framework/tours/qml/Muse/Tours/CMakeLists.txt
+++ b/framework/tours/qml/Muse/Tours/CMakeLists.txt
@@ -19,6 +19,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 muse_create_qml_module(muse_tours_qml ALIAS muse::tours_qml FOR muse_tours)
+target_link_libraries(muse_tours_qml PRIVATE Qt::Quick)
+
 
 qt_add_qml_module(muse_tours_qml
     URI Muse.Tours

--- a/framework/ui/api/themeapi.cpp
+++ b/framework/ui/api/themeapi.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "themeapi.h"
+
 #include <QFontMetrics>
 
 using namespace muse::ui;

--- a/framework/ui/api/themeapi.cpp
+++ b/framework/ui/api/themeapi.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "themeapi.h"
+#include <QFontMetrics>
 
 using namespace muse::ui;
 using namespace muse::api;

--- a/framework/ui/qml/Muse/Ui/initialletternavigation.cpp
+++ b/framework/ui/qml/Muse/Ui/initialletternavigation.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "initialletternavigation.h"
+#include <QRegularExpression>
 
 #include "global/log.h"
 

--- a/framework/ui/qml/Muse/Ui/initialletternavigation.cpp
+++ b/framework/ui/qml/Muse/Ui/initialletternavigation.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "initialletternavigation.h"
+
 #include <QRegularExpression>
 
 #include "global/log.h"

--- a/framework/ui/qml/Muse/Ui/initialletternavigation.h
+++ b/framework/ui/qml/Muse/Ui/initialletternavigation.h
@@ -23,8 +23,8 @@
 #pragma once
 
 #include <QObject>
-#include <qqmlintegration.h>
 #include <QTimer>
+#include <qqmlintegration.h>
 
 #include "abstractnavigation.h"
 

--- a/framework/ui/qml/Muse/Ui/initialletternavigation.h
+++ b/framework/ui/qml/Muse/Ui/initialletternavigation.h
@@ -24,6 +24,7 @@
 
 #include <QObject>
 #include <qqmlintegration.h>
+#include <QTimer>
 
 #include "abstractnavigation.h"
 

--- a/framework/ui/uimodule.h
+++ b/framework/ui/uimodule.h
@@ -22,8 +22,9 @@
 
 #pragma once
 
-#include "modularity/imodulesetup.h"
 #include <QtGlobal>
+
+#include "modularity/imodulesetup.h"
 
 namespace muse::api {
 class ThemeApi;

--- a/framework/ui/view/qmldataformatter.cpp
+++ b/framework/ui/view/qmldataformatter.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "qmldataformatter.h"
+
 #include <QLocale>
 
 #include "global/dataformatter.h"

--- a/framework/ui/view/qmldataformatter.cpp
+++ b/framework/ui/view/qmldataformatter.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "qmldataformatter.h"
+#include <QLocale>
 
 #include "global/dataformatter.h"
 

--- a/framework/ui/view/widgetstyle.cpp
+++ b/framework/ui/view/widgetstyle.cpp
@@ -34,6 +34,7 @@
 #include <QTextEdit>
 #include <QToolBar>
 #include <QVariant>
+#include <QPainter>
 
 #include "api/themeapi.h"
 #include "iconcodes.h"

--- a/framework/ui/view/widgetstyle.cpp
+++ b/framework/ui/view/widgetstyle.cpp
@@ -27,6 +27,7 @@
 #include <QGroupBox>
 #include <QLineEdit>
 #include <QMenu>
+#include <QPainter>
 #include <QPalette>
 #include <QStyle>
 #include <QStyleFactory>
@@ -34,7 +35,6 @@
 #include <QTextEdit>
 #include <QToolBar>
 #include <QVariant>
-#include <QPainter>
 
 #include "api/themeapi.h"
 #include "iconcodes.h"

--- a/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 muse_create_qml_module(muse_uicomponents_qml ALIAS muse::uicomponents_qml FOR muse_uicomponents)
 
+target_link_libraries(muse_uicomponents_qml PRIVATE Qt::Quick)
+
 qt_add_qml_module(muse_uicomponents_qml
     URI Muse.UiComponents
     VERSION 1.0

--- a/framework/uicomponents/qml/Muse/UiComponents/abstracttableviewmodel.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/abstracttableviewmodel.cpp
@@ -22,6 +22,7 @@
 #include "abstracttableviewmodel.h"
 
 #include <QSet>
+#include <QTimer>
 
 #include "internal/tableviewlistcell.h"
 

--- a/framework/uicomponents/qml/Muse/UiComponents/filteredflyoutmodel.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/filteredflyoutmodel.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <QObject>
+#include <QVariant>
 #include <qqmlintegration.h>
 
 namespace muse::uicomponents {

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -23,6 +23,7 @@
 #include "polylineplot.h"
 #include "realfn.h"
 
+#include <QCursor>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>

--- a/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/polylineplot.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "polylineplot.h"
-#include "realfn.h"
 
 #include <QCursor>
 #include <QPainter>
@@ -33,6 +32,8 @@
 
 #include <algorithm>
 #include <cmath>
+
+#include "realfn.h"
 
 using namespace muse::uicomponents;
 

--- a/framework/update/CMakeLists.txt
+++ b/framework/update/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 muse_create_module(muse_update ALIAS muse::update)
 
+target_link_libraries(muse_update PRIVATE Qt::Network)
+
 target_sources(muse_update PRIVATE
     updatemodule.cpp
     updatemodule.h

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -22,9 +22,9 @@
 
 #include "appupdatescenario.h"
 
-#include "updateerrors.h"
-
 #include <QUrl>
+
+#include "updateerrors.h"
 
 #include "async/async.h"
 #include "global/concurrency/concurrent.h"


### PR DESCRIPTION
Follow-up to the discussion in #254: makes the framework build with `MUSE_COMPILE_USE_PCH=OFF` and `MUSE_COMPILE_USE_UNITY=OFF` — every source and header is now self-contained instead of relying on the PCH force-include or a unity batch neighbor.

Two classes of fixes:

- **Missing includes** (`<QLocale>`, `<QPainter>`, `<QMetaEnum>`, `<functional>`, ...) in sources written against the PCH's implicit baseline. Includes `filesystem.h` (also fixed in #254 originally; consolidated here).
- **Missing Qt module links**: `muse_pch` links `Qt::Core/Gui/Quick` PUBLIC, so PCH-enabled modules silently inherited those Qt modules. Modules now declare their real Qt dependencies (`Qt::Quick`, `Qt::Network`, ...), and `muse_global` links `Qt::Qml` PUBLIC since its public `api/iapiengine.h` exposes `QJSValue`.

Verified by full strict builds (PCH off + unity off) on macOS (Apple clang / libc++) and Linux (gcc-14 / libstdc++, matching CI). Codestyle check passes.

Possible follow-up: a CI job building the strict configuration would keep this from regressing.


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
