### PR TITLE
Fuzzy text search, part 4: Search extensions & small improvements

### DIFF
--- a/framework/extensions/qml/Muse/Extensions/internal/ExtensionsListView.qml
+++ b/framework/extensions/qml/Muse/Extensions/internal/ExtensionsListView.qml
@@ -65,10 +65,12 @@ Column {
         id: filterModel
 
         filters: [
-            FilterValue {
+            FuzzyFilter {
+                id: fuzzyFilter
+
+                enabled: Boolean(fuzzyPattern)
+                fuzzyPattern: root.search
                 roleName: "name"
-                roleValue: root.search
-                compareType: CompareType.Contains
             },
             FilterValue {
                 roleName: "enabled"
@@ -79,6 +81,12 @@ Column {
                 roleName: "category"
                 roleValue: root.selectedCategory
                 compareType: CompareType.Contains
+            }
+        ]
+        sorters: [
+            FuzzyScoreSorter {
+                enabled: fuzzyFilter.enabled
+                fuzzyFilter: fuzzyFilter
             }
         ]
     }

--- a/framework/learn/qml/Muse/Learn/LearnPage.qml
+++ b/framework/learn/qml/Muse/Learn/LearnPage.qml
@@ -209,7 +209,6 @@ FocusScope {
                         enabled: Boolean(fuzzyPattern)
                         fuzzyPattern: searchField.searchText
                         roleName: "searchKey"
-                        caseSensitivity: Qt.CaseInsensitive
                     }
                 ]
 

--- a/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -58,7 +58,6 @@ ValueList {
                 enabled: Boolean(fuzzyPattern)
                 fuzzyPattern: root.searchText
                 roleName: "searchKey"
-                caseSensitivity: Qt.CaseInsensitive
             }
         ]
         sorters: [

--- a/framework/shortcuts_v2/qml/Muse/Shortcuts/internal/ShortcutsList.qml
+++ b/framework/shortcuts_v2/qml/Muse/Shortcuts/internal/ShortcutsList.qml
@@ -78,7 +78,6 @@ ValueList {
                 enabled: Boolean(fuzzyPattern)
                 fuzzyPattern: root.searchText
                 roleName: "searchKey"
-                caseSensitivity: Qt.CaseInsensitive
             }
         ]
         sorters: [

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -22,9 +22,6 @@
 
 #include "fuzzyfilter.h"
 
-#include <algorithm>
-#include <iterator>
-
 #include "sortfilterproxymodel.h"
 
 namespace muse::uicomponents {
@@ -36,7 +33,7 @@ FuzzyFilter::FuzzyFilter(QObject* parent)
 bool FuzzyFilter::acceptsRow(int sourceRow, const QModelIndex& sourceParent, const SortFilterProxyModel& proxyModel)
 {
     const QModelIndex sourceIndex = proxyModel.sourceModel()->index(sourceRow, 0, sourceParent);
-    const std::optional<double> score = getScore(sourceIndex, proxyModel);
+    const std::optional<double> score = getOrCalcScore(sourceIndex, proxyModel);
 
     return score.has_value();
 }
@@ -100,14 +97,39 @@ void FuzzyFilter::setCaseSensitivity(const Qt::CaseSensitivity caseSensitivity)
     emit dataChanged();
 }
 
-std::optional<double> FuzzyFilter::getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+std::optional<double> FuzzyFilter::getScore(const QModelIndex& sourceIndex) const
 {
-    auto scoreIt = m_scoreCache.find(sourceIndex);
+    const auto scoreIt = m_scoreCache.find(sourceIndex);
     if (scoreIt != m_scoreCache.end()) {
         return scoreIt.value();
     }
 
-    std::optional<double> score = calcScore(sourceIndex, proxyModel);
+    return std::nullopt;
+}
+
+void FuzzyFilter::compilePattern()
+{
+    clearScoreCache();
+
+    const QString caseAdjustedPattern = caseSensitivity() == Qt::CaseInsensitive
+                                        ? m_fuzzyPattern.toLower()
+                                        : m_fuzzyPattern;
+    const QStringList tokens = caseAdjustedPattern.split(u' ');
+
+    m_patternTokens.clear();
+    m_patternTokens.reserve(tokens.size());
+    for (const auto& token : tokens) {
+        m_patternTokens.push_back(token.toStdU32String());
+    }
+}
+
+std::optional<double> FuzzyFilter::getOrCalcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
+{
+    if (const std::optional<double> score = getScore(sourceIndex)) {
+        return score;
+    }
+
+    const std::optional<double> score = calcScore(sourceIndex, proxyModel);
     // don't cache score of filtered out items because the cache
     // is always reset before filtering and therefore only used for sorting
     // already filtered items
@@ -118,22 +140,6 @@ std::optional<double> FuzzyFilter::getScore(const QPersistentModelIndex& sourceI
     m_scoreCache.try_emplace(sourceIndex, *score);
 
     return score;
-}
-
-void FuzzyFilter::compilePattern()
-{
-    clearScoreCache();
-
-    m_patternTokens.clear();
-
-    const QString caseAdjustedPattern = caseSensitivity() == Qt::CaseInsensitive
-                                        ? m_fuzzyPattern.toLower()
-                                        : m_fuzzyPattern;
-
-    const QStringList tokens = caseAdjustedPattern.split(u' ');
-    std::transform(tokens.begin(), tokens.end(), std::back_inserter(m_patternTokens), [](const QString& token) {
-        return token.toStdU32String();
-    });
 }
 
 std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel& proxyModel)
@@ -162,11 +168,10 @@ std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, con
                                         ? 1 + (tokenSize / CHARS_PER_ERROR)
                                         : 0;
 
-        const double inverseTokenSize = 1.0 / tokenSize;
-        std::optional<double> bestTokenScore;
-
+        const double perCharScore = 1.0 / tokenSize;
+        std::optional<double> tokenScore;
         for (const auto& match : m_matcher(text, patternToken, maxDistance)) {
-            const double matchSimilarity = 1.0 - (match.editDistance * inverseTokenSize);
+            const double matchSimilarity = 1.0 - (match.editDistance * perCharScore);
             double matchScore = 5.0 * matchSimilarity;
 
             const bool isMatchStartAtStartOfWord = match.beginPos == 0
@@ -175,23 +180,23 @@ std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, con
                 const bool isMatchEndAtEndOfWord = match.endPos == text.size()
                                                    || text[match.endPos] == U' ';
                 if (isMatchEndAtEndOfWord) {
-                    matchScore += 2.0 * inverseTokenSize;
+                    matchScore += 2.0 * perCharScore;
                 } else {
-                    matchScore += inverseTokenSize;
+                    matchScore += perCharScore;
                 }
             }
 
-            if (bestTokenScore < matchScore) {
-                bestTokenScore = matchScore;
+            if (tokenScore < matchScore) {
+                tokenScore = matchScore;
             }
         }
 
         // no match for token found -> no score for entire pattern
-        if (!bestTokenScore) {
-            return bestTokenScore;
+        if (!tokenScore) {
+            return std::nullopt;
         }
 
-        score += *bestTokenScore;
+        score += *tokenScore;
     }
 
     return score;

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -22,6 +22,8 @@
 
 #include "fuzzyfilter.h"
 
+#include <QChar>
+
 #include "sortfilterproxymodel.h"
 
 namespace muse::uicomponents {
@@ -153,10 +155,10 @@ std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, con
             double matchScore = 5.0 * matchSimilarity;
 
             const bool isMatchStartAtStartOfWord = match.beginPos == 0
-                                                   || text[match.beginPos - 1] == U' ';
+                                                   || !QChar::isLetter(text[match.beginPos - 1]);
             if (isMatchStartAtStartOfWord) {
                 const bool isMatchEndAtEndOfWord = match.endPos == text.size()
-                                                   || text[match.endPos] == U' ';
+                                                   || !QChar::isLetter(text[match.endPos]);
                 if (isMatchEndAtEndOfWord) {
                     matchScore += 2.0 * perCharScore;
                 } else {

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -152,20 +152,29 @@ std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, con
         std::optional<double> tokenScore;
         for (const auto& match : m_matcher(text, patternToken, maxDistance)) {
             const double matchSimilarity = 1.0 - (match.editDistance * perCharScore);
-            double matchScore = 5.0 * matchSimilarity;
 
-            const bool isMatchStartAtStartOfWord = match.beginPos == 0
-                                                   || !QChar::isLetter(text[match.beginPos - 1]);
-            if (isMatchStartAtStartOfWord) {
-                const bool isMatchEndAtEndOfWord = match.endPos == text.size()
-                                                   || !QChar::isLetter(text[match.endPos]);
-                if (isMatchEndAtEndOfWord) {
-                    matchScore += 2.0 * perCharScore;
-                } else {
-                    matchScore += perCharScore;
+            const double scoreBonus = [&] {
+                const bool isFullMatch = (match.endPos - match.beginPos) == text.size();
+                if (isFullMatch) {
+                    return 3.0 * perCharScore;
                 }
-            }
 
+                const bool isMatchStartAtStartOfWord = match.beginPos == 0
+                                                       || !QChar::isLetter(text[match.beginPos - 1]);
+                if (isMatchStartAtStartOfWord) {
+                    const bool isMatchEndAtEndOfWord = match.endPos == text.size()
+                                                       || !QChar::isLetter(text[match.endPos]);
+                    if (isMatchEndAtEndOfWord) {
+                        return 2.0 * perCharScore;
+                    } else {
+                        return perCharScore;
+                    }
+                }
+
+                return 0.0;
+            }();
+
+            const double matchScore = 5.0 * matchSimilarity + scoreBonus;
             if (tokenScore < matchScore) {
                 tokenScore = matchScore;
             }

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.cpp
@@ -80,23 +80,6 @@ void FuzzyFilter::setRoleName(const QString& roleName)
     emit dataChanged();
 }
 
-Qt::CaseSensitivity FuzzyFilter::caseSensitivity() const
-{
-    return m_caseSensitivity;
-}
-
-void FuzzyFilter::setCaseSensitivity(const Qt::CaseSensitivity caseSensitivity)
-{
-    if (m_caseSensitivity == caseSensitivity) {
-        return;
-    }
-
-    m_caseSensitivity = caseSensitivity;
-    compilePattern();
-    emit caseSensitivityChanged();
-    emit dataChanged();
-}
-
 std::optional<double> FuzzyFilter::getScore(const QModelIndex& sourceIndex) const
 {
     const auto scoreIt = m_scoreCache.find(sourceIndex);
@@ -111,10 +94,7 @@ void FuzzyFilter::compilePattern()
 {
     clearScoreCache();
 
-    const QString caseAdjustedPattern = caseSensitivity() == Qt::CaseInsensitive
-                                        ? m_fuzzyPattern.toLower()
-                                        : m_fuzzyPattern;
-    const QStringList tokens = caseAdjustedPattern.split(u' ');
+    const QStringList tokens = m_fuzzyPattern.toLower().split(u' ');
 
     m_patternTokens.clear();
     m_patternTokens.reserve(tokens.size());
@@ -151,9 +131,7 @@ std::optional<double> FuzzyFilter::calcScore(const QModelIndex& sourceIndex, con
 
     const QString rawText = proxyModel.sourceModel()->data(sourceIndex, role)
                             .toString();
-    const std::u32string text = caseSensitivity() == Qt::CaseInsensitive
-                                ? rawText.toLower().toStdU32String()
-                                : rawText.toStdU32String();
+    const std::u32string text = rawText.toLower().toStdU32String();
 
     double score = 0.0;
     for (const auto& patternToken : m_patternTokens) {

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
@@ -60,7 +60,7 @@ public:
     Qt::CaseSensitivity caseSensitivity() const;
     void setCaseSensitivity(Qt::CaseSensitivity);
 
-    std::optional<double> getScore(const QPersistentModelIndex& sourceIndex, const SortFilterProxyModel&);
+    std::optional<double> getScore(const QModelIndex& sourceIndex) const;
 
 signals:
     void fuzzyPatternChanged();
@@ -70,6 +70,7 @@ signals:
 private:
     void compilePattern();
 
+    std::optional<double> getOrCalcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel&);
     std::optional<double> calcScore(const QModelIndex& sourceIndex, const SortFilterProxyModel&);
     void clearScoreCache();
 

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyfilter.h
@@ -43,7 +43,6 @@ class FuzzyFilter : public Filter
 
     Q_PROPERTY(QString fuzzyPattern READ fuzzyPattern WRITE setFuzzyPattern NOTIFY fuzzyPatternChanged)
     Q_PROPERTY(QString roleName READ roleName WRITE setRoleName NOTIFY roleNameChanged)
-    Q_PROPERTY(Qt::CaseSensitivity caseSensitivity READ caseSensitivity WRITE setCaseSensitivity NOTIFY caseSensitivityChanged)
 
 public:
     explicit FuzzyFilter(QObject* parent = nullptr);
@@ -57,15 +56,11 @@ public:
     QString roleName() const;
     void setRoleName(const QString&);
 
-    Qt::CaseSensitivity caseSensitivity() const;
-    void setCaseSensitivity(Qt::CaseSensitivity);
-
     std::optional<double> getScore(const QModelIndex& sourceIndex) const;
 
 signals:
     void fuzzyPatternChanged();
     void roleNameChanged();
-    void caseSensitivityChanged();
 
 private:
     void compilePattern();
@@ -76,7 +71,6 @@ private:
 
     QString m_fuzzyPattern;
     QString m_roleName;
-    Qt::CaseSensitivity m_caseSensitivity = Qt::CaseSensitive;
 
     std::vector<std::u32string> m_patternTokens;
     FuzzyMatcher m_matcher;

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -49,7 +49,6 @@ std::optional<double> getMaxScoreFromChildren(const FuzzyFilter& fuzzyFilter, co
 FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
     : Sorter(parent)
 {
-    setSortOrder(Qt::DescendingOrder);
 }
 
 bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
@@ -59,21 +58,38 @@ bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex
         return sourceLeft < sourceRight;
     }
 
+    // don't sort children when their parent has a score
+    // checking for one parent is enough. left and right always have the same parent
+    if (const QModelIndex leftParent = sourceLeft.parent(); leftParent.isValid()) {
+        if (m_fuzzyFilter->getScore(leftParent)) {
+            return sourceLeft < sourceRight;
+        }
+    }
+
     const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft);
     const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight);
 
     if (!proxyModel.isRecursiveFilteringEnabled()) {
-        return leftScore < rightScore;
+        return leftScore > rightScore;
     }
 
-    // rank parent items according to the highest child score
+    // prefer parents that match over parents with only children that match
+    if (leftScore && !rightScore) {
+        return true;
+    }
+
+    if (!leftScore && rightScore) {
+        return false;
+    }
+
+    // rank parent items according to their own score or the highest child score, whichever is higher
 
     const QAbstractItemModel& srcModel = *proxyModel.sourceModel();
 
     const std::optional<double> maxLeftChildScore = getMaxScoreFromChildren(*m_fuzzyFilter, srcModel, sourceLeft);
     const std::optional<double> maxRightChildScore = getMaxScoreFromChildren(*m_fuzzyFilter, srcModel, sourceRight);
 
-    return std::max(leftScore, maxLeftChildScore) < std::max(rightScore, maxRightChildScore);
+    return std::max(leftScore, maxLeftChildScore) > std::max(rightScore, maxRightChildScore);
 }
 
 FuzzyFilter* FuzzyScoreSorter::fuzzyFilter() const

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -30,14 +30,14 @@ FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
 }
 
 bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
-                                const SortFilterProxyModel& proxyModel)
+                                const SortFilterProxyModel& /*proxyModel*/)
 {
     if (!m_fuzzyFilter) {
         return sourceLeft < sourceRight;
     }
 
-    const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft, proxyModel);
-    const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight, proxyModel);
+    const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft);
+    const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight);
 
     return leftScore < rightScore;
 }

