### PR TITLE
AppUpdate. New flow. Step 2

### DIFF
--- a/framework/global/io/ifilesystem.h
+++ b/framework/global/io/ifilesystem.h
@@ -50,6 +50,7 @@ public:
     virtual EntryType entryType(const io::path_t& path) const = 0;
 
     virtual RetVal<uint64_t> fileSize(const io::path_t& path) const = 0;
+    virtual RetVal<uint64_t> availableSpace(const io::path_t& path) const = 0;
 
     virtual RetVal<io::paths_t> scanFiles(const io::path_t& rootDir, const std::vector<std::string>& filters,
                                           ScanMode mode = ScanMode::FilesInCurrentDirAndSubdirs) const = 0;

--- a/framework/global/io/ifilesystem.h
+++ b/framework/global/io/ifilesystem.h
@@ -49,6 +49,7 @@ public:
 
     virtual EntryType entryType(const io::path_t& path) const = 0;
 
+    //! NOTE In bytes
     virtual RetVal<uint64_t> fileSize(const io::path_t& path) const = 0;
     virtual RetVal<uint64_t> availableSpace(const io::path_t& path) const = 0;
 

--- a/framework/global/io/internal/filesystem.cpp
+++ b/framework/global/io/internal/filesystem.cpp
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QStorageInfo>
 #include <QDirListing>
 
 #ifdef Q_OS_WIN
@@ -276,6 +277,16 @@ RetVal<uint64_t> FileSystem::fileSize(const io::path_t& path) const
     QFileInfo fi(path.toQString());
     rv.val = static_cast<uint64_t>(fi.size());
     return rv;
+}
+
+RetVal<uint64_t> FileSystem::availableSpace(const io::path_t& path) const
+{
+    QStorageInfo storage(path.toQString());
+    if (!storage.isValid() || !storage.isReady()) {
+        return RetVal<uint64_t>(make_ret(Err::FSNotExist));
+    }
+
+    return RetVal<uint64_t>::make_ok(static_cast<uint64_t>(storage.bytesAvailable()));
 }
 
 RetVal<io::paths_t> FileSystem::scanFiles(const io::path_t& rootDir, const std::vector<std::string>& nameFilters, ScanMode mode) const

--- a/framework/global/io/internal/filesystem.h
+++ b/framework/global/io/internal/filesystem.h
@@ -48,6 +48,7 @@ public:
     EntryType entryType(const io::path_t& path) const override;
 
     RetVal<uint64_t> fileSize(const io::path_t& path) const override;
+    RetVal<uint64_t> availableSpace(const io::path_t& path) const override;
 
     RetVal<io::paths_t> scanFiles(const io::path_t& rootDir, const std::vector<std::string>& filters,
                                   ScanMode mode = ScanMode::FilesInCurrentDirAndSubdirs) const override;

--- a/framework/global/io/internal/memfilesystem.cpp
+++ b/framework/global/io/internal/memfilesystem.cpp
@@ -22,6 +22,7 @@
 #include "memfilesystem.h"
 
 #include <cstring>
+#include <limits>
 
 #include <QFile>
 #include <QFileInfo>
@@ -140,6 +141,11 @@ muse::RetVal<uint64_t> MemFileSystem::fileSize(const muse::io::path_t& path) con
     } else {
         return muse::RetVal<uint64_t>::make_ok(m_files.at(path).size());
     }
+}
+
+muse::RetVal<uint64_t> MemFileSystem::availableSpace(const muse::io::path_t&) const
+{
+    return muse::RetVal<uint64_t>::make_ok(std::numeric_limits<uint64_t>::max());
 }
 
 muse::RetVal<muse::io::paths_t> MemFileSystem::scanFiles(const muse::io::path_t& /*rootDir*/, const std::vector<std::string>& /*filters*/,

--- a/framework/global/io/internal/memfilesystem.h
+++ b/framework/global/io/internal/memfilesystem.h
@@ -43,6 +43,7 @@ public:
     muse::io::EntryType entryType(const muse::io::path_t& path) const override;
 
     muse::RetVal<uint64_t> fileSize(const muse::io::path_t& path) const override;
+    muse::RetVal<uint64_t> availableSpace(const muse::io::path_t& path) const override;
 
     muse::RetVal<muse::io::paths_t> scanFiles(const muse::io::path_t& rootDir, const std::vector<std::string>& filters,
                                               muse::io::ScanMode mode = muse::io::ScanMode::FilesInCurrentDirAndSubdirs) const override;

--- a/framework/global/tests/mocks/filesystemmock.h
+++ b/framework/global/tests/mocks/filesystemmock.h
@@ -39,6 +39,7 @@ public:
     MOCK_METHOD(EntryType, entryType, (const io::path_t& path), (const, override));
 
     MOCK_METHOD(RetVal<uint64_t>, fileSize, (const io::path_t& path), (const, override));
+    MOCK_METHOD(RetVal<uint64_t>, availableSpace, (const io::path_t& path), (const, override));
 
     MOCK_METHOD(RetVal<ByteArray>, readFile, (const io::path_t&), (const, override));
     MOCK_METHOD(Ret, readFile, (const io::path_t& filePath, ByteArray & data), (const, override));

--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -1030,6 +1030,7 @@ Ret Interactive::toRet(const QVariant& jsr) const
 
     Ret ret;
     ret.setCode(jsobj.value("errcode").toInt());
+    ret.setText(jsobj.value("text").toString().toStdString());
     return ret;
 }
 

--- a/framework/interactive/internal/interactive.cpp
+++ b/framework/interactive/internal/interactive.cpp
@@ -599,6 +599,7 @@ RetVal<Val> Interactive::openSync(const UriQuery& q)
 
     RetVal<Val> rv;
     QEventLoop loop;
+    bool finished = false;
     Promise<Val>::Resolve resolve;
     Promise<Val>::Reject reject;
     Promise<Val> promise = async::make_promise<Val>([&resolve, &reject](auto res, auto rej) {
@@ -607,14 +608,16 @@ RetVal<Val> Interactive::openSync(const UriQuery& q)
         return Promise<Val>::Result::unchecked();
     }, PromiseType::AsyncByBody);
 
-    promise.onResolve(this, [&rv, &loop](const Val& val) {
+    promise.onResolve(this, [&rv, &loop, &finished](const Val& val) {
         rv = RetVal<Val>::make_ok(val);
+        finished = true;
         loop.quit();
     });
 
-    promise.onReject(this, [&rv, &loop](int code, const std::string& err) {
+    promise.onReject(this, [&rv, &loop, &finished](int code, const std::string& err) {
         LOGE() << code << " " << err;
         rv.ret = make_ret(code, err);
+        finished = true;
         loop.quit();
     });
 
@@ -624,6 +627,12 @@ RetVal<Val> Interactive::openSync(const UriQuery& q)
     ContainerMeta openMeta = uriRegister()->meta(q.uri());
     if (openMeta.type == ContainerMeta::PrimaryPage) {
         LOGW() << "Primary pages should not open in synchronous mode, please fix this.";
+        return rv;
+    }
+
+    //! NOTE: The dialog may have finished synchronously while opening (e.g. it
+    //! closed itself on load); quit() before exec() is lost, so don't enter the loop.
+    if (finished) {
         return rv;
     }
 

--- a/framework/stubs/update/appupdatescenariostub.cpp
+++ b/framework/stubs/update/appupdatescenariostub.cpp
@@ -55,3 +55,17 @@ std::string AppUpdateScenarioStub::readyUpdateVersion() const
 void AppUpdateScenarioStub::installReadyUpdate()
 {
 }
+
+bool AppUpdateScenarioStub::hasCompletedUpdate() const
+{
+    return false;
+}
+
+muse::async::Notification AppUpdateScenarioStub::hasCompletedUpdateChanged() const
+{
+    return {};
+}
+
+void AppUpdateScenarioStub::dismissCompletedUpdate()
+{
+}

--- a/framework/stubs/update/appupdatescenariostub.cpp
+++ b/framework/stubs/update/appupdatescenariostub.cpp
@@ -69,3 +69,11 @@ muse::async::Notification AppUpdateScenarioStub::hasCompletedUpdateChanged() con
 void AppUpdateScenarioStub::dismissCompletedUpdate()
 {
 }
+
+void AppUpdateScenarioStub::showReadyUpdateInfo()
+{
+}
+
+void AppUpdateScenarioStub::dismissReadyUpdate()
+{
+}

--- a/framework/stubs/update/appupdatescenariostub.h
+++ b/framework/stubs/update/appupdatescenariostub.h
@@ -38,6 +38,8 @@ public:
     std::string readyUpdateVersion() const override;
 
     void installReadyUpdate() override;
+    void showReadyUpdateInfo() override;
+    void dismissReadyUpdate() override;
 
     bool hasCompletedUpdate() const override;
     async::Notification hasCompletedUpdateChanged() const override;

--- a/framework/stubs/update/appupdatescenariostub.h
+++ b/framework/stubs/update/appupdatescenariostub.h
@@ -38,5 +38,9 @@ public:
     std::string readyUpdateVersion() const override;
 
     void installReadyUpdate() override;
+
+    bool hasCompletedUpdate() const override;
+    async::Notification hasCompletedUpdateChanged() const override;
+    void dismissCompletedUpdate() override;
 };
 }

--- a/framework/stubs/update/appupdateservicestub.cpp
+++ b/framework/stubs/update/appupdateservicestub.cpp
@@ -67,3 +67,7 @@ muse::io::path_t AppUpdateServiceStub::downloadedReleasePath() const
 {
     return {};
 }
+
+void AppUpdateServiceStub::removeDownloadedRelease()
+{
+}

--- a/framework/stubs/update/appupdateservicestub.h
+++ b/framework/stubs/update/appupdateservicestub.h
@@ -38,5 +38,6 @@ public:
 
     bool isReleaseDownloaded() const override;
     muse::io::path_t downloadedReleasePath() const override;
+    void removeDownloadedRelease() override;
 };
 }

--- a/framework/stubs/update/updateconfigurationstub.cpp
+++ b/framework/stubs/update/updateconfigurationstub.cpp
@@ -52,12 +52,12 @@ muse::async::Notification UpdateConfigurationStub::needCheckForUpdateChanged() c
     return n;
 }
 
-bool UpdateConfigurationStub::autoInstallEnabled() const
+bool UpdateConfigurationStub::autoDownloadEnabled() const
 {
     return false;
 }
 
-void UpdateConfigurationStub::setAutoInstallEnabled(bool)
+void UpdateConfigurationStub::setAutoDownloadEnabled(bool)
 {
 }
 

--- a/framework/stubs/update/updateconfigurationstub.cpp
+++ b/framework/stubs/update/updateconfigurationstub.cpp
@@ -118,3 +118,12 @@ muse::io::path_t UpdateConfigurationStub::updateRequestHistoryJsonPath() const
 {
     return "";
 }
+
+std::string UpdateConfigurationStub::installingReleaseVersion() const
+{
+    return {};
+}
+
+void UpdateConfigurationStub::setInstallingReleaseVersion(const std::string&)
+{
+}

--- a/framework/stubs/update/updateconfigurationstub.cpp
+++ b/framework/stubs/update/updateconfigurationstub.cpp
@@ -79,11 +79,6 @@ void UpdateConfigurationStub::setSkippedReleaseVersion(const std::string&)
 {
 }
 
-bool UpdateConfigurationStub::checkForUpdateTestMode() const
-{
-    return false;
-}
-
 std::string UpdateConfigurationStub::checkForAppUpdateUrl() const
 {
     return "";

--- a/framework/stubs/update/updateconfigurationstub.cpp
+++ b/framework/stubs/update/updateconfigurationstub.cpp
@@ -127,3 +127,8 @@ std::string UpdateConfigurationStub::installingReleaseVersion() const
 void UpdateConfigurationStub::setInstallingReleaseVersion(const std::string&)
 {
 }
+
+muse::io::path_t UpdateConfigurationStub::helperLogPath() const
+{
+    return "";
+}

--- a/framework/stubs/update/updateconfigurationstub.h
+++ b/framework/stubs/update/updateconfigurationstub.h
@@ -46,8 +46,6 @@ public:
     io::path_t lastDownloadedPackagePath() const override;
     void setLastDownloadedPackagePath(const io::path_t& path) override;
 
-    bool checkForUpdateTestMode() const override;
-
     std::string checkForAppUpdateUrl() const override;
     std::string previousAppReleasesNotesUrl() const override;
 

--- a/framework/stubs/update/updateconfigurationstub.h
+++ b/framework/stubs/update/updateconfigurationstub.h
@@ -43,6 +43,9 @@ public:
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;
 
+    std::string installingReleaseVersion() const override;
+    void setInstallingReleaseVersion(const std::string& version) override;
+
     io::path_t lastDownloadedPackagePath() const override;
     void setLastDownloadedPackagePath(const io::path_t& path) override;
 

--- a/framework/stubs/update/updateconfigurationstub.h
+++ b/framework/stubs/update/updateconfigurationstub.h
@@ -37,8 +37,8 @@ public:
     void setNeedCheckForUpdate(bool needCheck) override;
     muse::async::Notification needCheckForUpdateChanged() const override;
 
-    bool autoInstallEnabled() const override;
-    void setAutoInstallEnabled(bool enabled) override;
+    bool autoDownloadEnabled() const override;
+    void setAutoDownloadEnabled(bool enabled) override;
 
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;

--- a/framework/stubs/update/updateconfigurationstub.h
+++ b/framework/stubs/update/updateconfigurationstub.h
@@ -59,6 +59,7 @@ public:
 
     io::path_t updateDataPath() const override;
     io::path_t downloadsPath() const override;
+    io::path_t helperLogPath() const override;
     io::path_t updateRequestHistoryJsonPath() const override;
 };
 }

--- a/framework/update/helper/updatetask_win.cpp
+++ b/framework/update/helper/updatetask_win.cpp
@@ -98,11 +98,11 @@ void logLine(const std::wstring& message)
     ::FlushFileBuffers(g_logFile);
 }
 
-void openLog(const std::wstring& appId)
+void openLog(const std::wstring& appId, bool truncate)
 {
     const std::wstring path = shared::logFilePath(appId);
-    g_logFile = ::CreateFileW(path.c_str(), FILE_APPEND_DATA, FILE_SHARE_READ, nullptr, OPEN_ALWAYS,
-                              FILE_ATTRIBUTE_NORMAL, nullptr);
+    g_logFile = ::CreateFileW(path.c_str(), FILE_APPEND_DATA, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                              truncate ? CREATE_ALWAYS : OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
 }
 
 void closeLog()
@@ -1692,7 +1692,7 @@ int runCommandLine()
     //! NOTE: Secured before the log is opened - every one of these commands runs
     //! privileged, and the log lives in that same directory.
     ensureSecureRoot(appId);
-    openLog(appId);
+    openLog(appId, isApply);
 
     int returnCode = 1;
 

--- a/framework/update/iappupdatescenario.h
+++ b/framework/update/iappupdatescenario.h
@@ -48,5 +48,10 @@ public:
 
     //! Install the already-downloaded update (asks to restart, then applies it).
     virtual void installReadyUpdate() = 0;
+
+    //! This launch is the first one after an update was installed.
+    virtual bool hasCompletedUpdate() const = 0;
+    virtual async::Notification hasCompletedUpdateChanged() const = 0;
+    virtual void dismissCompletedUpdate() = 0;
 };
 }

