### PR TITLE
Map tremolo to the tremolo strings preset on single string instruments

### DIFF
--- a/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
+++ b/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
@@ -946,7 +946,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(20, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(20, 40) }
+        { mpe::ArticulationType::Mute, midi::Program(20, 40) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(20, 44) },
     };
 
     static const ArticulationMapping VIOLA_SECTION = {
@@ -964,7 +968,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(30, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(30, 41) }
+        { mpe::ArticulationType::Mute, midi::Program(30, 41) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(30, 44) },
     };
 
     static const ArticulationMapping VIOLONCELLO_SECTION = {
@@ -982,7 +990,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(40, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(40, 49) }
+        { mpe::ArticulationType::Mute, midi::Program(40, 49) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(40, 44) },
     };
 
     static const ArticulationMapping CONTRABASS_SECTION = {
@@ -1001,6 +1013,10 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::Pizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(50, 45) },
         { mpe::ArticulationType::Mute, midi::Program(50, 43) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(50, 44) },
     };
 
     static const ArticulationMapping BRASS = {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/21122

A tremolo on a solo violin, viola, cello or double bass plays the plain arco sound: the solo `VIOLIN`, `VIOLA`, `VIOLONCELLO` and `CONTRABASS` articulation maps carry no tremolo entry, so the note stays on the standard channel. This adds the four tremolo articulations to each of them, on the same bank and program the section variants already use. Those solo maps already take every one of their articulations from that same bank, pizzicato is literally the same program in both, so tremolo was the only one left out. When a soundfont has no such bank, FluidSynth substitutes bank 0 with the same program number before giving up, so a third party font carrying a tremolo preset at program 44 is reached as well.

This replaces https://github.com/musescore/MuseScore/pull/30951, which made the same change while the file still lived in the MuseScore repository, where it can no longer be rebased because the path it edits is gone from that tree.

- [x] I signed the [CLA](https://musescore.org/en/cla) as [manolo](https://musescore.org/en/user):
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).
