### PR TITLE
Audio. Send notifications about volume/pan/mute/aux-sends changed

### DIFF
--- a/framework/audio/common/rpc/irpcchannel.h
+++ b/framework/audio/common/rpc/irpcchannel.h
@@ -92,6 +92,8 @@ enum class MsgCode {
     // notification
     SourceParamsChanged,
     FxChainParamsChanged,
+    ControlParamsChanged,
+    AuxSendsParamsChanged,
 
     // Input processing
     GetInputProcessingProgress,
@@ -190,6 +192,8 @@ inline std::string to_string(MsgCode m)
     // notification
     case MsgCode::SourceParamsChanged: return "SourceParamsChanged";
     case MsgCode::FxChainParamsChanged: return "FxChainParamsChanged";
+    case MsgCode::ControlParamsChanged: return "ControlParamsChanged";
+    case MsgCode::AuxSendsParamsChanged: return "AuxSendsParamsChanged";
 
     // Input processing
     case MsgCode::GetInputProcessingProgress: return "GetInputProcessingProgress";

--- a/framework/audio/engine/internal/audiocontext.cpp
+++ b/framework/audio/engine/internal/audiocontext.cpp
@@ -102,7 +102,9 @@ void AudioContext::deinit()
 
     m_saveSoundTracksProgress = SaveSoundTrackProgressData();
     m_sourceParamsChanged = async::Channel<TrackId, AudioSourceParams>();
+    m_controlParamsChanged = async::Channel<TrackId, ControlParams>();
     m_fxChainParamsChanged = async::Channel<TrackId, AudioFxChain>();
+    m_auxSendsParamsChanged = async::Channel<TrackId, AuxSendsParams>();
 
     async_disconnectAll();
 }
@@ -547,6 +549,7 @@ void AudioContext::setSourceParams(const TrackId trackId, const AudioSourceParam
     if (Track* t = track(trackId)) {
         if (t->params.source != params) {
             onSourceParamsChanged(*t, params);
+            m_sourceParamsChanged.send(trackId, t->params.source);
         }
     }
 }
@@ -557,6 +560,7 @@ void AudioContext::setControlParams(const TrackId trackId, const ControlParams& 
     if (Track* t = track(trackId)) {
         if (t->params.control != params) {
             onControlParamsChanged(*t, params);
+            m_controlParamsChanged.send(trackId, t->params.control);
         }
     }
 }
@@ -567,6 +571,7 @@ void AudioContext::setFxChainParams(const TrackId trackId, const AudioFxChain& p
     if (Track* t = track(trackId)) {
         if (t->params.fxChain != params) {
             onFxChainParamsChanged(*t, params);
+            m_fxChainParamsChanged.send(trackId, t->params.fxChain);
         }
     }
 }
@@ -577,6 +582,7 @@ void AudioContext::setAuxSendsParams(const TrackId trackId, const AuxSendsParams
     if (Track* t = track(trackId)) {
         if (t->params.auxSends != params) {
             onAuxSendsParamsChanged(*t, params);
+            m_auxSendsParamsChanged.send(trackId, t->params.auxSends);
         }
     }
 }
@@ -587,10 +593,22 @@ async::Channel<TrackId, AudioSourceParams> AudioContext::sourceParamsChanged() c
     return m_sourceParamsChanged;
 }
 
+async::Channel<TrackId, ControlParams> AudioContext::controlParamsChanged() const
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+    return m_controlParamsChanged;
+}
+
 async::Channel<TrackId, AudioFxChain> AudioContext::fxChainParamsChanged() const
 {
     ONLY_AUDIO_ENGINE_THREAD;
     return m_fxChainParamsChanged;
+}
+
+async::Channel<TrackId, AuxSendsParams> AudioContext::auxSendsParamsChanged() const
+{
+    ONLY_AUDIO_ENGINE_THREAD;
+    return m_auxSendsParamsChanged;
 }
 
 void AudioContext::processInput(const TrackId trackId) const

--- a/framework/audio/engine/internal/audiocontext.h
+++ b/framework/audio/engine/internal/audiocontext.h
@@ -87,7 +87,9 @@ public:
     void setAuxSendsParams(const TrackId trackId, const AuxSendsParams& params) override;
 
     async::Channel<TrackId, AudioSourceParams> sourceParamsChanged() const override;
+    async::Channel<TrackId, ControlParams> controlParamsChanged() const override;
     async::Channel<TrackId, AudioFxChain> fxChainParamsChanged() const override;
+    async::Channel<TrackId, AuxSendsParams> auxSendsParamsChanged() const override;
 
     // Input processing
     void processInput(const TrackId trackId) const override;