--- a/framework/update/iappupdatescenario.h
+++ b/framework/update/iappupdatescenario.h
@@ -48,6 +48,10 @@ public:
 
     //! Install the already-downloaded update (asks to restart, then applies it).
     virtual void installReadyUpdate() = 0;
+    //! Show the release notes of the ready update, with install/skip actions.
+    virtual void showReadyUpdateInfo() = 0;
+    //! Hide the ready update banner for this session (the package is kept).
+    virtual void dismissReadyUpdate() = 0;
 
     //! This launch is the first one after an update was installed.
     virtual bool hasCompletedUpdate() const = 0;

--- a/framework/update/iappupdateservice.h
+++ b/framework/update/iappupdateservice.h
@@ -44,6 +44,7 @@ public:
 
     virtual bool isReleaseDownloaded() const = 0;
     virtual muse::io::path_t downloadedReleasePath() const = 0;
+    virtual void removeDownloadedRelease() = 0;
 
     virtual bool canAutoInstall() const = 0;
 

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -332,7 +332,7 @@ bool AppUpdateScenario::shouldIgnoreUpdate(const ReleaseInfo& info) const
 
 void AppUpdateScenario::downloadUpdateInBackground()
 {
-    if (m_bgDownloadInProgress || hasReadyUpdate()) {
+    if (m_bgDownloadInProgress || !m_readyPackagePath.empty()) {
         return;
     }
 
@@ -350,6 +350,7 @@ void AppUpdateScenario::downloadUpdateInBackground()
     if (service()->isReleaseDownloaded()) {
         m_readyPackagePath = service()->downloadedReleasePath();
         m_readyUpdateVersion = service()->lastCheckResult().val.version;
+        m_readyUpdateDismissed = false;
         m_hasReadyUpdateChanged.notify();
         return;
     }
@@ -382,6 +383,7 @@ void AppUpdateScenario::downloadUpdateInBackground()
 
         m_readyPackagePath = res.val.toString();
         m_readyUpdateVersion = service()->lastCheckResult().val.version;
+        m_readyUpdateDismissed = false;
         m_hasReadyUpdateChanged.notify();
     }, Asyncable::Mode::SetReplace);
 }
@@ -417,7 +419,7 @@ void AppUpdateScenario::dismissCompletedUpdate()
 
 bool AppUpdateScenario::hasReadyUpdate() const
 {
-    return !m_readyPackagePath.empty();
+    return !m_readyPackagePath.empty() && !m_readyUpdateDismissed;
 }
 
 async::Notification AppUpdateScenario::hasReadyUpdateChanged() const
@@ -431,6 +433,20 @@ std::string AppUpdateScenario::readyUpdateVersion() const
 }
 
 void AppUpdateScenario::installReadyUpdate()
+{
+    if (m_readyPackagePath.empty()) {
+        return;
+    }
+
+    if (!service()->canAutoInstall() || multiwindowsProvider()->windowCount() != 1) {
+        askToCloseAppAndCompleteInstall(m_readyPackagePath).onResolve(this, [](const Ret&) {});
+        return;
+    }
+
+    prepareAndInstall(m_readyPackagePath).onResolve(this, [](const Ret&) {});
+}
+
+void AppUpdateScenario::showReadyUpdateInfo()
 {
     if (m_readyPackagePath.empty()) {
         return;
@@ -453,15 +469,18 @@ void AppUpdateScenario::installReadyUpdate()
             return;
         }
 
-        if (actionCode != "install") {
-            return;
+        if (actionCode == "install") {
+            installReadyUpdate();
         }
-
-        if (!service()->canAutoInstall() || multiwindowsProvider()->windowCount() != 1) {
-            askToCloseAppAndCompleteInstall(m_readyPackagePath).onResolve(this, [](const Ret&) {});
-            return;
-        }
-
-        prepareAndInstall(m_readyPackagePath).onResolve(this, [](const Ret&) {});
     });
+}
+
+void AppUpdateScenario::dismissReadyUpdate()
+{
+    if (m_readyPackagePath.empty() || m_readyUpdateDismissed) {
+        return;
+    }
+
+    m_readyUpdateDismissed = true;
+    m_hasReadyUpdateChanged.notify();
 }

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -92,23 +92,24 @@ bool AppUpdateScenario::hasUpdate() const
     return !shouldIgnoreUpdate(lastCheckResult.val);
 }
 
