### PR TITLE
Adjust popup "force close" logic

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -243,13 +243,7 @@ MenuView {
                 root.handleMenuItem(itemId)
             })
 
-            root.subMenuLoader.opened.connect(function(itemId) {
-                root.closePolicies = PopupView.NoAutoClose
-            })
-
             root.subMenuLoader.closed.connect(function(force) {
-                root.closePolicies = PopupView.CloseOnPressOutsideParent
-
                 if (force) {
                     root.close(true)
                     root.openNextMenu()

--- a/framework/uicomponents/qml/Muse/UiComponents/popupview.cpp
+++ b/framework/uicomponents/qml/Muse/UiComponents/popupview.cpp
@@ -101,7 +101,7 @@ void PopupView::initCloseController()
     m_closeController->setCanClose(!m_closePolicies.testFlag(ClosePolicy::NoAutoClose));
 
     m_closeController->closeNotification().onNotify(this, [this]() {
-        close(true);
+        close();
     });
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/34689

Using the `force` flag in `PopupView` causes all ancestors of a popup to be closed. This is true by default, which means we're force-closing any time the close controller sends a close notification.

From what I understand - we added the `root.closePolicies = PopupView.NoAutoClose` line so that parent popups would not be closed when clicking inside a descendant. By doing so we placed the responsibility of the "close" logic for the entire flyout on the popup furthest along it. The problem with this is illustrated in the attached issue - the search menu is not inside this popup or its parent item so we end up force-closing the entire flyout.

The thing is, semi-recently we [added some more explicit logic](https://github.com/musescore/MuseScore/pull/28189) to ensure that parent popups don't close when a click occurs inside a descendent. If we trust that this works (which it does on my end after some brief testing) we should be able to remove the `root.closePolicies = PopupView.NoAutoClose` assignment so that each popup is responsible for its own close logic, and then stop force-closing whenever the close controller sends a close notification.

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: macos windows_x64
musescore: musescore/MuseScore/main
musescore platforms: macos windows_x64 windows_portable