### PR TITLE
Require Qt::NetworkAuth only if needed

### DIFF
--- a/buildscripts/cmake/SetupQt6.cmake
+++ b/buildscripts/cmake/SetupQt6.cmake
@@ -55,8 +55,10 @@ set(QT_LIBRARIES
 
 if(NOT OS_IS_WASM)
 
-    list(APPEND qt_components NetworkAuth)
-    list(APPEND QT_LIBRARIES Qt::NetworkAuth)
+    if (MUSE_MODULE_CLOUD)
+        list(APPEND qt_components NetworkAuth)
+        list(APPEND QT_LIBRARIES Qt::NetworkAuth)
+    endif()
 
     list(APPEND qt_components PrintSupport)
     list(APPEND QT_LIBRARIES Qt::PrintSupport)


### PR DESCRIPTION
Resolves: allows skipping Qt::NetworkAuth linking if it is not used

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below (failure to complete this checklist accurately will result in the PR being closed) -->

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