-Promise<Ret> AppUpdateScenario::processUpdateError(int errorCode)
+Promise<Ret> AppUpdateScenario::processUpdateError(const Ret& error)
 {
     const auto unknownError = async::make_promise<Ret>([](auto resolve, auto) {
         return resolve(muse::make_ret(Ret::Code::UnknownError));
     });
 
+    const int errorCode = error.code();
     IF_ASSERT_FAILED(errorCode >= static_cast<int>(Ret::Code::UpdateFirst)
                      && errorCode <= static_cast<int>(Ret::Code::UpdateLast)) {
         return unknownError;
     }
 
-    const Err error = static_cast<Err>(errorCode);
-    IF_ASSERT_FAILED(error != Err::NoError) {
+    const Err err = static_cast<Err>(errorCode);
+    IF_ASSERT_FAILED(err != Err::NoError) {
         return unknownError;
     }
 
-    auto message = error == Err::NoUpdate ? showNoUpdateMsg() : showServerErrorMsg();
+    auto message = err == Err::NoUpdate ? showNoUpdateMsg() : showServerErrorMsg();
     return message.then<Ret>(this, [errorCode](const IInteractive::Result&, auto resolve) {
         const Ret::Code code = static_cast<Ret::Code>(errorCode);
         return resolve(muse::make_ret(code));
@@ -167,14 +168,41 @@ Promise<IInteractive::Result> AppUpdateScenario::showServerErrorMsg()
                                 muse::trc("update", "Check for update"));
 }
 
+Promise<Ret> AppUpdateScenario::askToRetryOnNotEnoughDiskSpace(const Ret& error, const std::function<Promise<Ret>()>& retry)
+{
+    const IInteractive::ButtonDatas buttons = {
+        interactive()->buttonData(IInteractive::Button::Cancel),
+        interactive()->buttonData(IInteractive::Button::Retry)
+    };
+
+    return interactive()->error(muse::trc("update", "Not enough disk space"), error.text(),
+                                buttons, int(IInteractive::Button::Retry), { IInteractive::WithIcon },
+                                muse::trc("update", "Check for update"))
+           .then<Ret>(this, [this, retry](const IInteractive::Result& res, auto resolve) {
+        if (!res.isButton(IInteractive::Button::Retry)) {
+            return resolve(muse::make_ret(Ret::Code::Cancel));
+        }
+
+        retry().onResolve(this, [resolve](const Ret& ret) {
+            (void)resolve(ret);
+        });
+
+        return Promise<Ret>::dummy_result();
+    });
+}
+
 Promise<Ret> AppUpdateScenario::downloadRelease()
 {
     io::path_t packagePath = service()->downloadedReleasePath();
 
     if (packagePath.empty()) {
         RetVal<Val> rv = interactive()->openSync("muse://update/app?mode=download");
+        if (rv.ret.code() == static_cast<int>(Err::NotEnoughDiskSpace)) {
+            return askToRetryOnNotEnoughDiskSpace(rv.ret, [this]() { return downloadRelease(); });
+        }
+
         if (!rv.ret) {
-            return processUpdateError(rv.ret.code());
+            return processUpdateError(rv.ret);
         }
         packagePath = rv.val.toString();
     }
@@ -202,6 +230,13 @@ Promise<Ret> AppUpdateScenario::prepareAndInstall(const io::path_t& packagePath)
             async::Async::call(this, [this, packagePath, prepared, resolve]() {
                 auto complete = [resolve](const Ret& ret) { (void)resolve(ret); };
                 if (!prepared.ret) {
+                    if (prepared.ret.code() == static_cast<int>(Err::NotEnoughDiskSpace)) {
+                        askToRetryOnNotEnoughDiskSpace(prepared.ret, [this, packagePath]() {
+                            return prepareAndInstall(packagePath);
+                        }).onResolve(this, complete);
+                        return;
+                    }
+
                     LOGE() << "failed to prepare update, falling back to manual install: " << prepared.ret.toString();
                     askToCloseAppAndCompleteInstall(packagePath).onResolve(this, complete);
                     return;

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -149,10 +149,7 @@ Promise<Ret> AppUpdateScenario::showReleaseInfo(const ReleaseInfo& info)
             return resolve(muse::make_ret(Ret::Code::Cancel));
         }
 
-        //! NOTE: In test mode we skip the progress dialog and jump straight to the "needs to close" dialog...
-        const bool testMode = configuration()->checkForUpdateTestMode();
-        auto promise = testMode ? askToCloseAppAndCompleteInstall(/*installerPath*/ String()) : downloadRelease();
-        promise.onResolve(this, [resolve](const Ret& ret) {
+        downloadRelease().onResolve(this, [resolve](const Ret& ret) {
             (void)resolve(ret);
         });
 
@@ -313,7 +310,7 @@ Promise<Ret> AppUpdateScenario::askToCloseAppAndCompleteInstall(const io::path_t
 
 bool AppUpdateScenario::shouldIgnoreUpdate(const ReleaseInfo& info) const
 {
-    return info.version == configuration()->skippedReleaseVersion() && !configuration()->checkForUpdateTestMode();
+    return info.version == configuration()->skippedReleaseVersion();
 }
 
 void AppUpdateScenario::downloadUpdateInBackground()

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -38,6 +38,19 @@ using namespace muse::update;
 using namespace muse::actions;
 using namespace muse::async;
 
+void AppUpdateScenario::init()
+{
+    const std::string installing = configuration()->installingReleaseVersion();
+    if (installing.empty()) {
+        return;
+    }
+
+    configuration()->setInstallingReleaseVersion(std::string());
+
+    //! NOTE: The version differs if the user canceled the installer or it failed.
+    m_hasCompletedUpdate = Version(installing) == application()->fullVersion();
+}
+
 bool AppUpdateScenario::needCheckForUpdate() const
 {
     return configuration()->needCheckForUpdate();
@@ -274,6 +287,8 @@ Promise<Ret> AppUpdateScenario::askToRestartAndInstall(const io::path_t& package
             return Promise<Ret>::dummy_result();
         }
 
+        configuration()->setInstallingReleaseVersion(service()->lastCheckResult().val.version);
+
         //! NOTE: The helper has been spawned and will replace the app and
         //! relaunch once we quit. Quit without an installer path so the
         //! legacy "open installer" path is not taken.
@@ -298,6 +313,8 @@ Promise<Ret> AppUpdateScenario::askToCloseAppAndCompleteInstall(const io::path_t
         if (res.isButton(IInteractive::Button::Cancel)) {
             return resolve(muse::make_ret(Ret::Code::Cancel));
         }
+
+        configuration()->setInstallingReleaseVersion(service()->lastCheckResult().val.version);
 
         if (multiwindowsProvider()->windowCount() != 1) {
             multiwindowsProvider()->quitAllAndRunInstallation(packagePath);
@@ -376,6 +393,26 @@ void AppUpdateScenario::skipRelease(const std::string& version)
 
     m_readyPackagePath = io::path_t();
     m_hasReadyUpdateChanged.notify();
+}
+
+bool AppUpdateScenario::hasCompletedUpdate() const
+{
+    return m_hasCompletedUpdate;
+}
+
+async::Notification AppUpdateScenario::hasCompletedUpdateChanged() const
+{
+    return m_hasCompletedUpdateChanged;
+}
+
+void AppUpdateScenario::dismissCompletedUpdate()
+{
+    if (!m_hasCompletedUpdate) {
+        return;
+    }
+
+    m_hasCompletedUpdate = false;
+    m_hasCompletedUpdateChanged.notify();
 }
 
 bool AppUpdateScenario::hasReadyUpdate() const

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -145,7 +145,7 @@ Promise<Ret> AppUpdateScenario::showReleaseInfo(const ReleaseInfo& info)
         }
 
         if (actionCode == "skip") {
-            configuration()->setSkippedReleaseVersion(info.version);
+            skipRelease(info.version);
             return resolve(muse::make_ret(Ret::Code::Cancel));
         }
 
@@ -356,10 +356,24 @@ void AppUpdateScenario::downloadUpdateInBackground()
             return;
         }
 
+        //! NOTE: The release may have been skipped while the download was running.
+        if (!hasUpdate()) {
+            return;
+        }
+
         m_readyPackagePath = res.val.toString();
         m_readyUpdateVersion = service()->lastCheckResult().val.version;
         m_hasReadyUpdateChanged.notify();
     }, Asyncable::Mode::SetReplace);
+}
+
+void AppUpdateScenario::skipRelease(const std::string& version)
+{
+    configuration()->setSkippedReleaseVersion(version);
+    service()->removeDownloadedRelease();
+
+    m_readyPackagePath = io::path_t();
+    m_hasReadyUpdateChanged.notify();
 }
 
 bool AppUpdateScenario::hasReadyUpdate() const
@@ -396,9 +410,7 @@ void AppUpdateScenario::installReadyUpdate()
         const QString actionCode = val.toQString();
 
         if (actionCode == "skip") {
-            configuration()->setSkippedReleaseVersion(m_readyUpdateVersion);
-            m_readyPackagePath = io::path_t();
-            m_hasReadyUpdateChanged.notify();
+            skipRelease(m_readyUpdateVersion);
             return;
         }
 

--- a/framework/update/internal/appupdatescenario.cpp
+++ b/framework/update/internal/appupdatescenario.cpp
@@ -322,7 +322,12 @@ void AppUpdateScenario::downloadUpdateInBackground()
         return;
     }
 
-    if (!hasUpdate() || !configuration()->autoInstallEnabled()) {
+    if (!hasUpdate()) {
+        return;
+    }
+
+    if (!configuration()->autoDownloadEnabled()) {
+        LOGI() << "background update download skipped: user has disabled";
         return;
     }
 

--- a/framework/update/internal/appupdatescenario.h
+++ b/framework/update/internal/appupdatescenario.h
@@ -63,11 +63,12 @@ public:
 private:
     friend class AppUpdateScenarioTests;
 
-    muse::async::Promise<Ret> processUpdateError(int errorCode);
+    muse::async::Promise<Ret> processUpdateError(const Ret& error);
 
     async::Promise<IInteractive::Result> showNoUpdateMsg();
     muse::async::Promise<Ret> showReleaseInfo(const ReleaseInfo& info);
     async::Promise<IInteractive::Result> showServerErrorMsg();
+    async::Promise<Ret> askToRetryOnNotEnoughDiskSpace(const Ret& error, const std::function<async::Promise<Ret>()>& retry);
 
     void downloadUpdateInBackground();
 

--- a/framework/update/internal/appupdatescenario.h
+++ b/framework/update/internal/appupdatescenario.h
@@ -49,6 +49,8 @@ public:
     AppUpdateScenario(const modularity::ContextPtr& iocCtx)
         : Contextable(iocCtx) {}
 
+    void init();
+
     bool needCheckForUpdate() const override;
     void checkForUpdate(bool manual) override;
 
@@ -59,6 +61,10 @@ public:
     std::string readyUpdateVersion() const override;
 
     void installReadyUpdate() override;
+
+    bool hasCompletedUpdate() const override;
+    async::Notification hasCompletedUpdateChanged() const override;
+    void dismissCompletedUpdate() override;
 
 private:
     friend class AppUpdateScenarioTests;
@@ -86,5 +92,8 @@ private:
     io::path_t m_readyPackagePath;
     std::string m_readyUpdateVersion;
     async::Notification m_hasReadyUpdateChanged;
+
+    bool m_hasCompletedUpdate = false;
+    async::Notification m_hasCompletedUpdateChanged;
 };
 }

--- a/framework/update/internal/appupdatescenario.h
+++ b/framework/update/internal/appupdatescenario.h
@@ -78,6 +78,7 @@ private:
     muse::async::Promise<Ret> askToRestartAndInstall(const io::path_t& packagePath, const io::path_t& preparedPath);
 
     bool shouldIgnoreUpdate(const ReleaseInfo& info) const;
+    void skipRelease(const std::string& version);
 
     bool m_checkInProgress = false;
 

--- a/framework/update/internal/appupdatescenario.h
+++ b/framework/update/internal/appupdatescenario.h
@@ -61,6 +61,8 @@ public:
     std::string readyUpdateVersion() const override;
 
     void installReadyUpdate() override;
+    void showReadyUpdateInfo() override;
+    void dismissReadyUpdate() override;
 
     bool hasCompletedUpdate() const override;
     async::Notification hasCompletedUpdateChanged() const override;
@@ -90,6 +92,7 @@ private:
 
     bool m_bgDownloadInProgress = false;
     io::path_t m_readyPackagePath;
+    bool m_readyUpdateDismissed = false;
     std::string m_readyUpdateVersion;
     async::Notification m_hasReadyUpdateChanged;
 

--- a/framework/update/internal/appupdateservice.cpp
+++ b/framework/update/internal/appupdateservice.cpp
@@ -681,6 +681,15 @@ io::path_t AppUpdateService::downloadedReleasePath() const
     return path;
 }
 
+void AppUpdateService::removeDownloadedRelease()
+{
+    if (m_downloadInProgress) {
+        m_updateProgress.cancel();
+    }
+
+    cleanupStalePackages(/*keepFileName*/ std::string());
+}
+
 io::path_t AppUpdateService::packagesDir() const
 {
     return canAutoInstall() ? configuration()->updateDataPath() : configuration()->downloadsPath();

--- a/framework/update/internal/appupdateservice.cpp
+++ b/framework/update/internal/appupdateservice.cpp
@@ -129,10 +129,6 @@ Promise<RetVal<ReleaseInfo> > AppUpdateService::checkForUpdate()
     return Promise<RetVal<ReleaseInfo> >([this](auto resolve, auto) {
         clear();
 
-        if (configuration()->checkForUpdateTestMode()) {
-            return resolve(m_lastCheckResult);
-        }
-
         if (!m_networkManager) {
             m_networkManager = networkManagerCreator()->makeNetworkManager();
         }

--- a/framework/update/internal/appupdateservice.cpp
+++ b/framework/update/internal/appupdateservice.cpp
@@ -512,10 +512,6 @@ QJsonObject AppUpdateService::resolveReleaseAsset(const QJsonObject& release) co
 
 bool AppUpdateService::canAutoInstall() const
 {
-    if (!configuration()->autoInstallEnabled()) {
-        return false;
-    }
-
     return updateInstaller()->isInPlaceUpdateSupported();
 }
 

--- a/framework/update/internal/appupdateservice.cpp
+++ b/framework/update/internal/appupdateservice.cpp
@@ -55,6 +55,8 @@ static const std::string PARTIAL_SUFFIX(".part");
 static constexpr uint64_t UNPACK_SIZE_FACTOR = 2;
 static constexpr uint64_t DISK_SPACE_RESERVE = 100ull * 1024 * 1024;
 
+static constexpr uint64_t MAX_PACKAGE_SIZE = 500ull * 1024 * 1024;
+
 static QDate calculateWeekBeginForDate(const QDate& date)
 {
     // 1 (Monday) + 6 mod 7 = 0
@@ -332,6 +334,11 @@ Ret AppUpdateService::checkDiskSpace(DiskSpaceFor purpose, uint64_t packageSize,
 {
     if (packageSize == 0) {
         return make_ok();
+    }
+
+    if (packageSize > MAX_PACKAGE_SIZE) {
+        LOGW() << "package size is not sane: " << packageSize;
+        return make_ret(Err::NotEnoughDiskSpace);
     }
 
     io::path_t dir;

--- a/framework/update/internal/appupdateservice.cpp
+++ b/framework/update/internal/appupdateservice.cpp
@@ -50,6 +50,11 @@ const QString PREVIOUS_REQUEST_DAY_KEY("Previous-Request-Day");
 
 static const std::string PARTIAL_SUFFIX(".part");
 
+//! NOTE: In-place install unpacks the package next to it, so reserve room for
+//! the unpacked app on top of the package itself.
+static constexpr uint64_t UNPACK_SIZE_FACTOR = 2;
+static constexpr uint64_t DISK_SPACE_RESERVE = 100ull * 1024 * 1024;
+
 static QDate calculateWeekBeginForDate(const QDate& date)
 {
     // 1 (Monday) + 6 mod 7 = 0
@@ -249,8 +254,6 @@ RetVal<Progress> AppUpdateService::downloadRelease()
     const path_t partialPath = finalPath + PARTIAL_SUFFIX;
     fileSystem()->makePath(muse::io::absoluteDirpath(partialPath));
 
-    configuration()->setLastDownloadedPackagePath(finalPath);
-
     //! NOTE: Resume an interrupted download by appending to the partial file and
     //! requesting the remaining bytes via a Range header.
     uint64_t offset = 0;
@@ -258,6 +261,13 @@ RetVal<Progress> AppUpdateService::downloadRelease()
         RetVal<uint64_t> sz = fileSystem()->fileSize(partialPath);
         offset = sz.ret ? sz.val : 0;
     }
+
+    Ret spaceRet = checkDiskSpace(DiskSpaceFor::Download, info.fileSize, offset);
+    if (!spaceRet) {
+        return RetVal<Progress>::make_ret(spaceRet);
+    }
+
+    configuration()->setLastDownloadedPackagePath(finalPath);
 
     RequestHeaders headers;
     io::IODevice::OpenMode mode = io::IODevice::WriteOnly;
@@ -320,6 +330,49 @@ RetVal<Progress> AppUpdateService::downloadRelease()
     }, Asyncable::Mode::SetReplace);
 
     return RetVal<Progress>::make_ok(m_updateProgress);
+}
+
+Ret AppUpdateService::checkDiskSpace(DiskSpaceFor purpose, uint64_t packageSize, uint64_t downloadedBytes) const
+{
+    if (packageSize == 0) {
+        return make_ok();
+    }
+
+    io::path_t dir;
+    uint64_t required = DISK_SPACE_RESERVE;
+
+    switch (purpose) {
+    case DiskSpaceFor::Download:
+        dir = packagesDir();
+        required += packageSize - std::min(downloadedBytes, packageSize);
+        if (canAutoInstall()) {
+            required += packageSize * UNPACK_SIZE_FACTOR;
+        }
+        break;
+    case DiskSpaceFor::Unpack:
+        dir = configuration()->updateDataPath();
+        required += packageSize * UNPACK_SIZE_FACTOR;
+        break;
+    }
+
+    RetVal<uint64_t> available = fileSystem()->availableSpace(dir);
+    if (!available.ret) {
+        LOGW() << "failed to query available disk space: " << available.ret.toString();
+        return make_ok();
+    }
+
+    if (available.val >= required) {
+        return make_ok();
+    }
+
+    LOGW() << "not enough disk space for update: required " << required << " bytes, available " << available.val;
+
+    const uint64_t mb = 1024 * 1024;
+    const uint64_t missingMb = (required - available.val + mb - 1) / mb;
+    const std::string text = muse::qtrc("update", "Free up at least %1 MB of disk space and try again.")
+                             .arg(QString::number(static_cast<qulonglong>(missingMb))).toStdString();
+
+    return make_ret(Err::NotEnoughDiskSpace, text);
 }
 
 RequestHeaders AppUpdateService::prepareHeaders(const UpdateRequestHistory& history) const
@@ -403,6 +456,7 @@ RetVal<ReleaseInfo> AppUpdateService::parseRelease(const QByteArray& json) const
     result.ret = muse::make_ok();
     result.val.fileName = assetObj.value("name").toString().toStdString();
     result.val.fileUrl = assetObj.value("browser_download_url").toString().toStdString();
+    result.val.fileSize = static_cast<uint64_t>(std::max<qint64>(assetObj.value("size").toInteger(), 0));
     result.val.version = version.toStdString();
     result.val.notes = release.value("bodyMarkdown").toString().toStdString();
 
@@ -467,6 +521,12 @@ bool AppUpdateService::canAutoInstall() const
 
 RetVal<muse::io::path_t> AppUpdateService::prepareUpdate(const muse::io::path_t& packagePath)
 {
+    RetVal<uint64_t> packageSize = fileSystem()->fileSize(packagePath);
+    Ret ret = checkDiskSpace(DiskSpaceFor::Unpack, packageSize.ret ? packageSize.val : 0);
+    if (!ret) {
+        return RetVal<muse::io::path_t>(ret);
+    }
+
     return updateInstaller()->prepareUpdate(packagePath);
 }
 

--- a/framework/update/internal/appupdateservice.h
+++ b/framework/update/internal/appupdateservice.h
@@ -64,6 +64,7 @@ public:
 
     bool isReleaseDownloaded() const override;
     muse::io::path_t downloadedReleasePath() const override;
+    void removeDownloadedRelease() override;
 
 private:
     friend class AppUpdateServiceTests;

--- a/framework/update/internal/appupdateservice.h
+++ b/framework/update/internal/appupdateservice.h
@@ -80,6 +80,12 @@ private:
 
     RetVal<ReleaseInfo> parseRelease(const QByteArray& json) const;
 
+    enum class DiskSpaceFor {
+        Download,   //!< package (minus already downloaded bytes) + unpack room if auto-install
+        Unpack      //!< staging of an already downloaded package
+    };
+    Ret checkDiskSpace(DiskSpaceFor purpose, uint64_t packageSize, uint64_t downloadedBytes = 0) const;
+
     InstallProgressUi makeInstallProgressUi() const;
 
     //! Ordered list of acceptable asset suffixes for this platform, most

--- a/framework/update/internal/platform/linux/linuxupdateinstaller.cpp
+++ b/framework/update/internal/platform/linux/linuxupdateinstaller.cpp
@@ -187,7 +187,7 @@ Ret LinuxUpdateInstaller::finalizeUpdate(const muse::io::path_t& preparedPath, c
 
     // 2. Spawn the detached helper. It waits for us to quit, replaces the
     //    AppImage and relaunches it.
-    const QString logPath = configuration()->updateDataPath().toQString() + "/museupdater.log";
+    const QString logPath = configuration()->helperLogPath().toQString();
     const QStringList args = {
         "--wait-pid", QString::number(QCoreApplication::applicationPid()),
         "--src", package,

--- a/framework/update/internal/platform/mac/macupdateinstaller.cpp
+++ b/framework/update/internal/platform/mac/macupdateinstaller.cpp
@@ -160,7 +160,7 @@ Ret MacUpdateInstaller::finalizeUpdate(const muse::io::path_t& preparedPath, con
     //    the staged bundle is signed by our team, swaps it into place and
     //    relaunches.
     const QString bundlePath = currentBundlePath().toQString();
-    const QString logPath = configuration()->updateDataPath().toQString() + "/museupdater.log";
+    const QString logPath = configuration()->helperLogPath().toQString();
     const QStringList args = {
         "--wait-pid", QString::number(QCoreApplication::applicationPid()),
         "--src", stagingApp,

--- a/framework/update/internal/platform/win/winupdateinstaller.cpp
+++ b/framework/update/internal/platform/win/winupdateinstaller.cpp
@@ -173,6 +173,20 @@ std::wstring WinUpdateInstaller::appId() const
     return baseName.toStdWString();
 }
 
+void WinUpdateInstaller::importHelperLog()
+{
+    const io::path_t src(QString::fromStdWString(win::logFilePath(appId())));
+    if (!fileSystem()->exists(src)) {
+        return;
+    }
+
+    const io::path_t dst = configuration()->helperLogPath();
+    const Ret ret = fileSystem()->copy(src, dst, true);
+    if (!ret) {
+        LOGW() << "failed to copy " << src << " to " << dst << ": " << ret.toString();
+    }
+}
+
 bool WinUpdateInstaller::isInPlaceUpdateSupported() const
 {
     if (!isRegisteredForThisInstall(appId())) {

--- a/framework/update/internal/platform/win/winupdateinstaller.h
+++ b/framework/update/internal/platform/win/winupdateinstaller.h
@@ -50,6 +50,8 @@ public:
     RetVal<muse::io::path_t> prepareUpdate(const muse::io::path_t& packagePath) override;
     Ret finalizeUpdate(const muse::io::path_t& preparedPath, const InstallProgressUi& ui) override;
 
+    void importHelperLog();
+
 private:
     //! Identifier shared with the installer-registered task and the HKLM key;
     //! the base name of the running executable, e.g. "MuseScore4".

--- a/framework/update/internal/updateconfiguration.cpp
+++ b/framework/update/internal/updateconfiguration.cpp
@@ -33,6 +33,7 @@ static const std::string module_name("update");
 static const Settings::Key CHECK_FOR_UPDATE_KEY(module_name, "application/checkForUpdate");
 static const Settings::Key ALLOW_UPDATE_ON_PRERELEASE(module_name, "application/allowUpdateOnPreRelease");
 static const Settings::Key SKIPPED_VERSION_KEY(module_name, "application/skippedVersion");
+static const Settings::Key INSTALLING_VERSION_KEY(module_name, "application/installingVersion");
 static const Settings::Key LAST_DOWNLOADED_PACKAGE_KEY(module_name, "application/lastDownloadedPackage");
 static const Settings::Key AUTO_DOWNLOAD_KEY(module_name, "application/autoDownload");
 
@@ -104,6 +105,16 @@ std::string UpdateConfiguration::skippedReleaseVersion() const
 void UpdateConfiguration::setSkippedReleaseVersion(const std::string& version)
 {
     settings()->setSharedValue(SKIPPED_VERSION_KEY, Val(version));
+}
+
+std::string UpdateConfiguration::installingReleaseVersion() const
+{
+    return settings()->value(INSTALLING_VERSION_KEY).toString();
+}
+
+void UpdateConfiguration::setInstallingReleaseVersion(const std::string& version)
+{
+    settings()->setSharedValue(INSTALLING_VERSION_KEY, Val(version));
 }
 
 muse::io::path_t UpdateConfiguration::lastDownloadedPackagePath() const

--- a/framework/update/internal/updateconfiguration.cpp
+++ b/framework/update/internal/updateconfiguration.cpp
@@ -35,7 +35,7 @@ static const Settings::Key CHECK_FOR_UPDATE_TEST_MODE_KEY(module_name, "applicat
 static const Settings::Key ALLOW_UPDATE_ON_PRERELEASE(module_name, "application/allowUpdateOnPreRelease");
 static const Settings::Key SKIPPED_VERSION_KEY(module_name, "application/skippedVersion");
 static const Settings::Key LAST_DOWNLOADED_PACKAGE_KEY(module_name, "application/lastDownloadedPackage");
-static const Settings::Key AUTO_INSTALL_KEY(module_name, "application/autoInstall");
+static const Settings::Key AUTO_DOWNLOAD_KEY(module_name, "application/autoDownload");
 
 void UpdateConfiguration::init()
 {
@@ -56,7 +56,7 @@ void UpdateConfiguration::init()
 #endif
     settings()->setDefaultValue(ALLOW_UPDATE_ON_PRERELEASE, Val(allowUpdateOnPreRelease));
 
-    settings()->setDefaultValue(AUTO_INSTALL_KEY, Val(true));
+    settings()->setDefaultValue(AUTO_DOWNLOAD_KEY, Val(true));
 }
 
 bool UpdateConfiguration::isAppUpdatable() const
@@ -89,14 +89,14 @@ async::Notification UpdateConfiguration::needCheckForUpdateChanged() const
     return m_needCheckForUpdateChanged;
 }
 
-bool UpdateConfiguration::autoInstallEnabled() const
+bool UpdateConfiguration::autoDownloadEnabled() const
 {
-    return settings()->value(AUTO_INSTALL_KEY).toBool();
+    return settings()->value(AUTO_DOWNLOAD_KEY).toBool();
 }
 
-void UpdateConfiguration::setAutoInstallEnabled(bool enabled)
+void UpdateConfiguration::setAutoDownloadEnabled(bool enabled)
 {
-    settings()->setSharedValue(AUTO_INSTALL_KEY, Val(enabled));
+    settings()->setSharedValue(AUTO_DOWNLOAD_KEY, Val(enabled));
 }
 
 std::string UpdateConfiguration::skippedReleaseVersion() const

--- a/framework/update/internal/updateconfiguration.cpp
+++ b/framework/update/internal/updateconfiguration.cpp
@@ -31,7 +31,6 @@ using namespace muse::update;
 static const std::string module_name("update");
 
 static const Settings::Key CHECK_FOR_UPDATE_KEY(module_name, "application/checkForUpdate");
-static const Settings::Key CHECK_FOR_UPDATE_TEST_MODE_KEY(module_name, "application/checkForUpdateTestMode");
 static const Settings::Key ALLOW_UPDATE_ON_PRERELEASE(module_name, "application/allowUpdateOnPreRelease");
 static const Settings::Key SKIPPED_VERSION_KEY(module_name, "application/skippedVersion");
 static const Settings::Key LAST_DOWNLOADED_PACKAGE_KEY(module_name, "application/lastDownloadedPackage");
@@ -45,8 +44,6 @@ void UpdateConfiguration::init()
     settings()->valueChanged(CHECK_FOR_UPDATE_KEY).onReceive(this, [this](const Val&) {
         m_needCheckForUpdateChanged.notify();
     });
-
-    settings()->setDefaultValue(CHECK_FOR_UPDATE_TEST_MODE_KEY, Val(false));
 
     bool allowUpdateOnPreRelease = false;
 #ifdef MUSESCORE_ALLOW_UPDATE_ON_PRERELEASE
@@ -117,11 +114,6 @@ muse::io::path_t UpdateConfiguration::lastDownloadedPackagePath() const
 void UpdateConfiguration::setLastDownloadedPackagePath(const muse::io::path_t& path)
 {
     settings()->setSharedValue(LAST_DOWNLOADED_PACKAGE_KEY, Val(path));
-}
-
-bool UpdateConfiguration::checkForUpdateTestMode() const
-{
-    return settings()->value(CHECK_FOR_UPDATE_TEST_MODE_KEY).toBool();
 }
 
 std::string UpdateConfiguration::checkForAppUpdateUrl() const

--- a/framework/update/internal/updateconfiguration.cpp
+++ b/framework/update/internal/updateconfiguration.cpp
@@ -170,3 +170,8 @@ muse::io::path_t UpdateConfiguration::updateRequestHistoryJsonPath() const
 {
     return globalConfiguration()->userAppDataPath() + "/update_request_history.json";
 }
+
+muse::io::path_t UpdateConfiguration::helperLogPath() const
+{
+    return globalConfiguration()->userAppDataPath() + "/logs/museupdater.log";
+}

--- a/framework/update/internal/updateconfiguration.h
+++ b/framework/update/internal/updateconfiguration.h
@@ -58,6 +58,9 @@ public:
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;
 
+    std::string installingReleaseVersion() const override;
+    void setInstallingReleaseVersion(const std::string& version) override;
+
     muse::io::path_t lastDownloadedPackagePath() const override;
     void setLastDownloadedPackagePath(const muse::io::path_t& path) override;
 

--- a/framework/update/internal/updateconfiguration.h
+++ b/framework/update/internal/updateconfiguration.h
@@ -61,8 +61,6 @@ public:
     muse::io::path_t lastDownloadedPackagePath() const override;
     void setLastDownloadedPackagePath(const muse::io::path_t& path) override;
 
-    bool checkForUpdateTestMode() const override;
-
     std::string checkForAppUpdateUrl() const override;
     std::string previousAppReleasesNotesUrl() const override;
 

--- a/framework/update/internal/updateconfiguration.h
+++ b/framework/update/internal/updateconfiguration.h
@@ -52,8 +52,8 @@ public:
     void setNeedCheckForUpdate(bool needCheck) override;
     muse::async::Notification needCheckForUpdateChanged() const override;
 
-    bool autoInstallEnabled() const override;
-    void setAutoInstallEnabled(bool enabled) override;
+    bool autoDownloadEnabled() const override;
+    void setAutoDownloadEnabled(bool enabled) override;
 
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;

--- a/framework/update/internal/updateconfiguration.h
+++ b/framework/update/internal/updateconfiguration.h
@@ -75,6 +75,7 @@ public:
     muse::io::path_t updateDataPath() const override;
     muse::io::path_t downloadsPath() const override;
     muse::io::path_t updateRequestHistoryJsonPath() const override;
+    muse::io::path_t helperLogPath() const override;
 
 private:
     muse::async::Notification m_needCheckForUpdateChanged;

--- a/framework/update/iupdateconfiguration.h
+++ b/framework/update/iupdateconfiguration.h
@@ -45,10 +45,8 @@ public:
     virtual void setNeedCheckForUpdate(bool needCheck) = 0;
     virtual muse::async::Notification needCheckForUpdateChanged() const = 0;
 
-    //! User preference: apply updates in-place and restart automatically (when
-    //! the platform supports it) instead of opening the downloaded installer.
-    virtual bool autoInstallEnabled() const = 0;
-    virtual void setAutoInstallEnabled(bool enabled) = 0;
+    virtual bool autoDownloadEnabled() const = 0;
+    virtual void setAutoDownloadEnabled(bool enabled) = 0;
 
     virtual std::string skippedReleaseVersion() const = 0;
     virtual void setSkippedReleaseVersion(const std::string& version) = 0;

--- a/framework/update/iupdateconfiguration.h
+++ b/framework/update/iupdateconfiguration.h
@@ -54,8 +54,6 @@ public:
     virtual muse::io::path_t lastDownloadedPackagePath() const = 0;
     virtual void setLastDownloadedPackagePath(const muse::io::path_t& path) = 0;
 
-    virtual bool checkForUpdateTestMode() const = 0;
-
     virtual std::string checkForAppUpdateUrl() const = 0;
     virtual std::string previousAppReleasesNotesUrl() const = 0;
 

--- a/framework/update/iupdateconfiguration.h
+++ b/framework/update/iupdateconfiguration.h
@@ -51,6 +51,9 @@ public:
     virtual std::string skippedReleaseVersion() const = 0;
     virtual void setSkippedReleaseVersion(const std::string& version) = 0;
 
+    virtual std::string installingReleaseVersion() const = 0;
+    virtual void setInstallingReleaseVersion(const std::string& version) = 0;
+
     virtual muse::io::path_t lastDownloadedPackagePath() const = 0;
     virtual void setLastDownloadedPackagePath(const muse::io::path_t& path) = 0;
 

--- a/framework/update/iupdateconfiguration.h
+++ b/framework/update/iupdateconfiguration.h
@@ -68,6 +68,7 @@ public:
     virtual muse::io::path_t updateDataPath() const = 0;
     virtual muse::io::path_t downloadsPath() const = 0;
     virtual muse::io::path_t updateRequestHistoryJsonPath() const = 0;
+    virtual muse::io::path_t helperLogPath() const = 0;
 };
 }
 

--- a/framework/update/qml/Muse/Update/AppReleaseInfoDialog.qml
+++ b/framework/update/qml/Muse/Update/AppReleaseInfoDialog.qml
@@ -95,7 +95,7 @@ StyledDialogView {
                 visible: root.readyToInstall
 
                 text: qsTrc("update", "%1 has downloaded an update and is ready to install. "
-                                      + "A restart will be required to complete the installation. "
+                                      + "%1 will restart to complete the installation. "
                                       + "If you have any unsaved changes, you will be prompted to save them first.")
                       .arg(root.appName)
                 horizontalAlignment: Qt.AlignLeft

--- a/framework/update/qml/Muse/Update/AppUpdateProgressDialog.qml
+++ b/framework/update/qml/Muse/Update/AppUpdateProgressDialog.qml
@@ -42,8 +42,8 @@ StyledDialogView {
     AppUpdateModel {
         id: updateModel
 
-        onFinished: function(errorCode, installerPath) {
-            root.ret = { errcode: errorCode, value: installerPath }
+        onFinished: function(errorCode, errorText, installerPath) {
+            root.ret = { errcode: errorCode, text: errorText, value: installerPath }
             root.hide()
         }
     }

--- a/framework/update/qml/Muse/Update/CMakeLists.txt
+++ b/framework/update/qml/Muse/Update/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_qml_module(muse_update_qml
         UpdateBanner.qml
         internal/AppReleaseInfoBottomPanel.qml
         internal/ReleaseNotesView.qml
+        internal/UpdateCompletedContent.qml
+        internal/UpdateReadyContent.qml
     IMPORTS
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml

--- a/framework/update/qml/Muse/Update/UpdateBanner.qml
+++ b/framework/update/qml/Muse/Update/UpdateBanner.qml
@@ -19,23 +19,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 import QtQuick
-import QtQuick.Layouts
 
 import Muse.Ui
 import Muse.UiComponents
 import Muse.Update
 
+import "internal"
+
 Rectangle {
     id: root
 
     readonly property bool hasReadyUpdate: updateBannerModel.updateReady
-    readonly property string updateVersion: updateBannerModel.updateVersion
+    readonly property bool hasCompletedUpdate: updateBannerModel.updateCompleted
 
-    implicitHeight: content.implicitHeight + 24
+    implicitHeight: loader.implicitHeight + 24
 
-    visible: hasReadyUpdate
+    visible: loader.sourceComponent !== null
 
     radius: 4
     color: ui.theme.backgroundPrimaryColor
@@ -50,35 +50,37 @@ Rectangle {
         updateBannerModel.load()
     }
 
-    ColumnLayout {
-        id: content
+    Loader {
+        id: loader
 
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.margins: 12
 
-        spacing: 8
+        sourceComponent: root.hasReadyUpdate ? readyContent
+                                             : root.hasCompletedUpdate ? completedContent
+                                                                       : null
+    }
 
-        StyledTextLabel {
-            Layout.fillWidth: true
+    Component {
+        id: readyContent
 
-            horizontalAlignment: Text.AlignLeft
-            wrapMode: Text.WordWrap
+        UpdateReadyContent {
+            updateVersion: updateBannerModel.updateVersion
 
-            text: root.updateVersion.length > 0
-                  ? qsTrc("update", "Update to version %1 is ready").arg(root.updateVersion)
-                  : qsTrc("update", "An update is ready")
-        }
-
-        FlatButton {
-            Layout.fillWidth: true
-
-            text: qsTrc("update", "Update")
-            accentButton: true
-
-            onClicked: {
+            onInstallRequested: {
                 updateBannerModel.install()
+            }
+        }
+    }
+
+    Component {
+        id: completedContent
+
+        UpdateCompletedContent {
+            onDismissRequested: {
+                updateBannerModel.dismissCompleted()
             }
         }
     }

--- a/framework/update/qml/Muse/Update/UpdateBanner.qml
+++ b/framework/update/qml/Muse/Update/UpdateBanner.qml
@@ -67,10 +67,19 @@ Rectangle {
         id: readyContent
 
         UpdateReadyContent {
+            appName: updateBannerModel.appName
             updateVersion: updateBannerModel.updateVersion
+
+            onDetailsRequested: {
+                updateBannerModel.showDetails()
+            }
 
             onInstallRequested: {
                 updateBannerModel.install()
+            }
+
+            onDismissRequested: {
+                updateBannerModel.dismissReady()
             }
         }
     }

--- a/framework/update/qml/Muse/Update/appupdatemodel.cpp
+++ b/framework/update/qml/Muse/Update/appupdatemodel.cpp
@@ -49,7 +49,7 @@ void AppUpdateModel::load(const QString& mode)
     RetVal<Progress> progress = service()->downloadRelease();
     if (!progress.ret) {
         LOGE() << progress.ret.toString();
-        emit finished(progress.ret.code(), QString());
+        emit finished(progress.ret.code(), QString::fromStdString(progress.ret.text()), QString());
         return;
     }
 
@@ -73,7 +73,7 @@ void AppUpdateModel::load(const QString& mode)
             LOGE() << res.ret.toString();
         }
 
-        emit finished(res.ret.code(), res.val.toQString());
+        emit finished(res.ret.code(), QString::fromStdString(res.ret.text()), res.val.toQString());
     });
 }
 

--- a/framework/update/qml/Muse/Update/appupdatemodel.h
+++ b/framework/update/qml/Muse/Update/appupdatemodel.h
@@ -57,7 +57,7 @@ public:
 
 signals:
     void started();
-    void finished(int errorCode, const QString& installerPath);
+    void finished(int errorCode, const QString& errorText, const QString& installerPath);
 
     void currentProgressChanged();
     void totalProgressChanged();

--- a/framework/update/qml/Muse/Update/internal/AppReleaseInfoBottomPanel.qml
+++ b/framework/update/qml/Muse/Update/internal/AppReleaseInfoBottomPanel.qml
@@ -86,7 +86,7 @@ RowLayout {
 
         Layout.alignment: Qt.AlignVCenter
 
-        text: qsTrc("update", "Install update")
+        text: qsTrc("update", "Update now")
         icon: IconCode.IMPORT
 
         accentButton: true

--- a/framework/update/qml/Muse/Update/internal/UpdateCompletedContent.qml
+++ b/framework/update/qml/Muse/Update/internal/UpdateCompletedContent.qml
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+RowLayout {
+    id: root
+
+    signal dismissRequested()
+
+    spacing: 12
+
+    Timer {
+        interval: 10000
+        running: true
+
+        onTriggered: {
+            root.dismissRequested()
+        }
+    }
+
+    Rectangle {
+        Layout.preferredWidth: 24
+        Layout.preferredHeight: 24
+
+        radius: width / 2
+        color: "#46A955"
+
+        StyledIconLabel {
+            anchors.centerIn: parent
+
+            iconCode: IconCode.TICK_RIGHT_ANGLE_THICK
+            color: "white"
+        }
+    }
+
+    StyledTextLabel {
+        Layout.fillWidth: true
+
+        horizontalAlignment: Text.AlignLeft
+        wrapMode: Text.WordWrap
+
+        text: qsTrc("update", "Updated successfully")
+        font: ui.theme.bodyBoldFont
+    }
+
+    FlatButton {
+        icon: IconCode.CLOSE_X_ROUNDED
+        transparent: true
+
+        navigation.accessible.name: qsTrc("update", "Dismiss")
+
+        onClicked: {
+            root.dismissRequested()
+        }
+    }
+}

--- a/framework/update/qml/Muse/Update/internal/UpdateCompletedContent.qml
+++ b/framework/update/qml/Muse/Update/internal/UpdateCompletedContent.qml
@@ -70,7 +70,7 @@ RowLayout {
         icon: IconCode.CLOSE_X_ROUNDED
         transparent: true
 
-        navigation.accessible.name: qsTrc("update", "Dismiss")
+        navigation.accessible.name: qsTrc("global", "Dismiss")
 
         onClicked: {
             root.dismissRequested()

--- a/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
+++ b/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+ColumnLayout {
+    id: root
+
+    property string updateVersion: ""
+
+    signal installRequested()
+
+    spacing: 8
+
+    StyledTextLabel {
+        Layout.fillWidth: true
+
+        horizontalAlignment: Text.AlignLeft
+        wrapMode: Text.WordWrap
+
+        text: root.updateVersion.length > 0
+              ? qsTrc("update", "Update to version %1 is ready").arg(root.updateVersion)
+              : qsTrc("update", "An update is ready")
+    }
+
+    FlatButton {
+        Layout.fillWidth: true
+
+        text: qsTrc("update", "Update")
+        accentButton: true
+
+        onClicked: {
+            root.installRequested()
+        }
+    }
+}

--- a/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
+++ b/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
@@ -28,31 +28,78 @@ import Muse.UiComponents
 ColumnLayout {
     id: root
 
+    property string appName: ""
     property string updateVersion: ""
 
+    signal detailsRequested()
     signal installRequested()
+    signal dismissRequested()
 
     spacing: 8
 
-    StyledTextLabel {
-        Layout.fillWidth: true
+    ColumnLayout {
+        spacing: 4
 
-        horizontalAlignment: Text.AlignLeft
-        wrapMode: Text.WordWrap
+        RowLayout {
+            Layout.fillWidth: true
 
-        text: root.updateVersion.length > 0
-              ? qsTrc("update", "Update to version %1 is ready").arg(root.updateVersion)
-              : qsTrc("update", "An update is ready")
+            spacing: 8
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+
+                horizontalAlignment: Text.AlignLeft
+
+                text: qsTrc("update", "Update available")
+                font: ui.theme.largeBodyBoldFont
+            }
+
+            FlatButton {
+                icon: IconCode.CLOSE_X_ROUNDED
+                transparent: true
+
+                navigation.accessible.name: qsTrc("update", "Dismiss")
+
+                onClicked: {
+                    root.dismissRequested()
+                }
+            }
+        }
+
+        StyledTextLabel {
+            Layout.fillWidth: true
+
+            horizontalAlignment: Text.AlignLeft
+            wrapMode: Text.WordWrap
+
+            text: root.updateVersion.length > 0 ? root.appName + " " + root.updateVersion : root.appName
+        }
     }
 
-    FlatButton {
+    RowLayout {
         Layout.fillWidth: true
 
-        text: qsTrc("update", "Update")
-        accentButton: true
+        spacing: 4
 
-        onClicked: {
-            root.installRequested()
+        FlatButton {
+            Layout.fillWidth: true
+
+            text: qsTrc("update", "See details")
+
+            onClicked: {
+                root.detailsRequested()
+            }
+        }
+
+        FlatButton {
+            Layout.fillWidth: true
+
+            text: qsTrc("update", "Update")
+            accentButton: true
+
+            onClicked: {
+                root.installRequested()
+            }
         }
     }
 }

--- a/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
+++ b/framework/update/qml/Muse/Update/internal/UpdateReadyContent.qml
@@ -58,7 +58,7 @@ ColumnLayout {
                 icon: IconCode.CLOSE_X_ROUNDED
                 transparent: true
 
-                navigation.accessible.name: qsTrc("update", "Dismiss")
+                navigation.accessible.name: qsTrc("global", "Dismiss")
 
                 onClicked: {
                     root.dismissRequested()

--- a/framework/update/qml/Muse/Update/updatebannermodel.cpp
+++ b/framework/update/qml/Muse/Update/updatebannermodel.cpp
@@ -49,9 +49,24 @@ QString UpdateBannerModel::updateVersion() const
     return QString::fromStdString(scenario()->readyUpdateVersion());
 }
 
+QString UpdateBannerModel::appName() const
+{
+    return application()->title().toQString();
+}
+
 void UpdateBannerModel::install()
 {
     scenario()->installReadyUpdate();
+}
+
+void UpdateBannerModel::showDetails()
+{
+    scenario()->showReadyUpdateInfo();
+}
+
+void UpdateBannerModel::dismissReady()
+{
+    scenario()->dismissReadyUpdate();
 }
 
 bool UpdateBannerModel::updateCompleted() const

--- a/framework/update/qml/Muse/Update/updatebannermodel.cpp
+++ b/framework/update/qml/Muse/Update/updatebannermodel.cpp
@@ -33,6 +33,10 @@ void UpdateBannerModel::load()
     scenario()->hasReadyUpdateChanged().onNotify(this, [this]() {
         emit updateReadyChanged();
     });
+
+    scenario()->hasCompletedUpdateChanged().onNotify(this, [this]() {
+        emit updateCompletedChanged();
+    });
 }
 
 bool UpdateBannerModel::updateReady() const
@@ -48,4 +52,14 @@ QString UpdateBannerModel::updateVersion() const
 void UpdateBannerModel::install()
 {
     scenario()->installReadyUpdate();
+}
+
+bool UpdateBannerModel::updateCompleted() const
+{
+    return scenario()->hasCompletedUpdate();
+}
+
+void UpdateBannerModel::dismissCompleted()
+{
+    scenario()->dismissCompletedUpdate();
 }

--- a/framework/update/qml/Muse/Update/updatebannermodel.h
+++ b/framework/update/qml/Muse/Update/updatebannermodel.h
@@ -37,6 +37,7 @@ class UpdateBannerModel : public QObject, public Contextable, public async::Asyn
 
     Q_PROPERTY(bool updateReady READ updateReady NOTIFY updateReadyChanged)
     Q_PROPERTY(QString updateVersion READ updateVersion NOTIFY updateReadyChanged)
+    Q_PROPERTY(bool updateCompleted READ updateCompleted NOTIFY updateCompletedChanged)
 
     QML_ELEMENT
 
@@ -47,11 +48,14 @@ public:
 
     Q_INVOKABLE void load();
     Q_INVOKABLE void install();
+    Q_INVOKABLE void dismissCompleted();
 
     bool updateReady() const;
     QString updateVersion() const;
+    bool updateCompleted() const;
 
 signals:
     void updateReadyChanged();
+    void updateCompletedChanged();
 };
 }

--- a/framework/update/qml/Muse/Update/updatebannermodel.h
+++ b/framework/update/qml/Muse/Update/updatebannermodel.h
@@ -28,6 +28,7 @@
 
 #include "modularity/ioc.h"
 
+#include "global/iapplication.h"
 #include "iappupdatescenario.h"
 
 namespace muse::update {
@@ -37,10 +38,12 @@ class UpdateBannerModel : public QObject, public Contextable, public async::Asyn
 
     Q_PROPERTY(bool updateReady READ updateReady NOTIFY updateReadyChanged)
     Q_PROPERTY(QString updateVersion READ updateVersion NOTIFY updateReadyChanged)
+    Q_PROPERTY(QString appName READ appName CONSTANT)
     Q_PROPERTY(bool updateCompleted READ updateCompleted NOTIFY updateCompletedChanged)
 
     QML_ELEMENT
 
+    GlobalInject<IApplication> application;
     ContextInject<IAppUpdateScenario> scenario = { this };
 
 public:
@@ -48,10 +51,13 @@ public:
 
     Q_INVOKABLE void load();
     Q_INVOKABLE void install();
+    Q_INVOKABLE void showDetails();
+    Q_INVOKABLE void dismissReady();
     Q_INVOKABLE void dismissCompleted();
 
     bool updateReady() const;
     QString updateVersion() const;
+    QString appName() const;
     bool updateCompleted() const;
 
 signals:

--- a/framework/update/tests/CMakeLists.txt
+++ b/framework/update/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_TEST muse_update_test)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/updateconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/appupdateservicemock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/updateinstallermock.h
     ${CMAKE_CURRENT_LIST_DIR}/appupdateservice_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/appupdatescenario_tests.cpp
 )

--- a/framework/update/tests/appupdatescenario_tests.cpp
+++ b/framework/update/tests/appupdatescenario_tests.cpp
@@ -471,3 +471,59 @@ TEST_F(AppUpdateScenarioTests, Init_NothingWasInstalling_NoCompletedUpdate)
 
     EXPECT_FALSE(m_scenario->hasCompletedUpdate());
 }
+
+TEST_F(AppUpdateScenarioTests, DismissReadyUpdate_HidesBanner_KeepsPackage)
+{
+    //! [GIVEN] A ready update
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ok(m_downloadProgress)));
+
+    downloadUpdateInBackground();
+    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("upd/MuseScore.dmg"))));
+    ASSERT_TRUE(m_scenario->hasReadyUpdate());
+
+    //! [THEN] The package is not removed
+    EXPECT_CALL(*m_service, removeDownloadedRelease())
+    .Times(0);
+
+    //! [WHEN] The user closes the banner
+    m_scenario->dismissReadyUpdate();
+
+    //! [THEN] The banner is hidden, but the update can still be installed
+    EXPECT_FALSE(m_scenario->hasReadyUpdate());
+
+    ON_CALL(*m_service, canAutoInstall())
+    .WillByDefault(Return(false));
+    EXPECT_CALL(*m_interactive, info(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Cancel));
+
+    m_scenario->installReadyUpdate();
+    pump();
+}
+
+TEST_F(AppUpdateScenarioTests, InstallReadyUpdate_GoesStraightToInstall)
+{
+    //! [GIVEN] A ready update and no in-place install support
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ok(m_downloadProgress)));
+
+    downloadUpdateInBackground();
+    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("upd/MuseScore.dmg"))));
+
+    ON_CALL(*m_service, canAutoInstall())
+    .WillByDefault(Return(false));
+
+    //! [THEN] No release info dialog is opened; the install prompt follows directly
+    EXPECT_CALL(*m_interactive, open(_))
+    .Times(0);
+    EXPECT_CALL(*m_interactive, info(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Cancel));
+
+    //! [WHEN] The user chooses "Restart and update"
+    m_scenario->installReadyUpdate();
+    pump();
+}

--- a/framework/update/tests/appupdatescenario_tests.cpp
+++ b/framework/update/tests/appupdatescenario_tests.cpp
@@ -21,14 +21,24 @@
  */
 #include <gmock/gmock.h>
 
+#include <QThreadPool>
+
 #include "mocks/updateconfigurationmock.h"
 #include "mocks/appupdateservicemock.h"
 #include "network/tests/mocks/networkinformationmock.h"
+#include "interactive/tests/mocks/interactivemock.h"
+#include "multiwindows/tests/mocks/multiwindowsprovidermock.h"
+
+#include "async/processevents.h"
 
 #include "update/internal/appupdatescenario.h"
+#include "update/updateerrors.h"
 
 #include "modularity/ioc.h"
 
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
 using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -52,6 +62,17 @@ public:
 
         m_networkInformation = std::make_shared<NiceMock<network::NetworkInformationMock> >();
         m_scenario->networkInformation.set(m_networkInformation);
+
+        m_interactive = std::make_shared<NiceMock<InteractiveMock> >();
+        m_scenario->interactive.set(m_interactive);
+
+        ON_CALL(*m_interactive, buttonData(_))
+        .WillByDefault(Invoke([](IInteractive::Button btn) {
+            return IInteractive::ButtonData(btn, std::string());
+        }));
+
+        m_multiwindowsProvider = std::make_shared<NiceMock<mi::MultiWindowsProviderMock> >();
+        m_scenario->multiwindowsProvider.set(m_multiwindowsProvider);
 
         //! [GIVEN] An update is available and auto-install is enabled
         ReleaseInfo info;
@@ -78,10 +99,47 @@ public:
         m_scenario->downloadUpdateInBackground();
     }
 
+    async::Promise<Ret> downloadRelease()
+    {
+        return m_scenario->downloadRelease();
+    }
+
+    async::Promise<Ret> prepareAndInstall(const io::path_t& packagePath)
+    {
+        return m_scenario->prepareAndInstall(packagePath);
+    }
+
+    //! A dialog action: the promise is created at call time (so the caller can
+    //! subscribe to it) and resolves with the given button once messages are processed
+    static auto dialog(IInteractive::Button btn)
+    {
+        return InvokeWithoutArgs([btn]() {
+            return async::make_promise<IInteractive::Result>([btn](auto resolve) {
+                return resolve(IInteractive::Result(static_cast<int>(btn)));
+            });
+        });
+    }
+
+    static RetVal<Val> notEnoughDiskSpace()
+    {
+        return RetVal<Val>(make_ret(Err::NotEnoughDiskSpace, "Free up 250 MB"));
+    }
+
+    //! Drain background work and queued async calls
+    static void pump()
+    {
+        for (int i = 0; i < 10; ++i) {
+            QThreadPool::globalInstance()->waitForDone();
+            async::processMessages();
+        }
+    }
+
     AppUpdateScenario* m_scenario = nullptr;
     std::shared_ptr<UpdateConfigurationMock> m_configuration;
     std::shared_ptr<AppUpdateServiceMock> m_service;
     std::shared_ptr<network::NetworkInformationMock> m_networkInformation;
+    std::shared_ptr<InteractiveMock> m_interactive;
+    std::shared_ptr<mi::MultiWindowsProviderMock> m_multiwindowsProvider;
     RetVal<ReleaseInfo> m_lastCheckResult;
     Progress m_downloadProgress;
 };
@@ -101,7 +159,7 @@ TEST_F(AppUpdateScenarioTests, BgDownload_UnmeteredNetwork_StartsDownload)
     downloadUpdateInBackground();
 
     //! [WHEN] The download finishes successfully
-    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("/tmp/upd/MuseScore.dmg"))));
+    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("upd/MuseScore.dmg"))));
 
     //! [THEN] The update is surfaced as ready to install
     EXPECT_TRUE(m_scenario->hasReadyUpdate());
