### PR TITLE
New crash handler functionalities

### DIFF
--- a/framework/diagnostics/diagnosticsmodule.cpp
+++ b/framework/diagnostics/diagnosticsmodule.cpp
@@ -39,6 +39,7 @@
 #include "muse_framework_config.h"
 
 #ifdef MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT
+#include "icrashhandler.h"
 #include "internal/crashhandler/crashhandler.h"
 #endif
 
@@ -60,6 +61,11 @@ void DiagnosticsModule::registerExports()
     m_configuration = std::make_shared<DiagnosticsConfiguration>(globalCtx());
     globalIoc()->registerExport<IDiagnosticsConfiguration>(mname, m_configuration);
     globalIoc()->registerExport<IDiagnosticsPathsRegister>(mname, new DiagnosticsPathsRegister());
+
+#ifdef MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT
+    m_crashHandler = std::make_shared<CrashHandler>();
+    globalIoc()->registerExport<ICrashHandler>(mname, m_crashHandler);
+#endif
 }
 
 void DiagnosticsModule::resolveImports()
@@ -91,8 +97,6 @@ void DiagnosticsModule::onInit(const IApplication::RunMode&)
 
 #ifdef MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT
 
-    static CrashHandler s_crashHandler;
-
 #ifdef Q_OS_WIN
     const muse::io::path_t handlerFile("crashpad_handler.exe");
 #else
@@ -111,7 +115,7 @@ void DiagnosticsModule::onInit(const IApplication::RunMode&)
         LOGD() << "crash server url: " << serverUrl;
     }
 
-    bool ok = s_crashHandler.start(handlerPath, dumpsDir, serverUrl);
+    bool ok = m_crashHandler->start(handlerPath, dumpsDir, serverUrl);
     if (!ok) {
         LOGE() << "failed start crash handler";
     } else {

--- a/framework/diagnostics/diagnosticsmodule.h
+++ b/framework/diagnostics/diagnosticsmodule.h
@@ -32,6 +32,7 @@
 namespace muse::diagnostics {
 class DiagnosticsConfiguration;
 class DiagnosticsActionsController;
+class CrashHandler;
 class DiagnosticsModule : public muse::modularity::IModuleSetup
 {
     muse::GlobalInject<muse::io::IFileSystem> fileSystem;
@@ -46,6 +47,7 @@ public:
 
 private:
     std::shared_ptr<DiagnosticsConfiguration> m_configuration;
+    std::shared_ptr<CrashHandler> m_crashHandler; // only set when the crashpad client is built in
 };
 
 class DiagnosticsContext : public muse::modularity::IContextSetup

--- a/framework/diagnostics/icrashhandler.h
+++ b/framework/diagnostics/icrashhandler.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MUSE_DIAGNOSTICS_ICRASHHANDLER_H
+#define MUSE_DIAGNOSTICS_ICRASHHANDLER_H
+
+#include "modularity/imoduleinterface.h"
+#include "global/types/string.h"
+
+namespace muse::diagnostics {
+//! Lets the application attach context to the crash reports of the running process.
+//! Only registered when the crashpad client is built in (MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT),
+//! so check for null.
+class ICrashHandler : MODULE_GLOBAL_INTERFACE
+{
+    INTERFACE_ID(ICrashHandler)
+public:
+    virtual ~ICrashHandler() = default;
+
+    //! Adds a Sentry tag to the session, helpful for filtering.
+    //! Must be called when applying command-line options - onInit is too late.
+    virtual void addSessionTag(const String& tag, const String& value) = 0;
+};
+}
+
+#endif // MUSE_DIAGNOSTICS_ICRASHHANDLER_H

--- a/framework/diagnostics/icrashhandler.h
+++ b/framework/diagnostics/icrashhandler.h
@@ -38,6 +38,12 @@ public:
     //! Adds a Sentry tag to the session, helpful for filtering.
     //! Must be called when applying command-line options - onInit is too late.
     virtual void addSessionTag(const String& tag, const String& value) = 0;
+
+    //! Whether a crash of this process is also handed to the operating system's crash
+    //! reporter. On by default. A spawned plugin-registration child process may want to turn it off.
+    //! On macOS that reporter is what shows the "<app> quit unexpectedly" dialog.
+    //! Windows and Linux have no such reporter, so this has no effect there.
+    virtual void setSystemCrashReporterForwardingEnabled(bool enabled) = 0;
 };
 }
 

--- a/framework/diagnostics/internal/crashhandler/crashhandler.cpp
+++ b/framework/diagnostics/internal/crashhandler/crashhandler.cpp
@@ -20,13 +20,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Crashpad headers first: some transitively include mini_chromium's base/logging.h,
+// which defines a LOG_STREAM macro that clashes with the muse logger's.
+#include <client/crashpad_client.h>
+#include <client/crashpad_info.h>
+#include <client/crash_report_database.h>
+#include <client/settings.h>
+#undef LOG_STREAM
+
 #include "crashhandler.h"
 
 #include <QDir>
-
-#include <client/crashpad_client.h>
-#include <client/crash_report_database.h>
-#include <client/settings.h>
 
 #include "log.h"
 
@@ -98,6 +102,10 @@ void CrashHandler::addSessionTag(const String& tag, const String& value)
     m_sessionTags.emplace(tag, value);
 }
 