@@ -187,7 +189,9 @@ private:
     async::Channel<TrackId> m_trackRemoved;
 
     async::Channel<TrackId, AudioSourceParams> m_sourceParamsChanged;
+    async::Channel<TrackId, ControlParams> m_controlParamsChanged;
     async::Channel<TrackId, AudioFxChain> m_fxChainParamsChanged;
+    async::Channel<TrackId, AuxSendsParams> m_auxSendsParamsChanged;
 
     // -----
     void onShouldProcessDuringSilenceChanged(const TrackId trackId, bool shouldProcess);

--- a/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -470,6 +470,14 @@ void EngineRpcController::init()
             channel()->send(rpc::make_notification(ctxId, MsgCode::SourceParamsChanged, RpcPacker::pack(trackId, params)));
         });
 
+        acontext->controlParamsChanged().onReceive(this, [this, ctxId](TrackId trackId, const ControlParams& params) {
+            channel()->send(rpc::make_notification(ctxId, MsgCode::ControlParamsChanged, RpcPacker::pack(trackId, params)));
+        });
+
+        acontext->auxSendsParamsChanged().onReceive(this, [this, ctxId](TrackId trackId, const AuxSendsParams& params) {
+            channel()->send(rpc::make_notification(ctxId, MsgCode::AuxSendsParamsChanged, RpcPacker::pack(trackId, params)));
+        });
+
         // Input processing
         onLongRequest(ctxId, MsgCode::ProcessInput, [this](const Msg& msg) {
             ONLY_AUDIO_RPC_THREAD;

--- a/framework/audio/engine/internal/iaudiocontext.h
+++ b/framework/audio/engine/internal/iaudiocontext.h
@@ -66,7 +66,9 @@ public:
     virtual void setAuxSendsParams(const TrackId trackId, const AuxSendsParams& params) = 0;
 
     virtual async::Channel<TrackId, AudioSourceParams> sourceParamsChanged() const = 0;
+    virtual async::Channel<TrackId, ControlParams> controlParamsChanged() const = 0;
     virtual async::Channel<TrackId, AudioFxChain> fxChainParamsChanged() const = 0;
+    virtual async::Channel<TrackId, AuxSendsParams> auxSendsParamsChanged() const = 0;
 
     // Input processing
     virtual void processInput(const TrackId trackId) const = 0;

--- a/framework/audio/main/internal/playback.cpp
+++ b/framework/audio/main/internal/playback.cpp
@@ -87,6 +87,34 @@ async::Promise<Ret> Playback::init()
         }
     });
 
+    channel()->onNotification(ctxId(), MsgCode::ControlParamsChanged, [this](const Msg& msg) {
+        ONLY_AUDIO_MAIN_THREAD;
+        TrackId trackId = 0;
+        ControlParams params;
+        IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId, params)) {
+            return;
+        }
+        if (trackId == MASTER_TRACK_ID) {
+            m_masterControlParamsChanged.send(params);
+        } else {
+            m_controlParamsChanged.send(trackId, params);
+        }
+    });
+
+    channel()->onNotification(ctxId(), MsgCode::AuxSendsParamsChanged, [this](const Msg& msg) {
+        ONLY_AUDIO_MAIN_THREAD;
+        TrackId trackId = 0;
+        AuxSendsParams params;
+        IF_ASSERT_FAILED(RpcPacker::unpack(msg.data, trackId, params)) {
+            return;
+        }
+        if (trackId == MASTER_TRACK_ID) {
+            m_masterAuxSendsParamsChanged.send(params);
+        } else {
+            m_auxSendsParamsChanged.send(trackId, params);
+        }
+    });
+
     return async::make_promise<Ret>([this](auto resolve, auto /*reject*/) {
         ONLY_AUDIO_MAIN_THREAD;
 
@@ -133,6 +161,8 @@ void Playback::deinit()
     channel()->onNotification(ctxId(), MsgCode::TrackRemoved, nullptr);
     channel()->onNotification(ctxId(), MsgCode::SourceParamsChanged, nullptr);
     channel()->onNotification(ctxId(), MsgCode::FxChainParamsChanged, nullptr);
+    channel()->onNotification(ctxId(), MsgCode::ControlParamsChanged, nullptr);
+    channel()->onNotification(ctxId(), MsgCode::AuxSendsParamsChanged, nullptr);
 
     m_saveSoundTrackProgressStream = SaveSoundTrackProgress();
     m_saveSoundTrackProgressStreamInited = false;
@@ -452,9 +482,19 @@ async::Channel<TrackId, AudioSourceParams> Playback::sourceParamsChanged() const
     return m_sourceParamsChanged;
 }
 
+async::Channel<TrackId, ControlParams> Playback::controlParamsChanged() const
+{
+    return m_controlParamsChanged;
+}
+
 async::Channel<TrackId, AudioFxChain> Playback::fxChainParamsChanged() const
 {
     return m_fxChainParamsChanged;
+}
+
+async::Channel<TrackId, AuxSendsParams> Playback::auxSendsParamsChanged() const
+{
+    return m_auxSendsParamsChanged;
 }
 
 // Same for master
@@ -478,9 +518,19 @@ void Playback::setMasterAuxSendsParams(const AuxSendsParams& params)
     setAuxSendsParams(MASTER_TRACK_ID, params);
 }
 