@@ -148,7 +206,7 @@ TEST_F(AppUpdateScenarioTests, BgDownload_AlreadyDownloaded_SurfacedEvenOnMetere
     ON_CALL(*m_service, isReleaseDownloaded())
     .WillByDefault(Return(true));
     ON_CALL(*m_service, downloadedReleasePath())
-    .WillByDefault(Return(io::path_t("/tmp/upd/MuseScore.dmg")));
+    .WillByDefault(Return(io::path_t("upd/MuseScore.dmg")));
 
     //! [GIVEN] The network connection is metered
     ON_CALL(*m_networkInformation, isMetered())
@@ -164,4 +222,119 @@ TEST_F(AppUpdateScenarioTests, BgDownload_AlreadyDownloaded_SurfacedEvenOnMetere
     //! [THEN] The downloaded update is still surfaced as ready to install
     EXPECT_TRUE(m_scenario->hasReadyUpdate());
     EXPECT_EQ(m_scenario->readyUpdateVersion(), "1000.0");
+}
+
+TEST_F(AppUpdateScenarioTests, BgDownload_NotEnoughDiskSpace_SkipsSilently)
+{
+    //! [GIVEN] The network connection is not metered
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+
+    //! [GIVEN] The service refuses to download because the disk is full
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ret(make_ret(Err::NotEnoughDiskSpace))));
+
+    //! [WHEN] A background download is requested
+    downloadUpdateInBackground();
+
+    //! [THEN] No update is surfaced as ready and a later retry is allowed
+    EXPECT_FALSE(m_scenario->hasReadyUpdate());
+
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ok(m_downloadProgress)));
+    downloadUpdateInBackground();
+}
+
+TEST_F(AppUpdateScenarioTests, ManualDownload_NotEnoughDiskSpace_Cancel_Stops)
+{
+    //! [GIVEN] The download dialog refuses to start because the disk is full
+    EXPECT_CALL(*m_interactive, openSync(_))
+    .WillOnce(Return(notEnoughDiskSpace()));
+
+    //! [THEN] An error with the details from the service is shown, and the user cancels
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(Invoke([](const std::string&, const IInteractive::Text& text, const IInteractive::ButtonDatas&,
+                        int, const IInteractive::Options&, const std::string&) {
+        EXPECT_EQ(text.text, "Free up 250 MB");
+        return async::make_promise<IInteractive::Result>([](auto resolve) {
+            return resolve(IInteractive::Result(static_cast<int>(IInteractive::Button::Cancel)));
+        });
+    }));
+
+    //! [WHEN] A manual download is requested
+    Ret result;
+    downloadRelease().onResolve(m_scenario, [&result](const Ret& ret) { result = ret; });
+    pump();
+
+    //! [THEN] The flow ends with Cancel
+    EXPECT_EQ(result.code(), static_cast<int>(Ret::Code::Cancel));
+}
+
+TEST_F(AppUpdateScenarioTests, ManualDownload_NotEnoughDiskSpace_Retry_ReopensDownload)
+{
+    //! [GIVEN] The disk is still full on the second attempt
+    EXPECT_CALL(*m_interactive, openSync(_))
+    .Times(2)
+    .WillRepeatedly(Return(notEnoughDiskSpace()));
+
+    //! [THEN] The user retries once, then cancels
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Retry))
+    .WillOnce(dialog(IInteractive::Button::Cancel));
+
+    //! [WHEN] A manual download is requested
+    Ret result;
+    downloadRelease().onResolve(m_scenario, [&result](const Ret& ret) { result = ret; });
+    pump();
+
+    EXPECT_EQ(result.code(), static_cast<int>(Ret::Code::Cancel));
+}
+
+TEST_F(AppUpdateScenarioTests, ManualDownload_NotEnoughDiskSpace_RetrySucceeds_ProceedsToInstall)
+{
+    //! [GIVEN] Space was freed up before the retry, so the second attempt downloads the package
+    EXPECT_CALL(*m_interactive, openSync(_))
+    .WillOnce(Return(notEnoughDiskSpace()))
+    .WillOnce(Return(RetVal<Val>::make_ok(Val(std::string("upd/MuseScore.dmg")))));
+
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Retry));
+
+    //! [GIVEN] Auto-install is not available, so the manual install prompt follows
+    ON_CALL(*m_service, canAutoInstall())
+    .WillByDefault(Return(false));
+
+    //! [THEN] The "close to complete installation" prompt is shown
+    EXPECT_CALL(*m_interactive, info(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Cancel));
+
+    //! [WHEN] A manual download is requested
+    Ret result;
+    downloadRelease().onResolve(m_scenario, [&result](const Ret& ret) { result = ret; });
+    pump();
+
+    EXPECT_EQ(result.code(), static_cast<int>(Ret::Code::Cancel));
+}
+
+TEST_F(AppUpdateScenarioTests, PrepareAndInstall_NotEnoughDiskSpace_Retry_PreparesAgain)
+{
+    //! [GIVEN] Staging fails for lack of space the first time and succeeds after a retry
+    const io::path_t package("upd/MuseScore.dmg");
+    EXPECT_CALL(*m_service, prepareUpdate(package))
+    .WillOnce(Return(RetVal<io::path_t>(make_ret(Err::NotEnoughDiskSpace, "Free up 250 MB"))))
+    .WillOnce(Return(RetVal<io::path_t>::make_ok(io::path_t("upd/staging/MuseScore.app"))));
+
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Retry));
+
+    //! [THEN] The restart prompt is shown; no fallback to the manual install prompt
+    EXPECT_CALL(*m_interactive, info(_, _, _, _, _, _))
+    .WillOnce(dialog(IInteractive::Button::Cancel));
+
+    //! [WHEN] The downloaded package is installed
+    Ret result;
+    prepareAndInstall(package).onResolve(m_scenario, [&result](const Ret& ret) { result = ret; });
+    pump();
+
+    EXPECT_EQ(result.code(), static_cast<int>(Ret::Code::Cancel));
 }