+void CrashHandler::setSystemCrashReporterForwardingEnabled(bool enabled)
+{
+    CrashpadInfo::GetCrashpadInfo()->set_system_crash_reporter_forwarding(enabled ? TriState::kEnabled : TriState::kDisabled);
+}
 
 void CrashHandler::removePendingLockFiles(const muse::io::path_t& dumpsDir)
 {

--- a/framework/diagnostics/internal/crashhandler/crashhandler.cpp
+++ b/framework/diagnostics/internal/crashhandler/crashhandler.cpp
@@ -63,6 +63,9 @@ bool CrashHandler::start(const muse::io::path_t& handlerFilePath, const muse::io
     std::map<std::string, std::string> annotations = {
         { "sentry[release]", application()->fullVersion().toStdString() + "." + application()->build().toStdString() }
     };
+    for (const auto& [tag, value] : m_sessionTags) {
+        annotations[muse::String{ "sentry[tags][%1]" }.arg(tag).toStdString()] = value.toStdString();
+    }
     // Optional arguments to pass to the handler
     std::vector<std::string> arguments;
     arguments.push_back("--no-rate-limit");
@@ -89,6 +92,12 @@ bool CrashHandler::start(const muse::io::path_t& handlerFilePath, const muse::io
 
     return success;
 }
+
+void CrashHandler::addSessionTag(const String& tag, const String& value)
+{
+    m_sessionTags.emplace(tag, value);
+}
+
 
 void CrashHandler::removePendingLockFiles(const muse::io::path_t& dumpsDir)
 {

--- a/framework/diagnostics/internal/crashhandler/crashhandler.h
+++ b/framework/diagnostics/internal/crashhandler/crashhandler.h
@@ -23,6 +23,7 @@
 #ifndef MUSE_DIAGNOSTICS_CRASHHANDLER_H
 #define MUSE_DIAGNOSTICS_CRASHHANDLER_H
 
+#include <unordered_map>
 #include <string>
 
 #include "io/path.h"
@@ -30,25 +31,30 @@
 #include "global/iapplication.h"
 #include "global/io/ifilesystem.h"
 
+#include "diagnostics/icrashhandler.h"
+
 namespace crashpad {
 class CrashpadClient;
 }
 
 namespace muse::diagnostics {
-class CrashHandler
+class CrashHandler : public ICrashHandler
 {
     GlobalInject<muse::io::IFileSystem> fileSystem;
     GlobalInject<muse::IApplication> application;
 
 public:
     CrashHandler() = default;
-    ~CrashHandler();
+    ~CrashHandler() override;
 
     bool start(const muse::io::path_t& handlerFilePath, const muse::io::path_t& dumpsDir, const std::string& serverUrl);
+
+    void addSessionTag(const String& tag, const String& value) override;
 
 private:
     void removePendingLockFiles(const muse::io::path_t& dumpsDir);
 
+    std::unordered_map<muse::String, String> m_sessionTags;
     crashpad::CrashpadClient* m_client = nullptr;
 };
 }

--- a/framework/diagnostics/internal/crashhandler/crashhandler.h
+++ b/framework/diagnostics/internal/crashhandler/crashhandler.h
@@ -50,6 +50,7 @@ public:
     bool start(const muse::io::path_t& handlerFilePath, const muse::io::path_t& dumpsDir, const std::string& serverUrl);
 
     void addSessionTag(const String& tag, const String& value) override;
+    void setSystemCrashReporterForwardingEnabled(bool enabled) override;
 
 private:
     void removePendingLockFiles(const muse::io::path_t& dumpsDir);


### PR DESCRIPTION
Needed for https://github.com/audacity/audacity/issues/11427

It promotes CrashHandler to an exportable ICrashHandler, with two interfaces:
* `addSessionTag`, so that our plugin-registration processes can be filtered on Sentry,
* `setSystemCrashReporterForwardingEnabled`, to allow a process on macos to stop the "<app> quit unexpectedly" dialog, which annoy everyone during plugin registration on macos who has crashing plugins during#

Documentation on minidump annotations for Sentry: https://docs.sentry.io/platforms/native/guides/minidumps/

- [x] I signed the [CLA](https://musescore.org/en/cla) as [username](https://musescore.org/en/user): <!-- Type your MuseScore.org username unless you're a regular contributor. -->
- [x] The title of the PR describes the problem it * 
addresses.
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves. If changes are extensive, there is a sequence of easily reviewable commits.
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines).
- [x] I understand all aspects of the code I'm contributing and I'm able to explain it if requested.
- [x] The code compiles and runs on my machine, preferably after each commit individually. I have manually tested and verified that my changes fulfil their intended purpose.
- [x] No prior attempts to resolve this problem exist, or if they do, I listed them in my PR description and described how I avoided repeating past mistakes.
- [x] There are no unnecessary changes.
- [x] I created a unit test or vtest to verify the changes I made (if applicable).

## Build configuration
<!--
Comment `/build` on this PR to dispatch consumer-app builds against this
framework PR. Edit the lines below to override defaults; remove the
section entirely to use defaults.

Format: {owner}/{repo}/{branch} (any public fork works).

Available platforms (space-separated):
  audacity:  linux_x64 macos windows_x64
  musescore: linux_x64 linux_arm64 macos windows_x64 windows_portable
-->
audacity: audacity/audacity/master
audacity platforms: linux_x64
musescore: musescore/MuseScore/main
musescore platforms: linux_x64