+async::Channel<ControlParams> Playback::masterControlParamsChanged() const
+{
+    return m_masterControlParamsChanged;
+}
+
 async::Channel<AudioFxChain> Playback::masterFxChainParamsChanged() const
 {
     return m_masterFxChainParamsChanged;
+}
+
+async::Channel<AuxSendsParams> Playback::masterAuxSendsParamsChanged() const
+{
+    return m_masterAuxSendsParamsChanged;
 }
 
 void Playback::processInput(const TrackId trackId) const

--- a/framework/audio/main/internal/playback.h
+++ b/framework/audio/main/internal/playback.h
@@ -81,14 +81,18 @@ public:
 
     // These parameters can be changed within the audio system.
     async::Channel<TrackId, AudioSourceParams> sourceParamsChanged() const override;
+    async::Channel<TrackId, ControlParams> controlParamsChanged() const override;
     async::Channel<TrackId, AudioFxChain> fxChainParamsChanged() const override;
+    async::Channel<TrackId, AuxSendsParams> auxSendsParamsChanged() const override;
 
     // Same for master
     async::Promise<TrackParams> masterParams() const override;
     void setMasterControlParams(const ControlParams& params) override;
     void setMasterFxChainParams(const AudioFxChain& params) override;
     void setMasterAuxSendsParams(const AuxSendsParams& params) override;
+    async::Channel<ControlParams> masterControlParamsChanged() const override;
     async::Channel<AudioFxChain> masterFxChainParamsChanged() const override;
+    async::Channel<AuxSendsParams> masterAuxSendsParamsChanged() const override;
 
     // Input processing
     void processInput(const TrackId trackId) const override;
@@ -124,8 +128,12 @@ private:
     async::Channel<TrackId> m_trackAdded;
     async::Channel<TrackId> m_trackRemoved;
     async::Channel<TrackId, AudioSourceParams> m_sourceParamsChanged;
+    async::Channel<TrackId, ControlParams> m_controlParamsChanged;
     async::Channel<TrackId, AudioFxChain> m_fxChainParamsChanged;
+    async::Channel<TrackId, AuxSendsParams> m_auxSendsParamsChanged;
+    async::Channel<ControlParams> m_masterControlParamsChanged;
     async::Channel<AudioFxChain> m_masterFxChainParamsChanged;
+    async::Channel<AuxSendsParams> m_masterAuxSendsParamsChanged;
 
     mutable bool m_saveSoundTrackProgressStreamInited = false;
     async::Channel<int64_t, int64_t, SaveSoundTrackStage> m_saveSoundTrackProgressStream;

--- a/framework/audio/main/iplayback.h
+++ b/framework/audio/main/iplayback.h
@@ -84,14 +84,18 @@ public:
 
     // These parameters can be changed within the audio system.
     virtual async::Channel<TrackId, AudioSourceParams> sourceParamsChanged() const = 0;
+    virtual async::Channel<TrackId, ControlParams> controlParamsChanged() const = 0;
     virtual async::Channel<TrackId, AudioFxChain> fxChainParamsChanged() const = 0;
+    virtual async::Channel<TrackId, AuxSendsParams> auxSendsParamsChanged() const = 0;
 
     // Same for master
     virtual async::Promise<TrackParams> masterParams() const = 0;
     virtual void setMasterControlParams(const ControlParams& params) = 0;
     virtual void setMasterFxChainParams(const AudioFxChain& params) = 0;
     virtual void setMasterAuxSendsParams(const AuxSendsParams& params) = 0;
+    virtual async::Channel<ControlParams> masterControlParamsChanged() const = 0;
     virtual async::Channel<AudioFxChain> masterFxChainParamsChanged() const = 0;
+    virtual async::Channel<AuxSendsParams> masterAuxSendsParamsChanged() const = 0;
 
     // Input processing
     virtual void processInput(const TrackId trackId) const = 0;


### PR DESCRIPTION
Regression from https://github.com/musescore/MuseScore/commit/0192600996d ("[audio] split the track parameters into parts")