--- a/framework/update/tests/appupdatescenario_tests.cpp
+++ b/framework/update/tests/appupdatescenario_tests.cpp
@@ -74,7 +74,7 @@ public:
         m_multiwindowsProvider = std::make_shared<NiceMock<mi::MultiWindowsProviderMock> >();
         m_scenario->multiwindowsProvider.set(m_multiwindowsProvider);
 
-        //! [GIVEN] An update is available and auto-install is enabled
+        //! [GIVEN] An update is available and automatic download is enabled
         ReleaseInfo info;
         info.version = "1000.0";
         m_lastCheckResult = RetVal<ReleaseInfo>::make_ok(info);
@@ -85,7 +85,7 @@ public:
         ON_CALL(*m_service, isReleaseDownloaded())
         .WillByDefault(Return(false));
 
-        ON_CALL(*m_configuration, autoInstallEnabled())
+        ON_CALL(*m_configuration, autoDownloadEnabled())
         .WillByDefault(Return(true));
     }
 
@@ -169,6 +169,24 @@ TEST_F(AppUpdateScenarioTests, BgDownload_UnmeteredNetwork_StartsDownload)
     //! [THEN] The update is surfaced as ready to install
     EXPECT_TRUE(m_scenario->hasReadyUpdate());
     EXPECT_EQ(m_scenario->readyUpdateVersion(), "1000.0");
