### PR TITLE
Allow overriding framework's language config

### DIFF
--- a/framework/languages/ilanguagesconfiguration.h
+++ b/framework/languages/ilanguagesconfiguration.h
@@ -45,6 +45,7 @@ public:
     virtual io::path_t languagesAppDataPath() const = 0;
     virtual io::path_t languagesUserAppDataPath() const = 0;
 
+    virtual io::path_t appLanguagesJsonPath() const = 0;
     virtual io::path_t builtinLanguagesJsonPath() const = 0;
     virtual io::path_t builtinLanguageFilePath(const QString& resourceName, const QString& languageCode) const = 0;
     virtual io::path_t userLanguageFilePath(const QString& resourceName, const QString& languageCode) const = 0;

--- a/framework/languages/internal/languagesconfiguration.cpp
+++ b/framework/languages/internal/languagesconfiguration.cpp
@@ -81,6 +81,11 @@ io::path_t LanguagesConfiguration::languagesUserAppDataPath() const
     return globalConfiguration()->userAppDataPath() + "/locale";
 }
 
+io::path_t LanguagesConfiguration::appLanguagesJsonPath() const
+{
+    return languagesAppDataPath() + "/languages.json";
+}
+
 io::path_t LanguagesConfiguration::builtinLanguagesJsonPath() const
 {
     return ":/languages/resources/languages.json";

--- a/framework/languages/internal/languagesconfiguration.h
+++ b/framework/languages/internal/languagesconfiguration.h
@@ -48,6 +48,7 @@ public:
     io::path_t languagesAppDataPath() const override;
     io::path_t languagesUserAppDataPath() const override;
 
+    io::path_t appLanguagesJsonPath() const override;
     io::path_t builtinLanguagesJsonPath() const override;
     io::path_t builtinLanguageFilePath(const QString& resourceName, const QString& languageCode) const override;
     io::path_t userLanguageFilePath(const QString& resourceName, const QString& languageCode) const override;

--- a/framework/languages/internal/languagesservice.cpp
+++ b/framework/languages/internal/languagesservice.cpp
@@ -125,7 +125,14 @@ void LanguagesService::loadLanguages()
     RetVal<ByteArray> languagesJson;
     {
         mi::ReadResourceLockGuard lock_guard(multiwindowsProvider(), LANGUAGES_RESOURCE_NAME);
-        languagesJson = fileSystem()->readFile(configuration()->builtinLanguagesJsonPath());
+        const io::path_t appLanguagesJsonPath = configuration()->appLanguagesJsonPath();
+        if (!appLanguagesJsonPath.empty()) {
+            languagesJson = fileSystem()->readFile(appLanguagesJsonPath);
+        }
+
+        if (!languagesJson.ret) {
+            languagesJson = fileSystem()->readFile(configuration()->builtinLanguagesJsonPath());
+        }
     }
     if (!languagesJson.ret) {
         LOGE() << "Failed to read languages.json: " << languagesJson.ret.toString();

--- a/framework/stubs/languages/languagesconfigurationstub.cpp
+++ b/framework/stubs/languages/languagesconfigurationstub.cpp
@@ -53,6 +53,11 @@ io::path_t LanguagesConfigurationStub::languagesUserAppDataPath() const
     return io::path_t();
 }
 
+io::path_t LanguagesConfigurationStub::appLanguagesJsonPath() const
+{
+    return io::path_t();
+}
+
 io::path_t LanguagesConfigurationStub::builtinLanguagesJsonPath() const
 {
     return io::path_t();

--- a/framework/stubs/languages/languagesconfigurationstub.h
+++ b/framework/stubs/languages/languagesconfigurationstub.h
@@ -37,6 +37,7 @@ public:
     io::path_t languagesAppDataPath() const override;
     io::path_t languagesUserAppDataPath() const override;
 
+    io::path_t appLanguagesJsonPath() const override;
     io::path_t builtinLanguagesJsonPath() const override;
     io::path_t builtinLanguageFilePath(const QString& resourceName, const QString& languageCode) const override;
     io::path_t userLanguageFilePath(const QString& resourceName, const QString& languageCode) const override;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11945

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [ ] I created a unit test or vtest to verify the changes I made (if applicable).