--- a/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/fuzzyscoresorter.cpp
@@ -22,7 +22,30 @@
 
 #include "fuzzyscoresorter.h"
 
+#include "sortfilterproxymodel.h"
+
+#include <algorithm>
+
 namespace muse::uicomponents {
+namespace {
+std::optional<double> getMaxScoreFromChildren(const FuzzyFilter& fuzzyFilter, const QAbstractItemModel& model,
+                                              const QModelIndex& parentIndex)
+{
+    const int childRowCount = model.rowCount(parentIndex);
+
+    std::optional<double> maxChildScore;
+    for (int i = 0; i < childRowCount; ++i) {
+        const QModelIndex childIndex = model.index(i, 0, parentIndex);
+        const std::optional<double> maxGrandChildrenScore = getMaxScoreFromChildren(fuzzyFilter, model, childIndex);
+        const std::optional<double> childScore = std::max(maxGrandChildrenScore, fuzzyFilter.getScore(childIndex));
+
+        maxChildScore = std::max(maxChildScore, childScore);
+    }
+
+    return maxChildScore;
+}
+}
+
 FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
     : Sorter(parent)
 {
@@ -30,7 +53,7 @@ FuzzyScoreSorter::FuzzyScoreSorter(QObject* parent)
 }
 
 bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight,
-                                const SortFilterProxyModel& /*proxyModel*/)
+                                const SortFilterProxyModel& proxyModel)
 {
     if (!m_fuzzyFilter) {
         return sourceLeft < sourceRight;
@@ -39,7 +62,18 @@ bool FuzzyScoreSorter::lessThan(const QModelIndex& sourceLeft, const QModelIndex
     const std::optional<double> leftScore = m_fuzzyFilter->getScore(sourceLeft);
     const std::optional<double> rightScore = m_fuzzyFilter->getScore(sourceRight);
 
-    return leftScore < rightScore;
+    if (!proxyModel.isRecursiveFilteringEnabled()) {
+        return leftScore < rightScore;
+    }
+
+    // rank parent items according to the highest child score
+
+    const QAbstractItemModel& srcModel = *proxyModel.sourceModel();
+
+    const std::optional<double> maxLeftChildScore = getMaxScoreFromChildren(*m_fuzzyFilter, srcModel, sourceLeft);
+    const std::optional<double> maxRightChildScore = getMaxScoreFromChildren(*m_fuzzyFilter, srcModel, sourceRight);
+
+    return std::max(leftScore, maxLeftChildScore) < std::max(rightScore, maxRightChildScore);
 }
 
 FuzzyFilter* FuzzyScoreSorter::fuzzyFilter() const


### PR DESCRIPTION
Part of: musescore/musescore#15983 

A couple of small cleanups, added fuzzy searching to `ExtensionsListView`, improved the match scoring a little, and add support for fuzzy searching through tree models. See commit messages for details.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