+}
+
+TEST_F(AppUpdateScenarioTests, BgDownload_AutoDownloadDisabled_SkipsDownload)
+{
+    //! [GIVEN] The user turned automatic download off
+    ON_CALL(*m_configuration, autoDownloadEnabled())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+
+    //! [THEN] No download is started
+    EXPECT_CALL(*m_service, downloadRelease())
+    .Times(0);
+
+    //! [WHEN] A background download is requested
+    downloadUpdateInBackground();
+
+    EXPECT_FALSE(m_scenario->hasReadyUpdate());
 }
 
 TEST_F(AppUpdateScenarioTests, BgDownload_MeteredNetwork_SkipsDownload)

--- a/framework/update/tests/appupdatescenario_tests.cpp
+++ b/framework/update/tests/appupdatescenario_tests.cpp
@@ -23,18 +23,17 @@
 
 #include <QThreadPool>
 
-#include "mocks/updateconfigurationmock.h"
-#include "mocks/appupdateservicemock.h"
+#include "global/tests/mocks/applicationmock.h"
 #include "network/tests/mocks/networkinformationmock.h"
 #include "interactive/tests/mocks/interactivemock.h"
 #include "multiwindows/tests/mocks/multiwindowsprovidermock.h"
+#include "mocks/updateconfigurationmock.h"
+#include "mocks/appupdateservicemock.h"
 
 #include "async/processevents.h"
 
 #include "update/internal/appupdatescenario.h"
 #include "update/updateerrors.h"
-
-#include "modularity/ioc.h"
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -74,6 +73,14 @@ public:
         m_multiwindowsProvider = std::make_shared<NiceMock<mi::MultiWindowsProviderMock> >();
         m_scenario->multiwindowsProvider.set(m_multiwindowsProvider);
 
+        m_application = std::make_shared<NiceMock<ApplicationMock> >();
+        m_scenario->application.set(m_application);
+
+        ON_CALL(*m_application, fullVersion())
+        .WillByDefault(Return(Version(CURRENT_VERSION)));
+        ON_CALL(*m_application, title())
+        .WillByDefault(Return(String(u"App")));
+
         //! [GIVEN] An update is available and automatic download is enabled
         ReleaseInfo info;
         info.version = "1000.0";
@@ -97,6 +104,11 @@ public:
     void downloadUpdateInBackground()
     {
         m_scenario->downloadUpdateInBackground();
+    }
+
+    void init()
+    {
+        m_scenario->init();
     }
 
     void skipRelease(const std::string& version)
@@ -139,7 +151,10 @@ public:
         }
     }
 
+    static constexpr const char* CURRENT_VERSION = "4.0.0";
+
     AppUpdateScenario* m_scenario = nullptr;
+    std::shared_ptr<ApplicationMock> m_application;
     std::shared_ptr<UpdateConfigurationMock> m_configuration;
     std::shared_ptr<AppUpdateServiceMock> m_service;
     std::shared_ptr<network::NetworkInformationMock> m_networkInformation;
@@ -405,4 +420,54 @@ TEST_F(AppUpdateScenarioTests, SkipRelease_WhileDownloading_DoesNotSurfaceUpdate
 
     //! [THEN] The skipped release is not surfaced as ready to install
     EXPECT_FALSE(m_scenario->hasReadyUpdate());
+}
+
+TEST_F(AppUpdateScenarioTests, Init_LaunchedWithInstalledVersion_ReportsCompletedUpdate)
+{
+    //! [GIVEN] The app quit to install this very version and is now running it
+    ON_CALL(*m_configuration, installingReleaseVersion())
+    .WillByDefault(Return(CURRENT_VERSION));
+
+    //! [THEN] The record is cleared so the banner shows only once
+    EXPECT_CALL(*m_configuration, setInstallingReleaseVersion(""));
+
+    //! [WHEN] The scenario starts
+    init();
+
+    //! [THEN] The update is reported as completed until dismissed
+    EXPECT_TRUE(m_scenario->hasCompletedUpdate());
+
+    m_scenario->dismissCompletedUpdate();
+    EXPECT_FALSE(m_scenario->hasCompletedUpdate());
+}
+
+TEST_F(AppUpdateScenarioTests, Init_InstallDidNotHappen_NoCompletedUpdate)
+{
+    //! [GIVEN] The app quit to install a version, but still runs the old one
+    ON_CALL(*m_configuration, installingReleaseVersion())
+    .WillByDefault(Return("1000.0"));
+
+    //! [THEN] The record is still cleared
+    EXPECT_CALL(*m_configuration, setInstallingReleaseVersion(""));
+
+    //! [WHEN] The scenario starts
+    init();
+
+    //! [THEN] Nothing is reported
+    EXPECT_FALSE(m_scenario->hasCompletedUpdate());
+}
+
+TEST_F(AppUpdateScenarioTests, Init_NothingWasInstalling_NoCompletedUpdate)
+{
+    //! [GIVEN] A regular launch
+    ON_CALL(*m_configuration, installingReleaseVersion())
+    .WillByDefault(Return(""));
+
+    EXPECT_CALL(*m_configuration, setInstallingReleaseVersion(_))
+    .Times(0);
+
+    //! [WHEN] The scenario starts
+    init();
+
+    EXPECT_FALSE(m_scenario->hasCompletedUpdate());
 }

--- a/framework/update/tests/appupdatescenario_tests.cpp
+++ b/framework/update/tests/appupdatescenario_tests.cpp
@@ -99,6 +99,11 @@ public:
         m_scenario->downloadUpdateInBackground();
     }
 
