### PR TITLE
Make per-module unit test switches to follow the global switch

### DIFF
--- a/framework/cmake/MuseDeclareOptions.cmake
+++ b/framework/cmake/MuseDeclareOptions.cmake
@@ -1,5 +1,25 @@
 include(CMakeDependentOption)
 
+# === Enviropment ===
+option(MUSE_QT_SUPPORT "Build with Qt support" ON)
+option(MUSE_THREADS_SUPPORT "Build with threads support" ON)
+option(MUSE_CONFIGURATION_IS_WEB "Configuration is web" OFF)
+
+# === Build options ===
+option(MUSE_COMPILE_ASAN "Enable Address Sanitizer" OFF)
+option(MUSE_COMPILE_USE_PCH "Use precompiled headers." ON)
+
+# === Debug options ===
+option(MUSE_COMPILE_STRING_DEBUG_HACK "Enable string debug hack (only clang)" ON)
+option(MUSE_LOAD_QML_FROM_SOURCE "Load QML from source files instead of compiled resources (for development and debugging)" OFF)
+
+# === Tests ===
+option(MUSE_ENABLE_UNIT_TESTS_CODE_COVERAGE "Enable code coverage for unit tests" OFF)
+option(MUSE_ENABLE_UNIT_TESTS "Build framework unit tests" ON)
+
+# === Tools ===
+option(MUSE_ENABLE_CUSTOM_ALLOCATOR "Enable custom allocator" OFF)
+
 macro(declare_muse_module_opt name def)
     option(MUSE_MODULE_${name} "Build ${name} module" ${def})
 
@@ -8,7 +28,7 @@ macro(declare_muse_module_opt name def)
     # 3. we can disable some submodules manually
     option(MUSE_MODULE_${name}_API "Build ${name} api" ON)
     option(MUSE_MODULE_${name}_QML "Build ${name} QML" ON)
-    option(MUSE_MODULE_${name}_TESTS "Build ${name} tests" ON)
+    option(MUSE_MODULE_${name}_TESTS "Build ${name} tests" ${MUSE_ENABLE_UNIT_TESTS})
 endmacro()
 
 # Modules framework (alphabetical order please)
@@ -105,23 +125,3 @@ declare_muse_module_opt(UPDATE ON)
 declare_muse_module_opt(VST OFF)
 
 declare_muse_module_opt(WORKSPACE ON)
-
-# === Enviropment ===
-option(MUSE_QT_SUPPORT "Build with Qt support" ON)
-option(MUSE_THREADS_SUPPORT "Build with threads support" ON)
-option(MUSE_CONFIGURATION_IS_WEB "Configuration is web" OFF)
-
-# === Build options ===
-option(MUSE_COMPILE_ASAN "Enable Address Sanitizer" OFF)
-option(MUSE_COMPILE_USE_PCH "Use precompiled headers." ON)
-
-# === Debug options ===
-option(MUSE_COMPILE_STRING_DEBUG_HACK "Enable string debug hack (only clang)" ON)
-option(MUSE_LOAD_QML_FROM_SOURCE "Load QML from source files instead of compiled resources (for development and debugging)" OFF)
-
-# === Tests ===
-option(MUSE_ENABLE_UNIT_TESTS "Build framework unit tests" ON)
-option(MUSE_ENABLE_UNIT_TESTS_CODE_COVERAGE "Enable code coverage for unit tests" OFF)
-
-# === Tools ===
-option(MUSE_ENABLE_CUSTOM_ALLOCATOR "Enable custom allocator" OFF)


### PR DESCRIPTION
Resolves: allows switching unit tests off with a single global switch MUSE_ENABLE_UNIT_TESTS

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
