### PR TITLE
FilePicker: expose a toolTipTitle alias to its internal button

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
@@ -46,6 +46,7 @@ Item {
     property string buttonText: qsTrc("ui", "Browse")
     property int buttonOrientation: Qt.Vertical
     property alias buttonWidth: button.implicitWidth
+    property alias toolTipTitle: button.toolTipTitle
 
     property NavigationPanel navigation: null
     property int navigationRowOrderStart: 0


### PR DESCRIPTION
## Summary
- `FilePicker`'s internal icon-only button has no way to set a tooltip title from outside the component — callers using `buttonType: FlatButton.IconOnly` had no way to give the button an accessible/hoverable label.
- Adds `property alias toolTipTitle: button.toolTipTitle`, mirroring the existing `buttonWidth` alias pattern already in the file.

## Context
Found while building a Video panel feature in `musescore/MuseScore` that uses an icon-only `FilePicker` for "Choose video" — assigning `toolTipTitle` on it directly is silently rejected under `pragma ComponentBehavior: Bound` (an unknown property assignment fails component creation, not just a warning), breaking the whole panel.

## Test plan
- [x] Verified an icon-only `FilePicker` with `toolTipTitle` set now creates successfully and shows the tooltip on hover.