+    void skipRelease(const std::string& version)
+    {
+        m_scenario->skipRelease(version);
+    }
+
     async::Promise<Ret> downloadRelease()
     {
         return m_scenario->downloadRelease();
@@ -337,4 +342,49 @@ TEST_F(AppUpdateScenarioTests, PrepareAndInstall_NotEnoughDiskSpace_Retry_Prepar
     pump();
 
     EXPECT_EQ(result.code(), static_cast<int>(Ret::Code::Cancel));
+}
+
+TEST_F(AppUpdateScenarioTests, SkipRelease_RemovesPackage_AndClearsReadyUpdate)
+{
+    //! [GIVEN] The release was downloaded in the background and is ready to install
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ok(m_downloadProgress)));
+
+    downloadUpdateInBackground();
+    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("upd/MuseScore.dmg"))));
+    ASSERT_TRUE(m_scenario->hasReadyUpdate());
+
+    //! [THEN] The version is remembered as skipped and the package is deleted
+    EXPECT_CALL(*m_configuration, setSkippedReleaseVersion("1000.0"));
+    EXPECT_CALL(*m_service, removeDownloadedRelease());
+
+    //! [WHEN] The user skips the release
+    skipRelease("1000.0");
+
+    //! [THEN] Nothing is left to install
+    EXPECT_FALSE(m_scenario->hasReadyUpdate());
+}
+
+TEST_F(AppUpdateScenarioTests, SkipRelease_WhileDownloading_DoesNotSurfaceUpdate)
+{
+    //! [GIVEN] A background download is running
+    ON_CALL(*m_networkInformation, isMetered())
+    .WillByDefault(Return(false));
+    EXPECT_CALL(*m_service, downloadRelease())
+    .WillOnce(Return(RetVal<Progress>::make_ok(m_downloadProgress)));
+
+    downloadUpdateInBackground();
+
+    //! [WHEN] The user skips the release before the download finishes
+    ON_CALL(*m_configuration, skippedReleaseVersion())
+    .WillByDefault(Return("1000.0"));
+    skipRelease("1000.0");
+
+    //! [WHEN] The (not yet canceled) download still reports success
+    m_downloadProgress.finish(ProgressResult::make_ok(Val(std::string("upd/MuseScore.dmg"))));
+
+    //! [THEN] The skipped release is not surfaced as ready to install
+    EXPECT_FALSE(m_scenario->hasReadyUpdate());
 }

--- a/framework/update/tests/appupdateservice_tests.cpp
+++ b/framework/update/tests/appupdateservice_tests.cpp
@@ -29,21 +29,18 @@ using ::testing::Return;
 
 #include "framework/network/networktypes.h"
 
-#include "mocks/updateconfigurationmock.h"
-#include "network/tests/mocks/networkmanagercreatormock.h"
-#include "network/tests/mocks/networkmanagermock.h"
 #include "global/tests/mocks/systeminfomock.h"
 #include "global/tests/mocks/filesystemmock.h"
+#include "global/tests/mocks/applicationmock.h"
+#include "network/tests/mocks/networkmanagercreatormock.h"
+#include "network/tests/mocks/networkmanagermock.h"
+#include "mocks/updateconfigurationmock.h"
 #include "mocks/updateinstallermock.h"
 
 #include "update/internal/appupdateservice.h"
 #include "update/updateerrors.h"
 
-#include "modularity/ioc.h"
-#include "global/iapplication.h"
-
 #include "async/processevents.h"
-#include "async/async.h"
 
 using namespace muse;
 using namespace muse::update;
@@ -53,8 +50,6 @@ using namespace muse::network;
 namespace muse::update {
 class AppUpdateServiceTests : public ::testing::Test, public ::async::Asyncable
 {
-    muse::GlobalInject<muse::IApplication> application;
-
 public:
     void SetUp() override
     {
@@ -81,6 +76,14 @@ public:
 
         m_updateInstaller = std::make_shared<NiceMock<UpdateInstallerMock> >();
         m_service->updateInstaller.set(m_updateInstaller);
+
+        m_application = std::make_shared<NiceMock<ApplicationMock> >();
+        m_service->application.set(m_application);
+
+        ON_CALL(*m_application, fullVersion())
+        .WillByDefault(Return(Version(CURRENT_VERSION)));
+        ON_CALL(*m_application, title())
+        .WillByDefault(Return(String(u"App")));
     }
 
     void TearDown() override
@@ -133,7 +136,7 @@ public:
                                         "{ \"version\": \"%1\", \"notes\": \"blabla2\" },"
                                         "{ \"version\": \"0.4.1\", \"notes\": \"blabla1\" }"
                                         "]"
-                                        "}").arg(application()->fullVersion().toString());
+                                        "}").arg(CURRENT_VERSION);
 
         EXPECT_CALL(*m_networkManager, get(QUrl(QString::fromStdString(previousAppReleasesNotesUrl)), _, _))
         .WillOnce(testing::Invoke(
@@ -168,6 +171,8 @@ public:
         .WillByDefault(Return(muse::make_ok()));
     }
 
+    static constexpr const char* CURRENT_VERSION = "4.0.0";
+
     AppUpdateService* m_service = nullptr;
     std::shared_ptr<UpdateConfigurationMock> m_configuration;
     std::shared_ptr<muse::network::NetworkManagerCreatorMock> m_networkManagerCreator;
@@ -175,6 +180,7 @@ public:
     std::shared_ptr<SystemInfoMock> m_systemInfoMock;
     std::shared_ptr<io::FileSystemMock> m_fileSystem;
     std::shared_ptr<UpdateInstallerMock> m_updateInstaller;
+    std::shared_ptr<ApplicationMock> m_application;
     Progress m_getReleaseInfoProgress;
     Progress m_getPrevReleasesInfoProgress;
     Progress m_downloadProgress;

--- a/framework/update/tests/appupdateservice_tests.cpp
+++ b/framework/update/tests/appupdateservice_tests.cpp
@@ -670,3 +670,53 @@ TEST_F(AppUpdateServiceTests, PrepareUpdate_EnoughDiskSpace_Stages)
     RetVal<io::path_t> rv = m_service->prepareUpdate(package);
     EXPECT_TRUE(rv.ret);
 }
+
+TEST_F(AppUpdateServiceTests, RemoveDownloadedRelease_RemovesPackageAndPartial)
+{
+    //! [GIVEN] A release whose package was recorded as downloaded
+    givenAvailableRelease();
+    ON_CALL(*m_configuration, lastDownloadedPackagePath())
+    .WillByDefault(Return(io::path_t("upd/MuseScore.dmg")));
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+
+    //! [THEN] Both the package and its partial file are removed and the record is cleared
+    EXPECT_CALL(*m_fileSystem, remove(io::path_t("upd/MuseScore.dmg"), false))
+    .WillOnce(Return(muse::make_ok()));
+    EXPECT_CALL(*m_fileSystem, remove(io::path_t("upd/MuseScore.dmg.part"), false))
+    .WillOnce(Return(muse::make_ok()));
+    EXPECT_CALL(*m_configuration, setLastDownloadedPackagePath(io::path_t()));
+
+    //! [WHEN] The release is removed
+    m_service->removeDownloadedRelease();
+}
+
+TEST_F(AppUpdateServiceTests, RemoveDownloadedRelease_WhileDownloading_CancelsDownload)
+{
+    //! [GIVEN] A download is in progress
+    givenAvailableRelease();
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .WillOnce(testing::Invoke([this](const QUrl&, IncomingDevicePtr, const RequestHeaders&) {
+        return RetVal<Progress>::make_ok(m_downloadProgress);
+    }));
+
+    RetVal<Progress> rv = m_service->downloadRelease();
+    ASSERT_TRUE(rv.ret);
+
+    bool canceled = false;
+    m_downloadProgress.canceled().onNotify(this, [&canceled]() { canceled = true; });
+
+    //! [WHEN] The release is removed
+    m_service->removeDownloadedRelease();
+
+    //! [THEN] The network request is canceled and a new download may be started
+    EXPECT_TRUE(canceled);
+
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .WillOnce(testing::Invoke([this](const QUrl&, IncomingDevicePtr, const RequestHeaders&) {
+        return RetVal<Progress>::make_ok(m_downloadProgress);
+    }));
+    EXPECT_TRUE(m_service->downloadRelease().ret);
+}

--- a/framework/update/tests/appupdateservice_tests.cpp
+++ b/framework/update/tests/appupdateservice_tests.cpp
@@ -34,8 +34,10 @@ using ::testing::Return;
 #include "network/tests/mocks/networkmanagermock.h"
 #include "global/tests/mocks/systeminfomock.h"
 #include "global/tests/mocks/filesystemmock.h"
+#include "mocks/updateinstallermock.h"
 
 #include "update/internal/appupdateservice.h"
+#include "update/updateerrors.h"
 
 #include "modularity/ioc.h"
 #include "global/iapplication.h"
@@ -76,6 +78,9 @@ public:
 
         m_fileSystem = std::make_shared<NiceMock<io::FileSystemMock> >();
         m_service->fileSystem.set(m_fileSystem);
+
+        m_updateInstaller = std::make_shared<NiceMock<UpdateInstallerMock> >();
+        m_service->updateInstaller.set(m_updateInstaller);
     }
 
     void TearDown() override
@@ -92,7 +97,7 @@ public:
         QString releasesNotes = "{"
                                 "\"tag_name\": \"v1000.0\","
                                 "\"assets\": ["
-                                "{ \"name\": \"MuseScore.dmg\", \"browser_download_url\": \"blabla\" },"
+                                "{ \"name\": \"MuseScore.dmg\", \"browser_download_url\": \"blabla\", \"size\": 12345 },"
                                 "{ \"name\": \"MuseScore.zip\", \"browser_download_url\": \"blabla\" },"
                                 "{ \"name\": \"MuseScore.msi\", \"browser_download_url\": \"blabla\" },"
                                 "{ \"name\": \"MuseScore.AppImage\", \"browser_download_url\": \"blabla\" }"
@@ -143,12 +148,14 @@ public:
 
     //! [GIVEN] An available release is ready to be downloaded.
     void givenAvailableRelease(const std::string& fileName = "MuseScore.dmg",
-                               const std::string& dataPath = "/tmp/upd")
+                               const std::string& dataPath = "upd",
+                               uint64_t fileSize = 0)
     {
         ReleaseInfo info;
         info.version = "1000.0";
         info.fileName = fileName;
-        info.fileUrl = "http://test/" + fileName;
+        info.fileUrl = "package-url";
+        info.fileSize = fileSize;
         m_service->m_lastCheckResult = RetVal<ReleaseInfo>::make_ok(info);
 
         ON_CALL(*m_configuration, updateDataPath())
@@ -167,6 +174,7 @@ public:
     std::shared_ptr<muse::network::NetworkManagerMock> m_networkManager;
     std::shared_ptr<SystemInfoMock> m_systemInfoMock;
     std::shared_ptr<io::FileSystemMock> m_fileSystem;
+    std::shared_ptr<UpdateInstallerMock> m_updateInstaller;
     Progress m_getReleaseInfoProgress;
     Progress m_getPrevReleasesInfoProgress;
     Progress m_downloadProgress;
@@ -369,6 +377,7 @@ TEST_F(AppUpdateServiceTests, ParseRelease_MacOS)
     //! [THEN] Should return correct release file
     EXPECT_TRUE(retVal.ret);
     EXPECT_EQ(retVal.val.fileName, "MuseScore.dmg");
+    EXPECT_EQ(retVal.val.fileSize, 12345u);
 }
 
 TEST_F(AppUpdateServiceTests, CheckForUpdate_ReleasesNotes)
@@ -459,8 +468,8 @@ TEST_F(AppUpdateServiceTests, DownloadRelease_Success_PromotesPartialToFinal)
     }));
 
     //! [THEN] On success the partial file is promoted to the final package name
-    EXPECT_CALL(*m_fileSystem, move(io::path_t("/tmp/upd/MuseScore.dmg.part"),
-                                    io::path_t("/tmp/upd/MuseScore.dmg"), true))
+    EXPECT_CALL(*m_fileSystem, move(io::path_t("upd/MuseScore.dmg.part"),
+                                    io::path_t("upd/MuseScore.dmg"), true))
     .WillOnce(Return(muse::make_ok()));
 
     m_service->downloadRelease();
@@ -519,7 +528,7 @@ TEST_F(AppUpdateServiceTests, DownloadRelease_RangeNotHonoured_DiscardsPartial)
     }));
 
     //! [THEN] The now-stale partial file is removed so the next attempt starts clean
-    EXPECT_CALL(*m_fileSystem, remove(io::path_t("/tmp/upd/MuseScore.dmg.part"), false))
+    EXPECT_CALL(*m_fileSystem, remove(io::path_t("upd/MuseScore.dmg.part"), false))
     .WillOnce(Return(muse::make_ok()));
 
     m_service->downloadRelease();
@@ -528,4 +537,136 @@ TEST_F(AppUpdateServiceTests, DownloadRelease_RangeNotHonoured_DiscardsPartial)
     ProgressResult res = ProgressResult::make_ok(Val());
     res.ret.setData("status", 200);
     m_downloadProgress.finish(res);
+}
+
+TEST_F(AppUpdateServiceTests, DownloadRelease_NotEnoughDiskSpace_DoesNotStart)
+{
+    //! [GIVEN] A 100 MB release and only 50 MB available where it would be stored
+    const uint64_t mb = 1024 * 1024;
+    givenAvailableRelease("MuseScore.dmg", "upd", 100 * mb);
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+    ON_CALL(*m_fileSystem, availableSpace(io::path_t("upd")))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(50 * mb)));
+
+    //! [THEN] No network request is made
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .Times(0);
+
+    //! [WHEN] Download the release
+    RetVal<Progress> rv = m_service->downloadRelease();
+
+    //! [THEN] The download is refused with a disk space error naming the missing amount
+    //! (100 MB package + 100 MB reserve - 50 MB available = 150 MB)
+    EXPECT_EQ(rv.ret.code(), static_cast<int>(Err::NotEnoughDiskSpace));
+    EXPECT_NE(rv.ret.text().find("150 MB"), std::string::npos);
+}
+
+TEST_F(AppUpdateServiceTests, DownloadRelease_EnoughDiskSpace_Starts)
+{
+    //! [GIVEN] A 100 MB release and plenty of space available
+    const uint64_t mb = 1024 * 1024;
+    givenAvailableRelease("MuseScore.dmg", "upd", 100 * mb);
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+    ON_CALL(*m_fileSystem, availableSpace(io::path_t("upd")))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(10000 * mb)));
+
+    //! [THEN] The download is started
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .WillOnce(testing::Invoke([this](const QUrl&, IncomingDevicePtr, const RequestHeaders&) {
+        return RetVal<Progress>::make_ok(m_downloadProgress);
+    }));
+
+    //! [WHEN] Download the release
+    RetVal<Progress> rv = m_service->downloadRelease();
+    EXPECT_TRUE(rv.ret);
+}
+
+TEST_F(AppUpdateServiceTests, DownloadRelease_UnknownPackageSize_SkipsDiskSpaceCheck)
+{
+    //! [GIVEN] The release has no size information and the disk is nearly full
+    givenAvailableRelease("MuseScore.dmg", "upd", 0);
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+    ON_CALL(*m_fileSystem, availableSpace(_))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(static_cast<uint64_t>(1))));
+
+    //! [THEN] The download is still started
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .WillOnce(testing::Invoke([this](const QUrl&, IncomingDevicePtr, const RequestHeaders&) {
+        return RetVal<Progress>::make_ok(m_downloadProgress);
+    }));
+
+    //! [WHEN] Download the release
+    RetVal<Progress> rv = m_service->downloadRelease();
+    EXPECT_TRUE(rv.ret);
+}
+
+TEST_F(AppUpdateServiceTests, DownloadRelease_Resume_OnlyRemainingBytesRequired)
+{
+    //! [GIVEN] A 100 MB release, 90 MB already downloaded, and 120 MB available
+    //! (enough for the remaining 10 MB plus the reserve, but not for the whole file)
+    const uint64_t mb = 1024 * 1024;
+    givenAvailableRelease("MuseScore.dmg", "upd", 100 * mb);
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(true)));
+    ON_CALL(*m_fileSystem, fileSize(_))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(90 * mb)));
+    ON_CALL(*m_fileSystem, availableSpace(io::path_t("upd")))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(120 * mb)));
+
+    //! [THEN] The download is resumed
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .WillOnce(testing::Invoke([this](const QUrl&, IncomingDevicePtr, const RequestHeaders&) {
+        return RetVal<Progress>::make_ok(m_downloadProgress);
+    }));
+
+    //! [WHEN] Download the release
+    RetVal<Progress> rv = m_service->downloadRelease();
+    EXPECT_TRUE(rv.ret);
+}
+
+TEST_F(AppUpdateServiceTests, PrepareUpdate_NotEnoughDiskSpace_DoesNotStage)
+{
+    //! [GIVEN] A downloaded 100 MB package and only 150 MB left in the update data dir
+    const uint64_t mb = 1024 * 1024;
+    const io::path_t package("upd/MuseScore.dmg");
+    ON_CALL(*m_configuration, updateDataPath())
+    .WillByDefault(Return(io::path_t("upd")));
+    ON_CALL(*m_fileSystem, fileSize(package))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(100 * mb)));
+    ON_CALL(*m_fileSystem, availableSpace(io::path_t("upd")))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(150 * mb)));
+
+    //! [THEN] The installer is not asked to stage anything
+    EXPECT_CALL(*m_updateInstaller, prepareUpdate(_))
+    .Times(0);
+
+    //! [WHEN] Prepare the update
+    RetVal<io::path_t> rv = m_service->prepareUpdate(package);
+
+    //! [THEN] It fails with a disk space error
+    EXPECT_EQ(rv.ret.code(), static_cast<int>(Err::NotEnoughDiskSpace));
+}
+
+TEST_F(AppUpdateServiceTests, PrepareUpdate_EnoughDiskSpace_Stages)
+{
+    //! [GIVEN] A downloaded 100 MB package and plenty of space in the update data dir
+    const uint64_t mb = 1024 * 1024;
+    const io::path_t package("upd/MuseScore.dmg");
+    ON_CALL(*m_configuration, updateDataPath())
+    .WillByDefault(Return(io::path_t("upd")));
+    ON_CALL(*m_fileSystem, fileSize(package))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(100 * mb)));
+    ON_CALL(*m_fileSystem, availableSpace(io::path_t("upd")))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(10000 * mb)));
+
+    //! [THEN] The installer stages the package
+    EXPECT_CALL(*m_updateInstaller, prepareUpdate(package))
+    .WillOnce(Return(RetVal<io::path_t>::make_ok(io::path_t("upd/staging/MuseScore.app"))));
+
+    //! [WHEN] Prepare the update
+    RetVal<io::path_t> rv = m_service->prepareUpdate(package);
+    EXPECT_TRUE(rv.ret);
 }

--- a/framework/update/tests/appupdateservice_tests.cpp
+++ b/framework/update/tests/appupdateservice_tests.cpp
@@ -609,6 +609,27 @@ TEST_F(AppUpdateServiceTests, DownloadRelease_UnknownPackageSize_SkipsDiskSpaceC
     EXPECT_TRUE(rv.ret);
 }
 
+TEST_F(AppUpdateServiceTests, DownloadRelease_AbsurdPackageSize_Rejected)
+{
+    //! [GIVEN] The server reports a package size far beyond anything real
+    //! (3 * size would wrap around uint64_t to 2 bytes)
+    givenAvailableRelease("MuseScore.dmg", "upd", 6148914691236517206ull);
+    ON_CALL(*m_fileSystem, exists(_))
+    .WillByDefault(Return(Ret(false)));
+    ON_CALL(*m_fileSystem, availableSpace(_))
+    .WillByDefault(Return(RetVal<uint64_t>::make_ok(10000ull * 1024 * 1024)));
+
+    //! [THEN] No network request is made
+    EXPECT_CALL(*m_networkManager, get(_, _, _))
+    .Times(0);
+
+    //! [WHEN] Download the release
+    RetVal<Progress> rv = m_service->downloadRelease();
+
+    //! [THEN] The download is refused
+    EXPECT_EQ(rv.ret.code(), static_cast<int>(Err::NotEnoughDiskSpace));
+}
+
 TEST_F(AppUpdateServiceTests, DownloadRelease_Resume_OnlyRemainingBytesRequired)
 {
     //! [GIVEN] A 100 MB release, 90 MB already downloaded, and 120 MB available

--- a/framework/update/tests/mocks/appupdateservicemock.h
+++ b/framework/update/tests/mocks/appupdateservicemock.h
@@ -36,6 +36,7 @@ public:
 
     MOCK_METHOD(bool, isReleaseDownloaded, (), (const, override));
     MOCK_METHOD(muse::io::path_t, downloadedReleasePath, (), (const, override));
+    MOCK_METHOD(void, removeDownloadedRelease, (), (override));
 
     MOCK_METHOD(bool, canAutoInstall, (), (const, override));
 

--- a/framework/update/tests/mocks/updateconfigurationmock.h
+++ b/framework/update/tests/mocks/updateconfigurationmock.h
@@ -45,6 +45,9 @@ public:
     MOCK_METHOD(std::string, skippedReleaseVersion, (), (const, override));
     MOCK_METHOD(void, setSkippedReleaseVersion, (const std::string&), (override));
 
+    MOCK_METHOD(std::string, installingReleaseVersion, (), (const, override));
+    MOCK_METHOD(void, setInstallingReleaseVersion, (const std::string&), (override));
+
     MOCK_METHOD(muse::io::path_t, lastDownloadedPackagePath, (), (const, override));
     MOCK_METHOD(void, setLastDownloadedPackagePath, (const muse::io::path_t&), (override));
 

--- a/framework/update/tests/mocks/updateconfigurationmock.h
+++ b/framework/update/tests/mocks/updateconfigurationmock.h
@@ -39,8 +39,8 @@ public:
     MOCK_METHOD(void, setNeedCheckForUpdate, (bool), (override));
     MOCK_METHOD(muse::async::Notification, needCheckForUpdateChanged, (), (const, override));
 
-    MOCK_METHOD(bool, autoInstallEnabled, (), (const, override));
-    MOCK_METHOD(void, setAutoInstallEnabled, (bool), (override));
+    MOCK_METHOD(bool, autoDownloadEnabled, (), (const, override));
+    MOCK_METHOD(void, setAutoDownloadEnabled, (bool), (override));
 
     MOCK_METHOD(std::string, skippedReleaseVersion, (), (const, override));
     MOCK_METHOD(void, setSkippedReleaseVersion, (const std::string&), (override));

--- a/framework/update/tests/mocks/updateconfigurationmock.h
+++ b/framework/update/tests/mocks/updateconfigurationmock.h
@@ -48,8 +48,6 @@ public:
     MOCK_METHOD(muse::io::path_t, lastDownloadedPackagePath, (), (const, override));
     MOCK_METHOD(void, setLastDownloadedPackagePath, (const muse::io::path_t&), (override));
 
-    MOCK_METHOD(bool, checkForUpdateTestMode, (), (const, override));
-
     MOCK_METHOD(std::string, checkForAppUpdateUrl, (), (const, override));
     MOCK_METHOD(std::string, previousAppReleasesNotesUrl, (), (const, override));
 

--- a/framework/update/tests/mocks/updateconfigurationmock.h
+++ b/framework/update/tests/mocks/updateconfigurationmock.h
@@ -61,6 +61,7 @@ public:
 
     MOCK_METHOD(muse::io::path_t, updateDataPath, (), (const, override));
     MOCK_METHOD(muse::io::path_t, downloadsPath, (), (const, override));
+    MOCK_METHOD(muse::io::path_t, helperLogPath, (), (const, override));
     MOCK_METHOD(muse::io::path_t, updateRequestHistoryJsonPath, (), (const, override));
 };
 }

--- a/framework/update/tests/mocks/updateinstallermock.h
+++ b/framework/update/tests/mocks/updateinstallermock.h
@@ -19,25 +19,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 #pragma once
 
-#include "types/ret.h"
+#include <gmock/gmock.h>
+
+#include "update/iupdateinstaller.h"
 
 namespace muse::update {
-enum class Err {
-    Undefined       = int(muse::Ret::Code::Undefined),
-    NoError         = int(muse::Ret::Code::Ok),
-    UnknownError    = int(muse::Ret::Code::UpdateFirst),
-
-    NoUpdate,
-    NetworkError,
-    ReleaseInfoParseError,
-    NotEnoughDiskSpace,
-};
-
-inline muse::Ret make_ret(Err e, const std::string& text = {})
+class UpdateInstallerMock : public IUpdateInstaller
 {
-    return muse::Ret(static_cast<int>(e), text);
-}
+public:
+    MOCK_METHOD(bool, isInPlaceUpdateSupported, (), (const, override));
+    MOCK_METHOD(RetVal<muse::io::path_t>, prepareUpdate, (const muse::io::path_t&), (override));
+    MOCK_METHOD(Ret, finalizeUpdate, (const muse::io::path_t&, const InstallProgressUi&), (override));
+};
 }

--- a/framework/update/updatemodule.cpp
+++ b/framework/update/updatemodule.cpp
@@ -130,5 +130,6 @@ void UpdateContext::resolveImports()
 void UpdateContext::onInit(const IApplication::RunMode&)
 {
     m_appUpdateService->init();
+    m_appUpdateScenario->init();
     m_actionController->init();
 }

--- a/framework/update/updatemodule.cpp
+++ b/framework/update/updatemodule.cpp
@@ -95,6 +95,10 @@ void UpdateModule::resolveImports()
 void UpdateModule::onInit(const IApplication::RunMode&)
 {
     m_configuration->init();
+
+#if defined(Q_OS_WIN)
+    std::static_pointer_cast<WinUpdateInstaller>(m_updateInstaller)->importHelperLog();
+#endif
 }
 
 IContextSetup* UpdateModule::newContext(const muse::modularity::ContextPtr& ctx) const

--- a/framework/update/updatetypes.h
+++ b/framework/update/updatetypes.h
@@ -54,6 +54,7 @@ struct ReleaseInfo {
     std::string version;
     std::string fileName;
     std::string fileUrl;
+    uint64_t fileSize = 0;
 
     std::string imageUrl;           // it can be base64 data, like "data:image/png;base64,iVBORw0KGgoA......"
     std::string notes;
@@ -101,6 +102,7 @@ static inline ValMap releaseInfoToValMap(const ReleaseInfo& info)
         { "version", Val(info.version) },
         { "fileName", Val(info.fileName) },
         { "fileUrl", Val(info.fileUrl) },
+        { "fileSize", Val(static_cast<int64_t>(info.fileSize)) },
         { "notes", Val(info.notes) },
         { "previousReleasesNotes", Val(releasesNotesToValList(info.previousReleasesNotes)) },
         { "additionalInfo", Val(info.additionInfo) },
@@ -117,6 +119,7 @@ static inline ReleaseInfo releaseInfoFromValMap(const ValMap& map)
     info.version = map.at("version").toString();
     info.fileName = map.at("fileName").toString();
     info.fileUrl = map.at("fileUrl").toString();
+    info.fileSize = static_cast<uint64_t>(map.at("fileSize").toInt64());
     info.notes = map.at("notes").toString();
     info.previousReleasesNotes = releasesNotesFromValList(map.at("previousReleasesNotes").toList());
     info.additionInfo = map.at("additionalInfo").toMap();

--- a/framework/update/updatetypes.h
+++ b/framework/update/updatetypes.h
@@ -84,52 +84,6 @@ static ValList releasesNotesToValList(const PrevReleasesNotesList& list)
 
     return valList;
 }
-
-static PrevReleasesNotesList releasesNotesFromValList(const ValList& list)
-{
-    PrevReleasesNotesList notes;
-    for (const Val& val : list) {
-        ValMap releaseMap = val.toMap();
-        notes.emplace_back(releaseMap.at("version").toString(), releaseMap.at("notes").toString());
-    }
-
-    return notes;
-}
-
-static inline ValMap releaseInfoToValMap(const ReleaseInfo& info)
-{
-    return {
-        { "version", Val(info.version) },
-        { "fileName", Val(info.fileName) },
-        { "fileUrl", Val(info.fileUrl) },
-        { "fileSize", Val(static_cast<int64_t>(info.fileSize)) },
-        { "notes", Val(info.notes) },
-        { "previousReleasesNotes", Val(releasesNotesToValList(info.previousReleasesNotes)) },
-        { "additionalInfo", Val(info.additionInfo) },
-        { "imageUrl", Val(info.imageUrl) },
-        { "actionTitle", Val(info.actionTitle) },
-        { "cancelTitle", Val(info.cancelTitle) },
-        { "actions", Val(info.actions) },
-    };
-}
-
-static inline ReleaseInfo releaseInfoFromValMap(const ValMap& map)
-{
-    ReleaseInfo info;
-    info.version = map.at("version").toString();
-    info.fileName = map.at("fileName").toString();
-    info.fileUrl = map.at("fileUrl").toString();
-    info.fileSize = static_cast<uint64_t>(map.at("fileSize").toInt64());
-    info.notes = map.at("notes").toString();
-    info.previousReleasesNotes = releasesNotesFromValList(map.at("previousReleasesNotes").toList());
-    info.additionInfo = map.at("additionalInfo").toMap();
-    info.imageUrl = map.at("imageUrl").toString();
-    info.actionTitle = map.at("actionTitle").toString();
-    info.cancelTitle = map.at("cancelTitle").toString();
-    info.actions = map.at("actions").toList();
-
-    return info;
-}
 }
 
 #endif // MUSE_UPDATE_UPDATETYPES_H


### PR DESCRIPTION
- Added disk space checks for app updates
   We get the downloaded release size from server. By default, we need approximately 100 MB to prevent the system from becoming completely full. 
   If we can't install the update automatically, we check if there's enough disk space. Reserve + file size
   If we can install it automatically, we need to add the same amount of file size to the current file size for unpacking. Reserve + file size * 2
   Background download skips silently, the manual download and Install flows show a "Not enough disk space" dialog with a Retry button.
- Moved updater's logs next to app's logs
- Added option in preferences to disable auto download release
- UI improvements